### PR TITLE
In insecure mode, force use of PIN for all operations

### DIFF
--- a/lib/HAPServer.js
+++ b/lib/HAPServer.js
@@ -850,6 +850,15 @@ HAPServer.prototype._handleAccessories = function(request, response, session, ev
     return;
   }
 
+  if (!session.encryption) {
+    if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
+      response.writeHead(401, {"Content-Type": "application/hap+json"});
+      response.end(JSON.stringify({status:HAPServer.Status.INSUFFICIENT_PRIVILEGES}));
+
+      return;
+    }
+  }
+
   // call out to listeners to retrieve the latest accessories JSON
   this.emit('accessories', once(function(err, accessories) {
 
@@ -901,6 +910,15 @@ HAPServer.prototype._handleCharacteristics = function(request, response, session
     return;
   }
 
+  if (!session.encryption) {
+    if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
+      response.writeHead(401, {"Content-Type": "application/hap+json"});
+      response.end(JSON.stringify({status:HAPServer.Status.INSUFFICIENT_PRIVILEGES}));
+
+      return;
+    }
+  }
+
   if (request.method == "GET") {
 
     // Extract the query params from the URL which looks like: /characteristics?id=1.9,2.14,...
@@ -949,14 +967,6 @@ HAPServer.prototype._handleCharacteristics = function(request, response, session
     }.bind(this)), false, session.sessionID);
   }
   else if (request.method == "PUT") {
-    if (!session.encryption) {
-      if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
-        response.writeHead(401, {"Content-Type": "application/hap+json"});
-        response.end(JSON.stringify({status:HAPServer.Status.INSUFFICIENT_PRIVILEGES}));
-
-        return;
-      }
-    }
 
     if(requestData.length == 0) {
       response.writeHead(400, {"Content-Type": "application/hap+json"});


### PR DESCRIPTION
As I have been widely using Insecure mode with homebridge-alexa, I found that /accessories and GET /characteristics can be accessed without supplying a PIN in insecure mode.  This pull request forces all insecure mode clients to supply the PIN.

For large scale projects potentially impacted by this change, I'm aware of my homebridge-alexa and @oznu and homebridge-config-ui-x.  So before merging, would need at a minimum Oznu to comment.