### PR TITLE
Increase type strictness, disable esModuleInterop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -474,6 +474,22 @@
       "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
       "dev": true
     },
+    "@types/node-persist": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/node-persist/-/node-persist-0.0.33.tgz",
+      "integrity": "sha512-JY/aQpndK6Nb/9ccfAaptSgzUpZp2VXillSXNrD40CURfFACWTMyGnFYzz4L44iKu7CTIg6hqjRZbBCr60URdw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/q": "^0"
+      }
+    },
+    "@types/q": {
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.37.tgz",
+      "integrity": "sha512-vjFGX1zMTMz/kUp3xgfJcxMVLkMWVMrdlyc0RwVyve1y9jxwqNaT8wTcv6M51ylq2a/zn5lm8g7qPSoIS4uvZQ==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1716,8 +1732,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1738,14 +1753,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1760,20 +1773,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1890,8 +1900,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1903,7 +1912,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1918,7 +1926,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1926,14 +1933,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1952,7 +1957,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2033,8 +2037,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2046,7 +2049,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2132,8 +2134,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2169,7 +2170,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2189,7 +2189,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2233,14 +2232,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4833,9 +4830,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
     "@types/ip": "^1.1.0",
     "@types/jest": "^24.0.15",
     "@types/node": "^10.17.13",
+    "@types/node-persist": "0.0.33",
     "jest": "^24.8.0",
     "rimraf": "^2.7.1",
     "simple-plist": "0.0.4",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.3"
   },
   "scripts": {
     "build": "rimraf dist/ && tsc",

--- a/src/BridgedCore.ts
+++ b/src/BridgedCore.ts
@@ -1,6 +1,6 @@
-import path from 'path';
+import * as path from 'path';
 
-import storage from 'node-persist';
+import * as storage from 'node-persist';
 
 import { Accessory, AccessoryEventTypes, AccessoryLoader, Bridge, Categories, uuid, VoidCallback } from './';
 

--- a/src/CameraCore.ts
+++ b/src/CameraCore.ts
@@ -1,4 +1,4 @@
-import storage from 'node-persist';
+import * as storage from 'node-persist';
 
 import { Accessory, AccessoryEventTypes, Camera, Categories, uuid, VoidCallback } from './';
 

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -1,6 +1,6 @@
-import path from 'path';
+import * as path from 'path';
 
-import storage from 'node-persist';
+import * as storage from 'node-persist';
 
 import { AccessoryLoader } from './';
 

--- a/src/accessories/AirConditioner_accessory.ts
+++ b/src/accessories/AirConditioner_accessory.ts
@@ -13,7 +13,7 @@ import {
   Service,
   uuid,
 } from '..';
-import { NodeCallback, VoidCallback } from '../types';
+import { VoidCallback } from '../types';
 
 var ACTest_data: Record<string, CharacteristicValue> = {
   fanPowerOn: false,

--- a/src/accessories/AppleTVRemote_accessory.ts
+++ b/src/accessories/AppleTVRemote_accessory.ts
@@ -1,6 +1,6 @@
 import { Accessory, ButtonState, ButtonType, Categories, HomeKitRemoteController, uuid } from '..';
 import * as http from "http";
-import url, { UrlWithParsedQuery } from "url";
+import * as url from "url";
 import { GStreamerAudioProducer, GStreamerOptions } from "./gstreamer-audioProducer";
 
 const remoteUUID = uuid.generate('hap-nodejs:accessories:remote');
@@ -46,7 +46,7 @@ http.createServer((request, response) => {
         return;
     }
 
-    const parsedPath: UrlWithParsedQuery = url.parse(request.url!, true);
+    const parsedPath: url.UrlWithParsedQuery = url.parse(request.url!, true);
     const pathname = parsedPath.pathname!.substring(1, parsedPath.pathname!.length);
     const query = parsedPath.query;
 

--- a/src/accessories/Sprinkler_accessory.ts
+++ b/src/accessories/Sprinkler_accessory.ts
@@ -46,7 +46,7 @@ sprinkler.category = Categories.SPRINKLER;
 
 // Add the actual Valve Service and listen for change events from iOS.
 // We can see the complete list of Services and Characteristics in `lib/gen/HomeKit.ts`
-var sprinklerService = sprinkler.addService(Service.Valve, "💦 Sprinkler")
+sprinkler.addService(Service.Valve, "💦 Sprinkler")
 
 
 // set some basic properties (these values are arbitrary and setting them is optional)
@@ -162,7 +162,6 @@ sprinkler
   .on(CharacteristicEventTypes.SET, (newValue: CharacteristicValue, callback: CharacteristicSetCallback) => {
     console.log("SetDuration => NewValue: " + newValue);
 
-    var err = null; // in case there were any problems
     SPRINKLER.defaultDuration = newValue;
     callback();
   });

--- a/src/accessories/Wi-FiRouter_accessory.ts
+++ b/src/accessories/Wi-FiRouter_accessory.ts
@@ -2,10 +2,8 @@ import {
   Accessory,
   AccessoryEventTypes,
   Categories,
-  Characteristic,
   Service,
   uuid,
-  VoidCallback,
 } from '..';
 
 const UUID = uuid.generate('hap-nodejs:accessories:wifi-router');
@@ -15,12 +13,11 @@ export const accessory = new Accessory('Wi-Fi Router', UUID);
 accessory.username = 'FA:3C:ED:D2:1A:A2';
 // @ts-ignore
 accessory.pincode = '031-45-154';
-// @ts-ignore
 accessory.category = Categories.ROUTER;
 
-accessory.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback) => {
+accessory.on(AccessoryEventTypes.IDENTIFY, (paired, callback) => {
   console.log("Identify the '%s'", accessory.displayName);
   callback();
 });
 
-const router = accessory.addService(Service.WiFiRouter);
+accessory.addService(Service.WiFiRouter);

--- a/src/accessories/gstreamer-audioProducer.ts
+++ b/src/accessories/gstreamer-audioProducer.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import * as assert from 'assert';
 import createDebug from 'debug';
 import {ChildProcess, spawn} from 'child_process';
 import {AudioCodecConfiguration, ErrorHandler, FrameHandler, SiriAudioStreamProducer} from "../lib/HomeKitRemoteController";
@@ -42,9 +42,7 @@ export type GStreamerOptions = {
  */
 export class GStreamerAudioProducer implements SiriAudioStreamProducer {
 
-    private readonly options: GStreamerOptions = {
-        alsaSrc: "plughw:1"
-    };
+    private readonly options: GStreamerOptions;
 
     private readonly frameHandler: FrameHandler;
     private readonly errorHandler: ErrorHandler;
@@ -55,11 +53,7 @@ export class GStreamerAudioProducer implements SiriAudioStreamProducer {
     constructor(frameHandler: FrameHandler, errorHandler: ErrorHandler, options?: Partial<GStreamerOptions>) {
         this.frameHandler = frameHandler;
         this.errorHandler = errorHandler;
-
-        for (const key in options) {
-            // @ts-ignore
-            GStreamerAudioProducer.options[key] = options[key];
-        }
+        this.options = { alsaSrc: "plughw:1", ...options };
     }
 
     startAudioProduction(selectedAudioConfiguration: AudioCodecConfiguration): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import storage from 'node-persist';
+import * as storage from 'node-persist';
 
 import './lib/gen';
 import * as accessoryLoader from './lib/AccessoryLoader';

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 import createDebug from 'debug';
 
 import * as uuid from './util/uuid';
@@ -919,7 +919,7 @@ export class Accessory extends EventEmitter<Events> {
         return;
       }
 
-      if (!characteristic.props.perms.includes(Perms.PAIRED_READ)) { // check if we are allowed to read from this characteristic
+      if (!characteristic.props.perms?.includes(Perms.PAIRED_READ)) { // check if we are allowed to read from this characteristic
         debug('[%s] Tried reading from Characteristic which does not allow reading (iid of %s and aid of %s)', this.displayName, characteristicData.aid, characteristicData.iid);
         const response: any = {
           aid: aid,
@@ -1082,7 +1082,7 @@ export class Accessory extends EventEmitter<Events> {
       // if "ev" is present, that means we need to register or unregister this client for change events for
       // this characteristic.
       if (typeof ev !== 'undefined') {
-        if (!characteristic.props.perms.includes(Perms.NOTIFY)) { // check if notify is allowed for this characteristic
+        if (!characteristic.props.perms?.includes(Perms.NOTIFY)) { // check if notify is allowed for this characteristic
           debug('[%s] Tried enabling notifications for Characteristic which does not allow notify (iid of %s and aid of %s)', this.displayName, characteristicData.aid, characteristicData.iid);
           const response: any = {
             aid: aid,
@@ -1137,7 +1137,7 @@ export class Accessory extends EventEmitter<Events> {
 
       // Found the characteristic - set the value if there is one
       if (typeof value !== 'undefined') {
-        if (!characteristic.props.perms.includes(Perms.PAIRED_WRITE)) { // check if write is allowed for this characteristic
+        if (!characteristic.props.perms?.includes(Perms.PAIRED_WRITE)) { // check if write is allowed for this characteristic
           debug('[%s] Tried writing to Characteristic which does not allow writing (iid of %s and aid of %s)', this.displayName, characteristicData.aid, characteristicData.iid);
           const response: any = {
             aid: aid,

--- a/src/lib/AccessoryLoader.ts
+++ b/src/lib/AccessoryLoader.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import createDebug from 'debug';
 
@@ -11,7 +11,7 @@ import {
   CharacteristicSetCallback
 } from './Characteristic';
 import * as uuid from './util/uuid';
-import { CharacteristicValue, NodeCallback, Nullable } from '../types';
+import { CharacteristicValue, Nullable } from '../types';
 
 const debug = createDebug('AccessoryLoader');
 

--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 
 import bonjour, { BonjourHap, MulticastOptions, Service } from 'bonjour-hap';
 
@@ -114,4 +114,3 @@ export class Advertiser {
     return setupHash;
   }
 }
-

--- a/src/lib/Camera.ts
+++ b/src/lib/Camera.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto';
-import fs from 'fs';
-import ip from 'ip';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as ip from 'ip';
 import { ChildProcess, spawn } from 'child_process';
 
 import { Service } from './Service';
@@ -239,8 +239,7 @@ export class Camera {
     this.services.push(myCameraEventRecordingManagement);
   }
 
-// Private
-  _createStreamControllers = (maxStreams: number, options: StreamControllerOptions) => {
+  private _createStreamControllers = (maxStreams: number, options: StreamControllerOptions) => {
 
     for (let i = 0; i < maxStreams; i++) {
       const streamController = new StreamController(i, options, this);

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -55,14 +55,14 @@ export enum Perms {
 }
 
 export interface CharacteristicProps {
-  format: Formats;
-  unit?: Units;
-  perms: Perms[];
+  format: Nullable<Formats>;
+  unit?:Nullable<Units>;
+  perms: Nullable<Perms[]>;
   ev?: boolean;
   description?: string;
-  minValue?: number;
-  maxValue?: number;
-  minStep?: number;
+  minValue?:Nullable<number>;
+  maxValue?:Nullable<number>;
+  minStep?:Nullable<number>;
   maxLen?: number;
   maxDataLen?: number;
   validValues?: number[];
@@ -364,7 +364,6 @@ export class Characteristic extends EventEmitter<Events> {
 
   constructor(public displayName?: string, public UUID?: string, props?: CharacteristicProps) {
     super();
-    // @ts-ignore
     this.props = props || {
       format: null,
       unit: null,
@@ -599,7 +598,7 @@ export class Characteristic extends EventEmitter<Events> {
           if (callback)
             callback(err);
         } else {
-          if (writeResponse !== undefined && this.props.perms.includes(Perms.WRITE_RESPONSE))
+          if (writeResponse !== undefined && this.props.perms?.includes(Perms.WRITE_RESPONSE))
             newValue = writeResponse; // support write response simply by letting the implementor pass the response as second argument to the callback
 
           if (newValue === undefined || newValue === null)
@@ -741,7 +740,7 @@ export class Characteristic extends EventEmitter<Events> {
       }
     }
     // if we're not readable, omit the "value" property - otherwise iOS will complain about non-compliance
-    if (this.props.perms.indexOf(Perms.READ) == -1)
+    if (this.props.perms?.indexOf(Perms.READ) == -1)
       delete hap.value;
     // delete the "value" property anyway if we were asked to
     if (opt && opt.omitValues)

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -1,9 +1,9 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 
 import createDebug from 'debug';
-import srp from 'fast-srp-hap';
-import tweetnacl from 'tweetnacl';
-import url from 'url';
+import * as srp from 'fast-srp-hap';
+import * as tweetnacl from 'tweetnacl';
+import * as url from 'url';
 
 import * as encryption from './util/encryption';
 import * as hkdf from './util/hkdf';
@@ -11,7 +11,6 @@ import * as tlv from './util/tlv';
 import { EventedHTTPServer, EventedHTTPServerEvents, Session } from './util/eventedhttp';
 import { once } from './util/once';
 import { IncomingMessage, ServerResponse } from "http";
-import { Characteristic } from './Characteristic';
 import { Accessory, CharacteristicEvents, Resource } from './Accessory';
 import { CharacteristicData, NodeCallback, PairingsCallback, SessionIdentifier, VoidCallback } from '../types';
 import { EventEmitter } from './EventEmitter';
@@ -340,8 +339,7 @@ export class HAPServer extends EventEmitter<Events> {
         depth: null
       }));
   }
-
-  _onEncrypt = (data: Buffer, encrypted: { data: Buffer; }, session: Session) => {
+  _onEncrypt = (data: Buffer, encrypted: { data: Buffer | number; error: Error | null }, session: Session) => {
     // instance of HAPEncryption (created in handlePairVerifyStepOne)
     var enc = session.encryption;
     // if accessoryToControllerKey is not empty, then encryption is enabled for this connection. However, we'll
@@ -879,10 +877,6 @@ export class HAPServer extends EventEmitter<Events> {
       response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
       return;
     }
-
-    type Characteristics = Pick<CharacteristicData, 'aid' | 'iid'> & {
-      status?: any;
-    };
 
     if (request.method == "GET") {
       // Extract the query params from the URL which looks like: /characteristics?id=1.9,2.14,...

--- a/src/lib/HomeKitRemoteController.ts
+++ b/src/lib/HomeKitRemoteController.ts
@@ -1,6 +1,6 @@
 import * as tlv from './util/tlv';
 import createDebug from 'debug';
-import assert from 'assert';
+import * as assert from 'assert';
 
 import {Service} from "./Service";
 import {

--- a/src/lib/StreamController.ts
+++ b/src/lib/StreamController.ts
@@ -1,6 +1,5 @@
-import crypto from 'crypto';
-
-import ip from 'ip';
+import * as crypto from 'crypto';
+import * as ip from 'ip';
 import createDebug from 'debug';
 
 import * as tlv from './util/tlv';
@@ -12,7 +11,6 @@ import {
   CharacteristicSetCallback
 } from './Characteristic';
 import RTPProxy from './camera/RTPProxy';
-import { EventEmitter } from './EventEmitter';
 import { Camera } from './Camera';
 import {
   Address,
@@ -343,8 +341,7 @@ export class StreamController {
     }
   }
 
-// Private
-  _createService = () => {
+  private _createService = () => {
     var managementService = new Service.CameraRTPStreamManagement('', this.identifier.toString());
 
     managementService
@@ -502,7 +499,7 @@ export class StreamController {
       var codec = audio[AudioTypes.CODEC];
       var audioCodecParamsTLV = tlv.decode(audio[AudioTypes.CODEC_PARAM]);
       var audioRTPParamsTLV = tlv.decode(audio[AudioTypes.RTP_PARAM]);
-      var comfortNoise = tlv.decode(audio[AudioTypes.COMFORT_NOISE]);
+      // var comfortNoise = tlv.decode(audio[AudioTypes.COMFORT_NOISE]);
 
       let audioCodec = codec.readUInt8(0);
       if (audioCodec !== undefined) {
@@ -597,7 +594,7 @@ export class StreamController {
     // Address
     var targetAddressPayload = objects[SetupTypes.ADDRESS];
     var processedAddressInfo = tlv.decode(targetAddressPayload) as any;
-    var isIPv6 = processedAddressInfo[SetupAddressInfo.ADDRESS_VER][0];
+    // var isIPv6 = processedAddressInfo[SetupAddressInfo.ADDRESS_VER][0];
     var targetAddress = processedAddressInfo[SetupAddressInfo.ADDRESS].toString('utf8');
     var targetVideoPort = processedAddressInfo[SetupAddressInfo.VIDEO_RTP_PORT].readUInt16LE(0);
     var targetAudioPort = processedAddressInfo[SetupAddressInfo.AUDIO_RTP_PORT].readUInt16LE(0);
@@ -985,7 +982,6 @@ export class StreamController {
 
       var codec = AudioCodecTypes.OPUS;
       var bitrate = AudioCodecParamBitRateTypes.VARIABLE;
-      var samplerate = AudioCodecParamSampleRateTypes.KHZ_24;
 
       var audioParamTLV = tlv.encode(
         AudioCodecParamTypes.CHANNEL, 1,
@@ -1007,4 +1003,3 @@ export class StreamController {
     return Buffer.concat([audioConfigurationsBuffer, tlv.encode(0x02, comfortNoiseValue)]).toString('base64');
   }
 }
-

--- a/src/lib/datastream/DataStreamParser.ts
+++ b/src/lib/datastream/DataStreamParser.ts
@@ -1,6 +1,6 @@
 import * as uuid from '../util/uuid'
 import * as encryption from "../util/encryption"
-import assert from 'assert';
+import * as assert from 'assert';
 import createDebug from 'debug';
 
 // welcome to hell :)

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -1,11 +1,11 @@
 import createDebug from 'debug';
-import assert from 'assert';
+import * as assert from 'assert';
 
 import * as encryption from '../util/encryption';
 import * as hkdf from '../util/hkdf';
 import {DataStreamParser, DataStreamReader, DataStreamWriter, Int64} from './DataStreamParser';
-import crypto from 'crypto';
-import net, {Socket} from 'net';
+import * as crypto from 'crypto';
+import * as net from 'net';
 import {HAPSessionEvents, Session} from "../util/eventedhttp";
 import {EventEmitter as NodeEventEmitter} from "events";
 import {EventEmitter} from "../EventEmitter";
@@ -289,7 +289,7 @@ export class DataStreamServer extends EventEmitter<DataStreamServerEventMap> {
         }
     }
 
-    private onConnection(socket: Socket) {
+    private onConnection(socket: net.Socket) {
         debug("[%s] New DataStream connection was established", socket.remoteAddress);
         const connection = new DataStreamConnection(socket);
 
@@ -424,7 +424,7 @@ export class DataStreamConnection extends EventEmitter<DataStreamConnectionEvent
 
     private static readonly MAX_PAYLOAD_LENGTH = 0b11111111111111111111;
 
-    private socket: Socket;
+    private socket: net.Socket;
     private session?: Session; // reference to the hap session. is present when state > UNIDENTIFIED
     readonly _remoteAddress: string;
     /*
@@ -452,7 +452,7 @@ export class DataStreamConnection extends EventEmitter<DataStreamConnectionEvent
 
     private helloTimer?: Timeout;
 
-    constructor(socket: Socket) {
+    constructor(socket: net.Socket) {
         super();
         this.socket = socket;
         this._remoteAddress = socket.remoteAddress!;

--- a/src/lib/gen/importAsClasses.ts
+++ b/src/lib/gen/importAsClasses.ts
@@ -1,9 +1,9 @@
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 
-import plist from 'simple-plist';
+import * as plist from 'simple-plist';
 
-import { Characteristic, Formats, Units } from "../Characteristic";
+import { Formats, Units } from "../Characteristic";
 
 /**
  * This module is intended to be run from the command line. It is a script that extracts Apple's Service

--- a/src/lib/model/AccessoryInfo.ts
+++ b/src/lib/model/AccessoryInfo.ts
@@ -1,7 +1,7 @@
-import storage from 'node-persist';
-import util from 'util';
-import assert from 'assert';
-import tweetnacl from 'tweetnacl';
+import * as storage from 'node-persist';
+import * as util from 'util';
+import * as assert from 'assert';
+import * as tweetnacl from 'tweetnacl';
 
 import { Categories } from '../Accessory';
 import { Session } from "../util/eventedhttp";
@@ -43,7 +43,7 @@ export class AccessoryInfo {
   relayPairedControllers: Record<string, string>;
   accessoryBagURL: string;
 
-  private constructor(username: string) {
+  constructor(username: string) {
     this.username = username;
     this.displayName = "";
     // @ts-ignore
@@ -306,4 +306,3 @@ export class AccessoryInfo {
   };
 
 }
-

--- a/src/lib/model/IdentifierCache.spec.ts
+++ b/src/lib/model/IdentifierCache.spec.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import storage from 'node-persist';
+import * as storage from 'node-persist';
 
 import { IdentifierCache } from './IdentifierCache';
 

--- a/src/lib/model/IdentifierCache.ts
+++ b/src/lib/model/IdentifierCache.ts
@@ -1,7 +1,7 @@
-import crypto from 'crypto';
-import util from 'util';
+import * as crypto from 'crypto';
+import * as util from 'util';
 
-import storage from 'node-persist';
+import * as storage from 'node-persist';
 
 /**
  * IdentifierCache is a model class that manages a system of associating HAP "Accessory IDs" and "Instance IDs"
@@ -117,16 +117,3 @@ export class IdentifierCache {
     }
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/lib/util/chacha20poly1305.ts
+++ b/src/lib/util/chacha20poly1305.ts
@@ -5,8 +5,8 @@
 // Implementation derived from chacha-ref.c version 20080118
 // See for details: http://cr.yp.to/chacha/chacha-20080128.pdf
 
-var Chacha20KeySize   = 32;
-var Chacha20NonceSize =  8;
+export const Chacha20KeySize   = 32;
+export const Chacha20NonceSize =  8;
 
 export class Chacha20Ctx {
   input: any[];
@@ -172,7 +172,6 @@ export function chacha20_keystream(ctx: Chacha20Ctx, dst: Buffer, len: number) {
 // Implementation derived from poly1305-donna-16.h
 // See for details: https://github.com/floodyberry/poly1305-donna
 
-var Poly1305KeySize = 32;
 var Poly1305TagSize = 16;
 
 export class Poly1305Ctx {

--- a/src/lib/util/encryption.ts
+++ b/src/lib/util/encryption.ts
@@ -1,14 +1,13 @@
-import assert from 'assert';
-import crypto from 'crypto';
+import * as assert from 'assert';
 
 import createDebug from 'debug';
-import tweetnacl from 'tweetnacl';
+import * as tweetnacl from 'tweetnacl';
 
 import * as chacha20poly1305 from './chacha20poly1305';
 
 const debug = createDebug('encryption');
 
-function fromHex(h: string) {
+export function fromHex(h: string) {
   h.replace(/([^0-9a-f])/g, '');
   var out = [], len = h.length, w = '';
   for (var i = 0; i < len; i += 2) {
@@ -210,7 +209,7 @@ function uintHighLow(number: number) {
   return [high, low]
 }
 
-function intHighLow(number: number) {
+export function intHighLow(number: number) {
   if (number > -1) {
     return uintHighLow(number)
   }
@@ -227,7 +226,7 @@ function intHighLow(number: number) {
   return [high, low]
 }
 
-function writeUInt64BE(number: number, buffer: Buffer, offset: number = 0) {
+export function writeUInt64BE(number: number, buffer: Buffer, offset: number = 0) {
   var hl = uintHighLow(number)
   buffer.writeUInt32BE(hl[0], offset)
   buffer.writeUInt32BE(hl[1], offset + 4)

--- a/src/lib/util/hkdf.ts
+++ b/src/lib/util/hkdf.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 import { BinaryLike } from './uuid';
 
 export function HKDF(hashAlg: string, salt: BinaryLike, ikm: BinaryLike, info: Buffer, size: number) {

--- a/src/lib/util/uuid.ts
+++ b/src/lib/util/uuid.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 
 type Binary = Buffer | NodeJS.TypedArray | DataView;
 export type BinaryLike = string | Binary;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,19 +2,17 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": [
-      "es2015",
-      "es2016",
-      "es2017",
-      "es2018"
-    ],
+    "lib": ["es2018"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
-    "esModuleInterop": true
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": false
   },
   "include": [
     "src/"


### PR DESCRIPTION
This PR contains a few changes, all in the interest of stronger typing and greater compatibility for `hap-nodejs` as a library:

- I disabled `esModuleInterop` and converted implicit namespace imports to explicit namespace imports. This is potentially controversial but for libraries it’s generally the better way to go. Libraries with `esModuleInterop` enabled require downstream consumers to enable `esModuleInterop` in their projects, whether or not they’d like to. `esModuleInterop` oddly makes libraries _less_ interoperable.
- I enabled `noUnusedLocals` and then removed, commented out, or exported unused variables and functions. Feel free to nit-pick with what I changed—I’ve got no opinions other than "unused code shouldn’t be left lying around".
- I updated TypeScript from 3.5.3 to 3.7.3 to be able to use the optional chaining feature ("the question mark") that was added in 3.7. Since your compile target is still `"es5"` the output code will remain ES5-compatible.
- I fixed some `@ts-ignore` comments (this is where I used optional chaining).
- I fixed some type issues (`private constructor`).
- I removed the yarn lockfile since it appears that `npm` is the preferred package manager.