### PR TITLE
Special case for AccessoryInformation service

### DIFF
--- a/lib/Service.js
+++ b/lib/Service.js
@@ -52,6 +52,10 @@ function Service(displayName, UUID, subtype) {
   // if one was given
   // if you don't provide a display name, some HomeKit apps may choose to hide the device.
   if (displayName) {
+    // Don't add the `Name` characteristic to `Service.AccessoryInformation` since it will be added when defining that service.
+    if (UUID === '0000003E-0000-1000-8000-0026BB765291') {
+      return;
+    }
     // create the characteristic if necessary
     var nameCharacteristic =
       this.getCharacteristic(Characteristic.Name) ||


### PR DESCRIPTION
Avoid adding the `Name` characteristic to `Service.AccessoryInformation` since it will be added when defining that service. This will prevent the same UUID as another Characteristic in this Service error.

Fixes #677 