### PR TITLE
Install, configure, and run prettier

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,8 @@ jobs:
       - name: npm install, build and test
         run: |
           npm ci
-          npm run build --if-present
+          npm run format-check
+          npm run build
           npm test
         env:
           CI: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1716,8 +1716,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1738,14 +1737,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1760,20 +1757,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1890,8 +1884,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1903,7 +1896,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1918,7 +1910,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1926,14 +1917,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1952,7 +1941,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2033,8 +2021,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2046,7 +2033,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2132,8 +2118,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2169,7 +2154,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2189,7 +2173,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2233,14 +2216,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3933,6 +3914,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "engines": {
     "node": ">=10.17.0"
   },
+  "prettier": {
+    "printWidth": 120,
+    "trailingComma": "es5"
+  },
   "dependencies": {
     "bonjour-hap": "^3.5.1",
     "debug": "^2.2.0",
@@ -22,6 +26,7 @@
     "@types/jest": "^24.0.15",
     "@types/node": "^10.17.13",
     "jest": "^24.8.0",
+    "prettier": "^1.19.1",
     "rimraf": "^2.7.1",
     "simple-plist": "0.0.4",
     "ts-jest": "^24.0.2",
@@ -30,6 +35,8 @@
   },
   "scripts": {
     "build": "rimraf dist/ && tsc",
+    "format": "prettier --write \"src/**/*.{js,ts,tsx,json}\"",
+    "format-check": "prettier --check \"src/**/*.{js,ts,tsx,json}\"",
     "prepublishOnly": "npm run build",
     "test": "jest",
     "start": "node dist/BridgedCore.js"

--- a/src/BridgedCore.ts
+++ b/src/BridgedCore.ts
@@ -1,8 +1,8 @@
-import path from 'path';
+import path from "path";
 
-import storage from 'node-persist';
+import storage from "node-persist";
 
-import { Accessory, AccessoryEventTypes, AccessoryLoader, Bridge, Categories, uuid, VoidCallback } from './';
+import { Accessory, AccessoryEventTypes, AccessoryLoader, Bridge, Categories, uuid, VoidCallback } from "./";
 
 console.log("HAP-NodeJS starting...");
 
@@ -10,7 +10,7 @@ console.log("HAP-NodeJS starting...");
 storage.initSync();
 
 // Start by creating our Bridge which will host all loaded Accessories
-const bridge = new Bridge('Node Bridge', uuid.generate("Node Bridge"));
+const bridge = new Bridge("Node Bridge", uuid.generate("Node Bridge"));
 
 // Listen for bridge identification event
 bridge.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback) => {
@@ -32,15 +32,15 @@ bridge.publish({
   username: "CC:22:3D:E3:CE:F6",
   port: 51826,
   pincode: "031-45-154",
-  category: Categories.BRIDGE
+  category: Categories.BRIDGE,
 });
 
-var signals = { 'SIGINT': 2, 'SIGTERM': 15 } as Record<string, number>;
+var signals = { SIGINT: 2, SIGTERM: 15 } as Record<string, number>;
 Object.keys(signals).forEach((signal: any) => {
-  process.on(signal, function () {
+  process.on(signal, function() {
     bridge.unpublish();
-    setTimeout(function (){
-        process.exit(128 + signals[signal]);
-    }, 1000)
+    setTimeout(function() {
+      process.exit(128 + signals[signal]);
+    }, 1000);
   });
 });

--- a/src/CameraCore.ts
+++ b/src/CameraCore.ts
@@ -1,6 +1,6 @@
-import storage from 'node-persist';
+import storage from "node-persist";
 
-import { Accessory, AccessoryEventTypes, Camera, Categories, uuid, VoidCallback } from './';
+import { Accessory, AccessoryEventTypes, Camera, Categories, uuid, VoidCallback } from "./";
 
 console.log("HAP-NodeJS starting...");
 
@@ -8,7 +8,7 @@ console.log("HAP-NodeJS starting...");
 storage.initSync();
 
 // Start by creating our Bridge which will host all loaded Accessories
-var cameraAccessory = new Accessory('Node Camera', uuid.generate("Node Camera"));
+var cameraAccessory = new Accessory("Node Camera", uuid.generate("Node Camera"));
 
 var cameraSource = new Camera();
 
@@ -20,19 +20,22 @@ cameraAccessory.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: Voi
 });
 
 // Publish the camera on the local network.
-cameraAccessory.publish({
-  username: "EC:22:3D:D3:CE:CE",
-  port: 51062,
-  pincode: "031-45-154",
-  category: Categories.CAMERA
-}, true);
+cameraAccessory.publish(
+  {
+    username: "EC:22:3D:D3:CE:CE",
+    port: 51062,
+    pincode: "031-45-154",
+    category: Categories.CAMERA,
+  },
+  true
+);
 
-var signals = { 'SIGINT': 2, 'SIGTERM': 15 } as Record<string, number>;
+var signals = { SIGINT: 2, SIGTERM: 15 } as Record<string, number>;
 Object.keys(signals).forEach((signal: any) => {
   process.on(signal, () => {
     cameraAccessory.unpublish();
     setTimeout(() => {
-        process.exit(128 + signals[signal]);
-    }, 1000)
+      process.exit(128 + signals[signal]);
+    }, 1000);
   });
 });

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -1,8 +1,8 @@
-import path from 'path';
+import path from "path";
 
-import storage from 'node-persist';
+import storage from "node-persist";
 
-import { AccessoryLoader } from './';
+import { AccessoryLoader } from "./";
 
 console.log("HAP-NodeJS starting...");
 
@@ -17,18 +17,23 @@ var dir = path.join(__dirname, "accessories");
 var accessories = AccessoryLoader.loadDirectory(dir);
 
 // Publish them all separately (as opposed to BridgedCore which publishes them behind a single Bridge accessory)
-accessories.forEach((accessory) => {
-
+accessories.forEach(accessory => {
   // To push Accessories separately, we'll need a few extra properties
   // @ts-ignore
   if (!accessory.username)
-    throw new Error("Username not found on accessory '" + accessory.displayName +
-                    "'. Core.js requires all accessories to define a unique 'username' property.");
+    throw new Error(
+      "Username not found on accessory '" +
+        accessory.displayName +
+        "'. Core.js requires all accessories to define a unique 'username' property."
+    );
 
   // @ts-ignore
   if (!accessory.pincode)
-    throw new Error("Pincode not found on accessory '" + accessory.displayName +
-                    "'. Core.js requires all accessories to define a 'pincode' property.");
+    throw new Error(
+      "Pincode not found on accessory '" +
+        accessory.displayName +
+        "'. Core.js requires all accessories to define a 'pincode' property."
+    );
 
   // publish this Accessory on the local network
   accessory.publish({
@@ -38,11 +43,11 @@ accessories.forEach((accessory) => {
     // @ts-ignore
     pincode: accessory.pincode,
     // @ts-ignore
-    category: accessory.category
+    category: accessory.category,
   });
 });
 
-var signals = { 'SIGINT': 2, 'SIGTERM': 15 } as Record<string, number>;
+var signals = { SIGINT: 2, SIGTERM: 15 } as Record<string, number>;
 Object.keys(signals).forEach((signal: any) => {
   process.on(signal, () => {
     for (var i = 0; i < accessories.length; i++) {
@@ -50,7 +55,7 @@ Object.keys(signals).forEach((signal: any) => {
     }
 
     setTimeout(() => {
-        process.exit(128 + signals[signal]);
-    }, 1000)
+      process.exit(128 + signals[signal]);
+    }, 1000);
   });
 });

--- a/src/accessories/AirConditioner_accessory.ts
+++ b/src/accessories/AirConditioner_accessory.ts
@@ -8,12 +8,14 @@ import {
   AccessoryEventTypes,
   Categories,
   Characteristic,
-  CharacteristicEventTypes, CharacteristicGetCallback, CharacteristicSetCallback,
+  CharacteristicEventTypes,
+  CharacteristicGetCallback,
+  CharacteristicSetCallback,
   CharacteristicValue,
   Service,
   uuid,
-} from '..';
-import { NodeCallback, VoidCallback } from '../types';
+} from "..";
+import { NodeCallback, VoidCallback } from "../types";
 
 var ACTest_data: Record<string, CharacteristicValue> = {
   fanPowerOn: false,
@@ -23,11 +25,14 @@ var ACTest_data: Record<string, CharacteristicValue> = {
   CurrentTemperature: 33,
   TargetTemperature: 32,
   TemperatureDisplayUnits: 1,
-  LightOn: false
-}
+  LightOn: false,
+};
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake fan.
-var ACTest = exports.accessory = new Accessory('Air Conditioner', uuid.generate('hap-nodejs:accessories:airconditioner'));
+var ACTest = (exports.accessory = new Accessory(
+  "Air Conditioner",
+  uuid.generate("hap-nodejs:accessories:airconditioner")
+));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -38,9 +43,7 @@ ACTest.pincode = "031-45-154";
 ACTest.category = Categories.THERMOSTAT;
 
 // set some basic properties (these values are arbitrary and setting them is optional)
-ACTest
-  .getService(Service.AccessoryInformation)!
-  .setCharacteristic(Characteristic.Manufacturer, "Sample Company")
+ACTest.getService(Service.AccessoryInformation)!.setCharacteristic(Characteristic.Manufacturer, "Sample Company");
 
 // listen for the "identify" event for this Accessory
 ACTest.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback) => {
@@ -51,19 +54,21 @@ ACTest.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback
 // Add the actual Fan Service and listen for change events from iOS.
 // We can see the complete list of Services and Characteristics in `lib/gen/HomeKit.ts`
 
-var FanService = ACTest.addService(Service.Fan, "Blower") // services exposed to the user should have "names" like "Fake Light" for us
-FanService.getCharacteristic(Characteristic.On)!
-  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-    console.log("Fan Power Changed To "+value);
-    ACTest_data.fanPowerOn=value
+var FanService = ACTest.addService(Service.Fan, "Blower"); // services exposed to the user should have "names" like "Fake Light" for us
+FanService.getCharacteristic(Characteristic.On)!.on(
+  CharacteristicEventTypes.SET,
+  (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+    console.log("Fan Power Changed To " + value);
+    ACTest_data.fanPowerOn = value;
     callback(); // Our fake Fan is synchronous - this value has been successfully set
-  });
+  }
+);
 
 // We want to intercept requests for our current power state so we can query the hardware itself instead of
 // allowing HAP-NodeJS to return the cached Characteristic.value.
-FanService.getCharacteristic(Characteristic.On)!
-  .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-
+FanService.getCharacteristic(Characteristic.On)!.on(
+  CharacteristicEventTypes.GET,
+  (callback: CharacteristicGetCallback) => {
     // this event is emitted when you ask Siri directly whether your fan is on or not. you might query
     // the fan hardware itself to find this out, then call the callback. But if you take longer than a
     // few seconds to respond, Siri will give up.
@@ -72,12 +77,11 @@ FanService.getCharacteristic(Characteristic.On)!
 
     if (ACTest_data.fanPowerOn) {
       callback(err, true);
-    }
-    else {
+    } else {
       callback(err, false);
     }
-  });
-
+  }
+);
 
 // also add an "optional" Characteristic for speed
 FanService.addCharacteristic(Characteristic.RotationSpeed)
@@ -86,11 +90,11 @@ FanService.addCharacteristic(Characteristic.RotationSpeed)
   })
   .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
     console.log("Setting fan rSpeed to %s", value);
-    ACTest_data.rSpeed=value
+    ACTest_data.rSpeed = value;
     callback();
-  })
+  });
 
-var ThermostatService = ACTest.addService(Service.Thermostat,"Thermostat");
+var ThermostatService = ACTest.addService(Service.Thermostat, "Thermostat");
 ThermostatService.addLinkedService(FanService);
 
 ThermostatService.getCharacteristic(Characteristic.CurrentHeatingCoolingState)!
@@ -98,63 +102,61 @@ ThermostatService.getCharacteristic(Characteristic.CurrentHeatingCoolingState)!
   .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
     callback(null, ACTest_data.CurrentHeatingCoolingState);
   })
-  .on(CharacteristicEventTypes.SET,(value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-      ACTest_data.CurrentHeatingCoolingState=value;
-      console.log( "Characteristic CurrentHeatingCoolingState changed to %s",value);
-      callback();
-    });
+  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+    ACTest_data.CurrentHeatingCoolingState = value;
+    console.log("Characteristic CurrentHeatingCoolingState changed to %s", value);
+    callback();
+  });
 
- ThermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)!
+ThermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)!
   .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
     callback(null, ACTest_data.TargetHeatingCoolingState);
   })
-  .on(CharacteristicEventTypes.SET,(value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-      ACTest_data.TargetHeatingCoolingState=value;
-      console.log( "Characteristic TargetHeatingCoolingState changed to %s",value);
-      callback();
-    });
+  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+    ACTest_data.TargetHeatingCoolingState = value;
+    console.log("Characteristic TargetHeatingCoolingState changed to %s", value);
+    callback();
+  });
 
- ThermostatService.getCharacteristic(Characteristic.CurrentTemperature)!
+ThermostatService.getCharacteristic(Characteristic.CurrentTemperature)!
   .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
     callback(null, ACTest_data.CurrentTemperature);
   })
-  .on(CharacteristicEventTypes.SET,(value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-      ACTest_data.CurrentTemperature=value;
-      console.log( "Characteristic CurrentTemperature changed to %s",value);
-      callback();
-    });
+  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+    ACTest_data.CurrentTemperature = value;
+    console.log("Characteristic CurrentTemperature changed to %s", value);
+    callback();
+  });
 
- ThermostatService.getCharacteristic(Characteristic.TargetTemperature)!
+ThermostatService.getCharacteristic(Characteristic.TargetTemperature)!
   .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
     callback(null, ACTest_data.TargetTemperature);
   })
-  .on(CharacteristicEventTypes.SET,(value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-      ACTest_data.TargetTemperature=value;
-      console.log( "Characteristic TargetTemperature changed to %s",value);
-      callback();
-    });
+  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+    ACTest_data.TargetTemperature = value;
+    console.log("Characteristic TargetTemperature changed to %s", value);
+    callback();
+  });
 
- ThermostatService.getCharacteristic(Characteristic.TemperatureDisplayUnits)!
+ThermostatService.getCharacteristic(Characteristic.TemperatureDisplayUnits)!
   .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
     callback(null, ACTest_data.TemperatureDisplayUnits);
   })
-  .on(CharacteristicEventTypes.SET,(value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-      ACTest_data.TemperatureDisplayUnits=value;
-      console.log( "Characteristic TemperatureDisplayUnits changed to %s",value);
-      callback();
-    });
+  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+    ACTest_data.TemperatureDisplayUnits = value;
+    console.log("Characteristic TemperatureDisplayUnits changed to %s", value);
+    callback();
+  });
 
-
-
-var LightService = ACTest.addService(Service.Lightbulb, 'AC Light');
+var LightService = ACTest.addService(Service.Lightbulb, "AC Light");
 LightService.getCharacteristic(Characteristic.On)!
-    .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-      callback(null, ACTest_data.LightOn);
-    })
-    .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-      ACTest_data.LightOn=value;
-      console.log( "Characteristic Light On changed to %s",value);
-      callback();
-    });
+  .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+    callback(null, ACTest_data.LightOn);
+  })
+  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+    ACTest_data.LightOn = value;
+    console.log("Characteristic Light On changed to %s", value);
+    callback();
+  });
 LightService.setHiddenService(true);
 ACTest.setPrimaryService(ThermostatService);

--- a/src/accessories/AppleTVRemote_accessory.ts
+++ b/src/accessories/AppleTVRemote_accessory.ts
@@ -1,10 +1,10 @@
-import { Accessory, ButtonState, ButtonType, Categories, HomeKitRemoteController, uuid } from '..';
+import { Accessory, ButtonState, ButtonType, Categories, HomeKitRemoteController, uuid } from "..";
 import * as http from "http";
 import url, { UrlWithParsedQuery } from "url";
 import { GStreamerAudioProducer, GStreamerOptions } from "./gstreamer-audioProducer";
 
-const remoteUUID = uuid.generate('hap-nodejs:accessories:remote');
-const remote = exports.accessory = new Accessory('Remote', remoteUUID);
+const remoteUUID = uuid.generate("hap-nodejs:accessories:remote");
+const remote = (exports.accessory = new Accessory("Remote", remoteUUID));
 
 // @ts-ignore
 remote.username = "DB:AF:E0:5C:69:76";
@@ -15,13 +15,14 @@ remote.category = Categories.TARGET_CONTROLLER;
 // ----------------- for siri support -----------------
 // CHANGE this to enable siri support. Read docs in 'gstreamer-audioProducer.ts' for necessary package dependencies
 const siriSupport = false;
-const gstreamerOptions: Partial<GStreamerOptions> = { // any configuration regarding the producer can be made here
+const gstreamerOptions: Partial<GStreamerOptions> = {
+  // any configuration regarding the producer can be made here
 };
 // ----------------------------------------------------
 
 const controller = siriSupport
-    ? new HomeKitRemoteController(GStreamerAudioProducer, gstreamerOptions)
-    : new HomeKitRemoteController();
+  ? new HomeKitRemoteController(GStreamerAudioProducer, gstreamerOptions)
+  : new HomeKitRemoteController();
 controller.addServicesToAccessory(remote);
 
 /*
@@ -39,11 +40,12 @@ controller.addServicesToAccessory(remote);
     /setActiveTarget?identifier=<id>  - set currently controlled apple tv
  */
 
-http.createServer((request, response) => {
+http
+  .createServer((request, response) => {
     if (request.method !== "GET") {
-        response.writeHead(405, {"Content-Type": "text/html"});
-        response.end("Method Not Allowed");
-        return;
+      response.writeHead(405, { "Content-Type": "text/html" });
+      response.end("Method Not Allowed");
+      return;
     }
 
     const parsedPath: UrlWithParsedQuery = url.parse(request.url!, true);
@@ -51,112 +53,112 @@ http.createServer((request, response) => {
     const query = parsedPath.query;
 
     if (pathname === "setActiveTarget") {
-        if (query === undefined || query.identifier === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. Must include 'identifier' in query string!");
-            return;
-        }
-
-        const targetIdentifier = parseInt(query.identifier as string, 10);
-        if (!controller.isConfigured(targetIdentifier)) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. No target found for given identifier " + targetIdentifier);
-            return;
-        }
-
-        controller.setActiveIdentifier(targetIdentifier);
-        response.writeHead(200, {"Content-Type": "text/html"});
-        response.end("OK");
+      if (query === undefined || query.identifier === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. Must include 'identifier' in query string!");
         return;
+      }
+
+      const targetIdentifier = parseInt(query.identifier as string, 10);
+      if (!controller.isConfigured(targetIdentifier)) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. No target found for given identifier " + targetIdentifier);
+        return;
+      }
+
+      controller.setActiveIdentifier(targetIdentifier);
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end("OK");
+      return;
     } else if (pathname === "getActiveTarget") {
-        response.writeHead(200, {"Content-Type": "text/html"});
-        response.end(controller.activeIdentifier + "");
-        return;
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end(controller.activeIdentifier + "");
+      return;
     } else if (pathname === "getTargetId") {
-        if (query === undefined || query.name === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. Must include 'name' in query string!");
-            return;
-        }
-
-        const targetIdentifier = controller.getTargetIdentifierByName(query.name as string);
-        if (targetIdentifier === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. No target found for given name " + query.name);
-            return;
-        }
-
-        response.writeHead(200, {"Content-Type": "text/html"});
-        response.end("" + targetIdentifier);
+      if (query === undefined || query.name === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. Must include 'name' in query string!");
         return;
+      }
+
+      const targetIdentifier = controller.getTargetIdentifierByName(query.name as string);
+      if (targetIdentifier === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. No target found for given name " + query.name);
+        return;
+      }
+
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end("" + targetIdentifier);
+      return;
     } else if (pathname === "button") {
-        if (query === undefined || query.state === undefined || query.button === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. Must include 'state' and 'button' in query string!");
-            return;
-        }
-
-        const buttonState = parseInt(query.state as string, 10);
-        const button = parseInt(query.button as string, 10);
-        if (ButtonState[buttonState] === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. Unknown button state " + query.state);
-            return;
-        }
-        if (ButtonType[button] === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. Unknown button " + query.button);
-            return;
-        }
-
-        if (buttonState === ButtonState.UP) {
-            controller.releaseButton(button);
-        } else if (buttonState === ButtonState.DOWN) {
-            controller.pushButton(button);
-        }
-
-        response.writeHead(200, {"Content-Type": "text/html"});
-        response.end("OK");
+      if (query === undefined || query.state === undefined || query.button === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. Must include 'state' and 'button' in query string!");
         return;
+      }
+
+      const buttonState = parseInt(query.state as string, 10);
+      const button = parseInt(query.button as string, 10);
+      if (ButtonState[buttonState] === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. Unknown button state " + query.state);
+        return;
+      }
+      if (ButtonType[button] === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. Unknown button " + query.button);
+        return;
+      }
+
+      if (buttonState === ButtonState.UP) {
+        controller.releaseButton(button);
+      } else if (buttonState === ButtonState.DOWN) {
+        controller.pushButton(button);
+      }
+
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end("OK");
+      return;
     } else if (pathname === "press") {
-        if (query === undefined || query.button === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. Must include 'button' in query string!");
-            return;
-        }
-
-        let time = 200;
-        if (query.time !== undefined) {
-            const parsedTime = parseInt(query.time as string, 10);
-            if (parsedTime)
-                time = parsedTime;
-        }
-
-        const button = parseInt(query.button as string, 10);
-        if (ButtonType[button] === undefined) {
-            response.writeHead(400, {"Content-Type": "text/html"});
-            response.end("Bad request. Unknown button " + query.button);
-            return;
-        }
-
-        controller.pushAndReleaseButton(button, time);
-
-        response.writeHead(200, {"Content-Type": "text/html"});
-        response.end("OK");
+      if (query === undefined || query.button === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. Must include 'button' in query string!");
         return;
+      }
+
+      let time = 200;
+      if (query.time !== undefined) {
+        const parsedTime = parseInt(query.time as string, 10);
+        if (parsedTime) time = parsedTime;
+      }
+
+      const button = parseInt(query.button as string, 10);
+      if (ButtonType[button] === undefined) {
+        response.writeHead(400, { "Content-Type": "text/html" });
+        response.end("Bad request. Unknown button " + query.button);
+        return;
+      }
+
+      controller.pushAndReleaseButton(button, time);
+
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end("OK");
+      return;
     } else if (pathname === "listTargets") {
-        const targets = controller.targetConfigurations;
+      const targets = controller.targetConfigurations;
 
-        response.writeHead(200, {"Content-Type": "application/json"});
-        response.end(JSON.stringify(targets, undefined, 4));
-        return;
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify(targets, undefined, 4));
+      return;
     } else if (pathname === "getActive") {
-        response.writeHead(200, {"Content-Type": "text/html"});
-        response.end(controller.isActive()? "true": "false");
-        return;
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end(controller.isActive() ? "true" : "false");
+      return;
     } else {
-        response.writeHead(404, {"Content-Type": "text/html"});
-        response.end("Not Found. No path found for " + pathname);
-        return;
+      response.writeHead(404, { "Content-Type": "text/html" });
+      response.end("Not Found. No path found for " + pathname);
+      return;
     }
-}).listen(8080);
+  })
+  .listen(8080);

--- a/src/accessories/Fan_accessory.ts
+++ b/src/accessories/Fan_accessory.ts
@@ -4,23 +4,23 @@ import {
   AccessoryEventTypes,
   Categories,
   Characteristic,
-  CharacteristicEventTypes, CharacteristicSetCallback,
+  CharacteristicEventTypes,
+  CharacteristicSetCallback,
   CharacteristicValue,
   NodeCallback,
   Service,
   uuid,
-  VoidCallback
-} from '..';
+  VoidCallback,
+} from "..";
 
 var FAKE_FAN: Record<string, any> = {
   powerOn: false,
   rSpeed: 100,
   setPowerOn: (on: CharacteristicValue) => {
-    if(on){
+    if (on) {
       //put your code here to turn on the fan
       FAKE_FAN.powerOn = on;
-    }
-    else{
+    } else {
       //put your code here to turn off the fan
       FAKE_FAN.powerOn = on;
     }
@@ -33,11 +33,11 @@ var FAKE_FAN: Record<string, any> = {
   identify: () => {
     //put your code here to identify the fan
     console.log("Fan Identified!");
-  }
-}
+  },
+};
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake fan.
-var fan = exports.accessory = new Accessory('Fan', uuid.generate('hap-nodejs:accessories:Fan'));
+var fan = (exports.accessory = new Accessory("Fan", uuid.generate("hap-nodejs:accessories:Fan")));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -48,9 +48,7 @@ fan.pincode = "031-45-154";
 fan.category = Categories.FAN;
 
 // set some basic properties (these values are arbitrary and setting them is optional)
-fan
-  .getService(Service.AccessoryInformation)!
-  .setCharacteristic(Characteristic.Manufacturer, "Sample Company")
+fan.getService(Service.AccessoryInformation)!.setCharacteristic(Characteristic.Manufacturer, "Sample Company");
 
 // listen for the "identify" event for this Accessory
 fan.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback) => {
@@ -74,7 +72,6 @@ fan
   .getService(Service.Fan)!
   .getCharacteristic(Characteristic.On)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-
     // this event is emitted when you ask Siri directly whether your fan is on or not. you might query
     // the fan hardware itself to find this out, then call the callback. But if you take longer than a
     // few seconds to respond, Siri will give up.
@@ -83,8 +80,7 @@ fan
 
     if (FAKE_FAN.powerOn) {
       callback(err, true);
-    }
-    else {
+    } else {
       callback(err, false);
     }
   });
@@ -99,4 +95,4 @@ fan
   .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
     FAKE_FAN.setSpeed(value);
     callback();
-  })
+  });

--- a/src/accessories/GarageDoorOpener_accessory.ts
+++ b/src/accessories/GarageDoorOpener_accessory.ts
@@ -3,12 +3,14 @@ import {
   AccessoryEventTypes,
   Categories,
   Characteristic,
-  CharacteristicEventTypes, CharacteristicSetCallback, CharacteristicValue,
+  CharacteristicEventTypes,
+  CharacteristicSetCallback,
+  CharacteristicValue,
   NodeCallback,
   Service,
   uuid,
-  VoidCallback
-} from '..';
+  VoidCallback,
+} from "..";
 
 var FAKE_GARAGE = {
   opened: false,
@@ -26,15 +28,15 @@ var FAKE_GARAGE = {
     //add your code here which allows the garage to be identified
     console.log("Identify the Garage");
   },
-  status: () =>{
+  status: () => {
     //use this section to get sensor values. set the boolean FAKE_GARAGE.opened with a sensor value.
     console.log("Sensor queried!");
     //FAKE_GARAGE.opened = true/false;
-  }
+  },
 };
 
-var garageUUID = uuid.generate('hap-nodejs:accessories:'+'GarageDoor');
-var garage = exports.accessory = new Accessory('Garage Door', garageUUID);
+var garageUUID = uuid.generate("hap-nodejs:accessories:" + "GarageDoor");
+var garage = (exports.accessory = new Accessory("Garage Door", garageUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -60,15 +62,13 @@ garage
   .setCharacteristic(Characteristic.TargetDoorState, Characteristic.TargetDoorState.CLOSED) // force initial state to CLOSED
   .getCharacteristic(Characteristic.TargetDoorState)!
   .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-
     if (value == Characteristic.TargetDoorState.CLOSED) {
       FAKE_GARAGE.close();
       callback();
       garage
         .getService(Service.GarageDoorOpener)!
         .setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
-    }
-    else if (value == Characteristic.TargetDoorState.OPEN) {
+    } else if (value == Characteristic.TargetDoorState.OPEN) {
       FAKE_GARAGE.open();
       callback();
       garage
@@ -77,20 +77,17 @@ garage
     }
   });
 
-
 garage
   .getService(Service.GarageDoorOpener)!
   .getCharacteristic(Characteristic.CurrentDoorState)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-
     var err = null;
     FAKE_GARAGE.status();
 
     if (FAKE_GARAGE.opened) {
       console.log("Query: Is Garage Open? Yes.");
       callback(err, Characteristic.CurrentDoorState.OPEN);
-    }
-    else {
+    } else {
       console.log("Query: Is Garage Open? No.");
       callback(err, Characteristic.CurrentDoorState.CLOSED);
     }

--- a/src/accessories/Light_accessory.ts
+++ b/src/accessories/Light_accessory.ts
@@ -3,16 +3,16 @@ import {
   AccessoryEventTypes,
   Categories,
   Characteristic,
-  CharacteristicEventTypes, CharacteristicSetCallback,
+  CharacteristicEventTypes,
+  CharacteristicSetCallback,
   CharacteristicValue,
   NodeCallback,
   Service,
   uuid,
-  VoidCallback
-} from '..';
+  VoidCallback,
+} from "..";
 
 class LightControllerClass {
-
   name: CharacteristicValue = "Simple Light"; //name of accessory
   pincode: CharacteristicValue = "031-45-154";
   username: CharacteristicValue = "FA:3C:ED:5A:1A:1A"; // MAC like address used by HomeKit to differentiate accessories.
@@ -27,48 +27,57 @@ class LightControllerClass {
 
   outputLogs = false; //output logs
 
-  setPower(status: CharacteristicValue) { //set power of accessory
-    if(this.outputLogs) console.log("Turning the '%s' %s", this.name, status ? "on" : "off");
+  setPower(status: CharacteristicValue) {
+    //set power of accessory
+    if (this.outputLogs) console.log("Turning the '%s' %s", this.name, status ? "on" : "off");
     this.power = status;
   }
 
-  getPower() { //get power of accessory
-    if(this.outputLogs) console.log("'%s' is %s.", this.name, this.power ? "on" : "off");
+  getPower() {
+    //get power of accessory
+    if (this.outputLogs) console.log("'%s' is %s.", this.name, this.power ? "on" : "off");
     return this.power;
   }
 
-  setBrightness(brightness: CharacteristicValue) { //set brightness
-    if(this.outputLogs) console.log("Setting '%s' brightness to %s", this.name, brightness);
+  setBrightness(brightness: CharacteristicValue) {
+    //set brightness
+    if (this.outputLogs) console.log("Setting '%s' brightness to %s", this.name, brightness);
     this.brightness = brightness;
   }
 
-  getBrightness() { //get brightness
-    if(this.outputLogs) console.log("'%s' brightness is %s", this.name, this.brightness);
+  getBrightness() {
+    //get brightness
+    if (this.outputLogs) console.log("'%s' brightness is %s", this.name, this.brightness);
     return this.brightness;
   }
 
-  setSaturation(saturation: CharacteristicValue) { //set brightness
-    if(this.outputLogs) console.log("Setting '%s' saturation to %s", this.name, saturation);
+  setSaturation(saturation: CharacteristicValue) {
+    //set brightness
+    if (this.outputLogs) console.log("Setting '%s' saturation to %s", this.name, saturation);
     this.saturation = saturation;
   }
 
-  getSaturation() { //get brightness
-    if(this.outputLogs) console.log("'%s' saturation is %s", this.name, this.saturation);
+  getSaturation() {
+    //get brightness
+    if (this.outputLogs) console.log("'%s' saturation is %s", this.name, this.saturation);
     return this.saturation;
   }
 
-  setHue(hue: CharacteristicValue) { //set brightness
-    if(this.outputLogs) console.log("Setting '%s' hue to %s", this.name, hue);
+  setHue(hue: CharacteristicValue) {
+    //set brightness
+    if (this.outputLogs) console.log("Setting '%s' hue to %s", this.name, hue);
     this.hue = hue;
   }
 
-  getHue() { //get hue
-    if(this.outputLogs) console.log("'%s' hue is %s", this.name, this.hue);
+  getHue() {
+    //get hue
+    if (this.outputLogs) console.log("'%s' hue is %s", this.name, this.hue);
     return this.hue;
   }
 
-  identify() { //identify the accessory
-    if(this.outputLogs) console.log("Identify the '%s'", this.name);
+  identify() {
+    //identify the accessory
+    if (this.outputLogs) console.log("Identify the '%s'", this.name);
   }
 }
 
@@ -77,10 +86,10 @@ const LightController = new LightControllerClass();
 // Generate a consistent UUID for our light Accessory that will remain the same even when
 // restarting our server. We use the `uuid.generate` helper function to create a deterministic
 // UUID based on an arbitrary "namespace" and the word "light".
-var lightUUID = uuid.generate('hap-nodejs:accessories:light' + LightController.name);
+var lightUUID = uuid.generate("hap-nodejs:accessories:light" + LightController.name);
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our light.
-var lightAccessory = exports.accessory = new Accessory(LightController.name as string, lightUUID);
+var lightAccessory = (exports.accessory = new Accessory(LightController.name as string, lightUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -93,9 +102,9 @@ lightAccessory.category = Categories.LIGHTBULB;
 // set some basic properties (these values are arbitrary and setting them is optional)
 lightAccessory
   .getService(Service.AccessoryInformation)!
-    .setCharacteristic(Characteristic.Manufacturer, LightController.manufacturer)
-    .setCharacteristic(Characteristic.Model, LightController.model)
-    .setCharacteristic(Characteristic.SerialNumber, LightController.serialNumber);
+  .setCharacteristic(Characteristic.Manufacturer, LightController.manufacturer)
+  .setCharacteristic(Characteristic.Model, LightController.model)
+  .setCharacteristic(Characteristic.SerialNumber, LightController.serialNumber);
 
 // listen for the "identify" event for this Accessory
 lightAccessory.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback) => {

--- a/src/accessories/Lock_accessory.ts
+++ b/src/accessories/Lock_accessory.ts
@@ -3,12 +3,13 @@ import {
   AccessoryEventTypes,
   Categories,
   Characteristic,
-  CharacteristicEventTypes, CharacteristicSetCallback,
+  CharacteristicEventTypes,
+  CharacteristicSetCallback,
   CharacteristicValue,
   Service,
-  uuid
-} from '../';
-import { NodeCallback, VoidCallback } from '../types';
+  uuid,
+} from "../";
+import { NodeCallback, VoidCallback } from "../types";
 
 // here's a fake hardware device that we'll expose to HomeKit
 var FAKE_LOCK = {
@@ -23,16 +24,16 @@ var FAKE_LOCK = {
   },
   identify: () => {
     console.log("Identify the lock!");
-  }
-}
+  },
+};
 
 // Generate a consistent UUID for our Lock Accessory that will remain the same even when
 // restarting our server. We use the `uuid.generate` helper function to create a deterministic
 // UUID based on an arbitrary "namespace" and the word "lock".
-var lockUUID = uuid.generate('hap-nodejs:accessories:lock');
+var lockUUID = uuid.generate("hap-nodejs:accessories:lock");
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake lock.
-var lock = exports.accessory = new Accessory('Lock', lockUUID);
+var lock = (exports.accessory = new Accessory("Lock", lockUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -61,7 +62,6 @@ lock
   .addService(Service.LockMechanism, "Fake Lock") // services exposed to the user should have "names" like "Fake Light" for us
   .getCharacteristic(Characteristic.LockTargetState)!
   .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-
     if (value == Characteristic.LockTargetState.UNSECURED) {
       FAKE_LOCK.unlock();
       callback(); // Our fake Lock is synchronous - this value has been successfully set
@@ -70,8 +70,7 @@ lock
       lock
         .getService(Service.LockMechanism)!
         .setCharacteristic(Characteristic.LockCurrentState, Characteristic.LockCurrentState.UNSECURED);
-    }
-    else if (value == Characteristic.LockTargetState.SECURED) {
+    } else if (value == Characteristic.LockTargetState.SECURED) {
       FAKE_LOCK.lock();
       callback(); // Our fake Lock is synchronous - this value has been successfully set
 
@@ -88,7 +87,6 @@ lock
   .getService(Service.LockMechanism)!
   .getCharacteristic(Characteristic.LockCurrentState)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-
     // this event is emitted when you ask Siri directly whether your lock is locked or not. you might query
     // the lock hardware itself to find this out, then call the callback. But if you take longer than a
     // few seconds to respond, Siri will give up.
@@ -98,8 +96,7 @@ lock
     if (FAKE_LOCK.locked) {
       console.log("Are we locked? Yes.");
       callback(err, Characteristic.LockCurrentState.SECURED);
-    }
-    else {
+    } else {
       console.log("Are we locked? No.");
       callback(err, Characteristic.LockCurrentState.UNSECURED);
     }

--- a/src/accessories/MotionSensor_accessory.ts
+++ b/src/accessories/MotionSensor_accessory.ts
@@ -8,8 +8,9 @@ import {
   CharacteristicValue,
   NodeCallback,
   Service,
-  uuid, VoidCallback
-} from '..';
+  uuid,
+  VoidCallback,
+} from "..";
 
 var MOTION_SENSOR = {
   motionDetected: false,
@@ -20,16 +21,16 @@ var MOTION_SENSOR = {
   },
   identify: () => {
     console.log("Identify the motion sensor!");
-  }
-}
+  },
+};
 
 // Generate a consistent UUID for our Motion Sensor Accessory that will remain the same even when
 // restarting our server. We use the `uuid.generate` helper function to create a deterministic
 // UUID based on an arbitrary "namespace" and the word "motionsensor".
-var motionSensorUUID = uuid.generate('hap-nodejs:accessories:motionsensor');
+var motionSensorUUID = uuid.generate("hap-nodejs:accessories:motionsensor");
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake motionSensor.
-var motionSensor = exports.accessory = new Accessory('Motion Sensor', motionSensorUUID);
+var motionSensor = (exports.accessory = new Accessory("Motion Sensor", motionSensorUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -56,6 +57,6 @@ motionSensor
   .addService(Service.MotionSensor, "Fake Motion Sensor") // services exposed to the user should have "names" like "Fake Motion Sensor" for us
   .getCharacteristic(Characteristic.MotionDetected)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-     MOTION_SENSOR.getStatus();
-     callback(null, Boolean(MOTION_SENSOR.motionDetected));
-});
+    MOTION_SENSOR.getStatus();
+    callback(null, Boolean(MOTION_SENSOR.motionDetected));
+  });

--- a/src/accessories/Outlet_accessory.ts
+++ b/src/accessories/Outlet_accessory.ts
@@ -3,43 +3,49 @@ import {
   AccessoryEventTypes,
   Categories,
   Characteristic,
-  CharacteristicEventTypes, CharacteristicSetCallback,
-  CharacteristicValue, NodeCallback,
+  CharacteristicEventTypes,
+  CharacteristicSetCallback,
+  CharacteristicValue,
+  NodeCallback,
   Service,
   uuid,
-  VoidCallback
-} from '..';
-import { Nullable } from '../types';
+  VoidCallback,
+} from "..";
+import { Nullable } from "../types";
 
 let err: Nullable<Error> = null; // in case there were any problems
 
 // here's a fake hardware device that we'll expose to HomeKit
 var FAKE_OUTLET = {
   powerOn: false,
-    setPowerOn: (on: CharacteristicValue) => {
+  setPowerOn: (on: CharacteristicValue) => {
     console.log("Turning the outlet %s!...", on ? "on" : "off");
     if (on) {
-          FAKE_OUTLET.powerOn = true;
-          if(err) { return console.log(err); }
-          console.log("...outlet is now on.");
+      FAKE_OUTLET.powerOn = true;
+      if (err) {
+        return console.log(err);
+      }
+      console.log("...outlet is now on.");
     } else {
-          FAKE_OUTLET.powerOn = false;
-          if(err) { return console.log(err); }
-          console.log("...outlet is now off.");
+      FAKE_OUTLET.powerOn = false;
+      if (err) {
+        return console.log(err);
+      }
+      console.log("...outlet is now off.");
     }
   },
-    identify: function() {
+  identify: function() {
     console.log("Identify the outlet.");
-    }
-}
+  },
+};
 
 // Generate a consistent UUID for our outlet Accessory that will remain the same even when
 // restarting our server. We use the `uuid.generate` helper function to create a deterministic
 // UUID based on an arbitrary "namespace" and the accessory name.
-var outletUUID = uuid.generate('hap-nodejs:accessories:Outlet');
+var outletUUID = uuid.generate("hap-nodejs:accessories:Outlet");
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake light.
-var outlet = exports.accessory = new Accessory('Outlet', outletUUID);
+var outlet = (exports.accessory = new Accessory("Outlet", outletUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -78,7 +84,6 @@ outlet
   .getService(Service.Outlet)!
   .getCharacteristic(Characteristic.On)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-
     // this event is emitted when you ask Siri directly whether your light is on or not. you might query
     // the light hardware itself to find this out, then call the callback. But if you take longer than a
     // few seconds to respond, Siri will give up.
@@ -88,8 +93,7 @@ outlet
     if (FAKE_OUTLET.powerOn) {
       console.log("Are we on? Yes.");
       callback(err, true);
-    }
-    else {
+    } else {
       console.log("Are we on? No.");
       callback(err, false);
     }

--- a/src/accessories/Sprinkler_accessory.ts
+++ b/src/accessories/Sprinkler_accessory.ts
@@ -8,8 +8,8 @@ import {
   CharacteristicValue,
   NodeCallback,
   Service,
-  uuid
-} from '..';
+  uuid,
+} from "..";
 
 var SPRINKLER: any = {
   active: false,
@@ -24,17 +24,16 @@ var SPRINKLER: any = {
   },
   identify: () => {
     console.log("Identify the sprinkler!");
-  }
-}
-
+  },
+};
 
 // Generate a consistent UUID for our Motion Sensor Accessory that will remain the same even when
 // restarting our server. We use the `uuid.generate` helper function to create a deterministic
 // UUID based on an arbitrary "namespace" and the word "motionsensor".
-var sprinklerUUID = uuid.generate('hap-nodejs:accessories:sprinkler');
+var sprinklerUUID = uuid.generate("hap-nodejs:accessories:sprinkler");
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake motionSensor.
-var sprinkler = exports.accessory = new Accessory('💦 Sprinkler', sprinklerUUID);
+var sprinkler = (exports.accessory = new Accessory("💦 Sprinkler", sprinklerUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -46,33 +45,28 @@ sprinkler.category = Categories.SPRINKLER;
 
 // Add the actual Valve Service and listen for change events from iOS.
 // We can see the complete list of Services and Characteristics in `lib/gen/HomeKit.ts`
-var sprinklerService = sprinkler.addService(Service.Valve, "💦 Sprinkler")
-
+var sprinklerService = sprinkler.addService(Service.Valve, "💦 Sprinkler");
 
 // set some basic properties (these values are arbitrary and setting them is optional)
 sprinkler
   .getService(Service.Valve)!
   .setCharacteristic(Characteristic.ValveType, "1") // IRRIGATION/SPRINKLER = 1; SHOWER_HEAD = 2; WATER_FAUCET = 3;
-  .setCharacteristic(Characteristic.Name, SPRINKLER.name)
-  ;
+  .setCharacteristic(Characteristic.Name, SPRINKLER.name);
 
 sprinkler
   .getService(Service.Valve)!
   .getCharacteristic(Characteristic.Active)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-
     console.log("get Active");
     var err = null; // in case there were any problems
 
     if (SPRINKLER.active) {
       callback(err, true);
-    }
-    else {
+    } else {
       callback(err, false);
     }
   })
   .on(CharacteristicEventTypes.SET, (newValue: CharacteristicValue, callback: CharacteristicSetCallback) => {
-
     console.log("set Active => setNewValue: " + newValue);
 
     if (SPRINKLER.active) {
@@ -83,17 +77,11 @@ sprinkler
         SPRINKLER.timerEnd = SPRINKLER.defaultDuration + Math.floor(new Date().getTime() / 1000);
         callback(null);
 
-        sprinkler
-        .getService(Service.Valve)!
-        .setCharacteristic(Characteristic.SetDuration, 0);
+        sprinkler.getService(Service.Valve)!.setCharacteristic(Characteristic.SetDuration, 0);
 
-        sprinkler
-        .getService(Service.Valve)!
-        .setCharacteristic(Characteristic.InUse, 0);
-
+        sprinkler.getService(Service.Valve)!.setCharacteristic(Characteristic.InUse, 0);
       }, 1000);
-    }
-    else {
+    } else {
       SPRINKLER.active = true;
       openVentile();
       setTimeout(function() {
@@ -101,22 +89,16 @@ sprinkler
         SPRINKLER.timerEnd = SPRINKLER.defaultDuration + Math.floor(new Date().getTime() / 1000);
         callback(null, SPRINKLER.defaultDuration);
 
-        sprinkler
-        .getService(Service.Valve)!
-        .setCharacteristic(Characteristic.InUse, 1);
+        sprinkler.getService(Service.Valve)!.setCharacteristic(Characteristic.InUse, 1);
 
         sprinkler
-        .getService(Service.Valve)!
-        .setCharacteristic(Characteristic.RemainingDuration, SPRINKLER.defaultDuration);
+          .getService(Service.Valve)!
+          .setCharacteristic(Characteristic.RemainingDuration, SPRINKLER.defaultDuration);
 
-        sprinkler
-        .getService(Service.Valve)!
-        .setCharacteristic(Characteristic.SetDuration, SPRINKLER.defaultDuration);
-
+        sprinkler.getService(Service.Valve)!.setCharacteristic(Characteristic.SetDuration, SPRINKLER.defaultDuration);
       }, 1000);
     }
   });
-
 
 sprinkler
   .getService(Service.Valve)!
@@ -127,8 +109,7 @@ sprinkler
 
     if (SPRINKLER.active) {
       callback(err, true);
-    }
-    else {
+    } else {
       callback(err, false);
     }
   })
@@ -136,27 +117,22 @@ sprinkler
     console.log("set In_Use => NewValue: " + newValue);
   });
 
-
-  sprinkler
+sprinkler
   .getService(Service.Valve)!
   .getCharacteristic(Characteristic.RemainingDuration)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-
     var err = null; // in case there were any problems
 
     if (SPRINKLER.active) {
-
       var duration = SPRINKLER.timerEnd - Math.floor(new Date().getTime() / 1000);
-      console.log("RemainingDuration: " + duration)
+      console.log("RemainingDuration: " + duration);
       callback(err, duration);
-    }
-    else {
+    } else {
       callback(err, 0);
     }
   });
 
-
-  sprinkler
+sprinkler
   .getService(Service.Valve)!
   .getCharacteristic(Characteristic.SetDuration)!
   .on(CharacteristicEventTypes.SET, (newValue: CharacteristicValue, callback: CharacteristicSetCallback) => {
@@ -167,12 +143,11 @@ sprinkler
     callback();
   });
 
+// Sprinkler Controll
+function openVentile() {
+  // Add your code here
+}
 
-  // Sprinkler Controll
-  function openVentile() {
-    // Add your code here
-  }
-
-  function closeVentile() {
-    // Add your code here
-  }
+function closeVentile() {
+  // Add your code here
+}

--- a/src/accessories/TV_accessory.ts
+++ b/src/accessories/TV_accessory.ts
@@ -6,16 +6,16 @@ import {
   CharacteristicSetCallback,
   CharacteristicValue,
   Service,
-  uuid
-} from '..';
+  uuid,
+} from "..";
 
 // Generate a consistent UUID for TV that will remain the same even when
 // restarting our server. We use the `uuid.generate` helper function to create a deterministic
 // UUID based on an arbitrary "namespace" and the word "tv".
-var tvUUID = uuid.generate('hap-nodejs:accessories:tv');
+var tvUUID = uuid.generate("hap-nodejs:accessories:tv");
 
 // This is the Accessory that we'll return to HAP-NodeJS.
-var tv = exports.accessory = new Accessory('TV', tvUUID);
+var tv = (exports.accessory = new Accessory("TV", tvUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -29,14 +29,12 @@ tv.category = Categories.TELEVISION;
 // We can see the complete list of Services and Characteristics in `lib/gen/HomeKit.ts`
 var televisionService = tv.addService(Service.Television, "Television", "Television");
 
-televisionService
-  .setCharacteristic(Characteristic.ConfiguredName, "Television");
+televisionService.setCharacteristic(Characteristic.ConfiguredName, "Television");
 
-televisionService
-  .setCharacteristic(
-    Characteristic.SleepDiscoveryMode,
-    Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE
-  );
+televisionService.setCharacteristic(
+  Characteristic.SleepDiscoveryMode,
+  Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE
+);
 
 televisionService
   .getCharacteristic(Characteristic.Active)!
@@ -45,8 +43,7 @@ televisionService
     callback(null);
   });
 
-televisionService
-  .setCharacteristic(Characteristic.ActiveIdentifier, 1);
+televisionService.setCharacteristic(Characteristic.ActiveIdentifier, 1);
 
 televisionService
   .getCharacteristic(Characteristic.ActiveIdentifier)!
@@ -78,13 +75,14 @@ televisionService
 
 // Speaker
 
-var speakerService = tv.addService(Service.TelevisionSpeaker)
+var speakerService = tv.addService(Service.TelevisionSpeaker);
 
 speakerService
   .setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
   .setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
 
-speakerService.getCharacteristic(Characteristic.VolumeSelector)!
+speakerService
+  .getCharacteristic(Characteristic.VolumeSelector)!
   .on(CharacteristicEventTypes.SET, (newValue: CharacteristicValue, callback: CharacteristicSetCallback) => {
     console.log("set VolumeSelector => setNewValue: " + newValue);
     callback(null);

--- a/src/accessories/TemperatureSensor_accessory.ts
+++ b/src/accessories/TemperatureSensor_accessory.ts
@@ -1,5 +1,14 @@
 // here's a fake temperature sensor device that we'll expose to HomeKit
-import { Accessory, Categories, Characteristic, CharacteristicEventTypes, CharacteristicValue, NodeCallback, Service, uuid } from '..';
+import {
+  Accessory,
+  Categories,
+  Characteristic,
+  CharacteristicEventTypes,
+  CharacteristicValue,
+  NodeCallback,
+  Service,
+  uuid,
+} from "..";
 
 var FAKE_SENSOR = {
   currentTemperature: 50,
@@ -10,17 +19,16 @@ var FAKE_SENSOR = {
   randomizeTemperature: function() {
     // randomize temperature to a value between 0 and 100
     FAKE_SENSOR.currentTemperature = Math.round(Math.random() * 100);
-  }
-}
-
+  },
+};
 
 // Generate a consistent UUID for our Temperature Sensor Accessory that will remain the same
 // even when restarting our server. We use the `uuid.generate` helper function to create
 // a deterministic UUID based on an arbitrary "namespace" and the string "temperature-sensor".
-var sensorUUID = uuid.generate('hap-nodejs:accessories:temperature-sensor');
+var sensorUUID = uuid.generate("hap-nodejs:accessories:temperature-sensor");
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake lock.
-var sensor = exports.accessory = new Accessory('Temperature Sensor', sensorUUID);
+var sensor = (exports.accessory = new Accessory("Temperature Sensor", sensorUUID));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
@@ -36,19 +44,16 @@ sensor
   .addService(Service.TemperatureSensor)!
   .getCharacteristic(Characteristic.CurrentTemperature)!
   .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-
     // return our current value
     callback(null, FAKE_SENSOR.getTemperature());
   });
 
 // randomize our temperature reading every 3 seconds
 setInterval(function() {
-
   FAKE_SENSOR.randomizeTemperature();
 
   // update the characteristic value so interested iOS devices can get notified
   sensor
     .getService(Service.TemperatureSensor)!
     .setCharacteristic(Characteristic.CurrentTemperature, FAKE_SENSOR.currentTemperature);
-
 }, 3000);

--- a/src/accessories/Thermostat_accessory.ts
+++ b/src/accessories/Thermostat_accessory.ts
@@ -1,148 +1,182 @@
 // HomeKit types required
 import * as types from "./types";
-import { Categories, CharacteristicValue } from '..';
+import { Categories, CharacteristicValue } from "..";
 
 const execute = (accessory: string, characteristic: string, value: CharacteristicValue) => {
-  console.log("executed accessory: " + accessory + ", and characteristic: " + characteristic + ", with value: " +  value + ".");
-}
+  console.log(
+    "executed accessory: " + accessory + ", and characteristic: " + characteristic + ", with value: " + value + "."
+  );
+};
 
 export const accessory = {
   displayName: "Thermostat 1",
   username: "CA:3E:BC:4D:5E:FF",
   pincode: "031-45-154",
   category: Categories.THERMOSTAT,
-  services: [{
-    sType: types.ACCESSORY_INFORMATION_STYPE,
-    characteristics: [{
-      cType: types.NAME_CTYPE,
-      onUpdate: null,
-      perms: ["pr"],
-      format: "string",
-      initialValue: "Thermostat 1",
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Bla",
-      designedMaxLength: 255
-    },{
-      cType: types.MANUFACTURER_CTYPE,
-      onUpdate: null,
-      perms: ["pr"],
-      format: "string",
-      initialValue: "Oltica",
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Bla",
-      designedMaxLength: 255
-    },{
-      cType: types.MODEL_CTYPE,
-      onUpdate: null,
-      perms: ["pr"],
-      format: "string",
-      initialValue: "Rev-1",
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Bla",
-      designedMaxLength: 255
-    },{
-      cType: types.SERIAL_NUMBER_CTYPE,
-      onUpdate: null,
-      perms: ["pr"],
-      format: "string",
-      initialValue: "A1S2NASF88EW",
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Bla",
-      designedMaxLength: 255
-    },{
-       cType: types.FIRMWARE_REVISION_CTYPE,
-       onUpdate: null,
-       perms: ["pr"],
-       format: "string",
-       initialValue: "1.0.0",
-       supportEvents: false,
-       supportBonjour: false,
-       manfDescription: "Bla",
-       designedMaxLength: 255
-   },{
-      cType: types.IDENTIFY_CTYPE,
-      onUpdate: null,
-      perms: ["pw"],
-      format: "bool",
-      initialValue: false,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Identify Accessory",
-      designedMaxLength: 1
-    }]
-  },{
-    sType: types.THERMOSTAT_STYPE,
-    characteristics: [{
-      cType: types.NAME_CTYPE,
-      onUpdate: null,
-      perms: ["pr"],
-      format: "string",
-      initialValue: "Thermostat Control",
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Bla",
-      designedMaxLength: 255
-    },{
-      cType: types.CURRENTHEATINGCOOLING_CTYPE,
-      onUpdate: (value: CharacteristicValue) => { console.log("Change:",value); execute("Thermostat", "Current HC", value); },
-      perms: ["pr","ev"],
-      format: "uint8",
-      initialValue: 0,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Current Mode",
-      designedMaxLength: 1,
-      designedMinValue: 0,
-      designedMaxValue: 2,
-      designedMinStep: 1,
-    },{
-      cType: types.TARGETHEATINGCOOLING_CTYPE,
-      onUpdate: (value: CharacteristicValue) => { console.log("Change:",value); execute("Thermostat", "Target HC", value); },
-      perms: ["pw","pr","ev"],
-      format: "uint8",
-      initialValue: 0,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Target Mode",
-      designedMinValue: 0,
-      designedMaxValue: 3,
-      designedMinStep: 1,
-    },{
-      cType: types.CURRENT_TEMPERATURE_CTYPE,
-      onUpdate: (value: CharacteristicValue) => { console.log("Change:",value); execute("Thermostat", "Current Temperature", value); },
-      perms: ["pr","ev"],
-      format: "float",
-      initialValue: 20,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Current Temperature",
-      unit: "celsius"
-    },{
-      cType: types.TARGET_TEMPERATURE_CTYPE,
-      onUpdate: (value: CharacteristicValue) => { console.log("Change:",value); execute("Thermostat", "Target Temperature", value); },
-      perms: ["pw","pr","ev"],
-      format: "float",
-      initialValue: 20,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Target Temperature",
-      designedMinValue: 16,
-      designedMaxValue: 38,
-      designedMinStep: 1,
-      unit: "celsius"
-    },{
-      cType: types.TEMPERATURE_UNITS_CTYPE,
-      onUpdate: (value: CharacteristicValue) => { console.log("Change:",value); execute("Thermostat", "Unit", value); },
-      perms: ["pw","pr","ev"],
-      format: "uint8",
-      initialValue: 0,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Unit"
-    }]
-  }]
-}
+  services: [
+    {
+      sType: types.ACCESSORY_INFORMATION_STYPE,
+      characteristics: [
+        {
+          cType: types.NAME_CTYPE,
+          onUpdate: null,
+          perms: ["pr"],
+          format: "string",
+          initialValue: "Thermostat 1",
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Bla",
+          designedMaxLength: 255,
+        },
+        {
+          cType: types.MANUFACTURER_CTYPE,
+          onUpdate: null,
+          perms: ["pr"],
+          format: "string",
+          initialValue: "Oltica",
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Bla",
+          designedMaxLength: 255,
+        },
+        {
+          cType: types.MODEL_CTYPE,
+          onUpdate: null,
+          perms: ["pr"],
+          format: "string",
+          initialValue: "Rev-1",
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Bla",
+          designedMaxLength: 255,
+        },
+        {
+          cType: types.SERIAL_NUMBER_CTYPE,
+          onUpdate: null,
+          perms: ["pr"],
+          format: "string",
+          initialValue: "A1S2NASF88EW",
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Bla",
+          designedMaxLength: 255,
+        },
+        {
+          cType: types.FIRMWARE_REVISION_CTYPE,
+          onUpdate: null,
+          perms: ["pr"],
+          format: "string",
+          initialValue: "1.0.0",
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Bla",
+          designedMaxLength: 255,
+        },
+        {
+          cType: types.IDENTIFY_CTYPE,
+          onUpdate: null,
+          perms: ["pw"],
+          format: "bool",
+          initialValue: false,
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Identify Accessory",
+          designedMaxLength: 1,
+        },
+      ],
+    },
+    {
+      sType: types.THERMOSTAT_STYPE,
+      characteristics: [
+        {
+          cType: types.NAME_CTYPE,
+          onUpdate: null,
+          perms: ["pr"],
+          format: "string",
+          initialValue: "Thermostat Control",
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Bla",
+          designedMaxLength: 255,
+        },
+        {
+          cType: types.CURRENTHEATINGCOOLING_CTYPE,
+          onUpdate: (value: CharacteristicValue) => {
+            console.log("Change:", value);
+            execute("Thermostat", "Current HC", value);
+          },
+          perms: ["pr", "ev"],
+          format: "uint8",
+          initialValue: 0,
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Current Mode",
+          designedMaxLength: 1,
+          designedMinValue: 0,
+          designedMaxValue: 2,
+          designedMinStep: 1,
+        },
+        {
+          cType: types.TARGETHEATINGCOOLING_CTYPE,
+          onUpdate: (value: CharacteristicValue) => {
+            console.log("Change:", value);
+            execute("Thermostat", "Target HC", value);
+          },
+          perms: ["pw", "pr", "ev"],
+          format: "uint8",
+          initialValue: 0,
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Target Mode",
+          designedMinValue: 0,
+          designedMaxValue: 3,
+          designedMinStep: 1,
+        },
+        {
+          cType: types.CURRENT_TEMPERATURE_CTYPE,
+          onUpdate: (value: CharacteristicValue) => {
+            console.log("Change:", value);
+            execute("Thermostat", "Current Temperature", value);
+          },
+          perms: ["pr", "ev"],
+          format: "float",
+          initialValue: 20,
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Current Temperature",
+          unit: "celsius",
+        },
+        {
+          cType: types.TARGET_TEMPERATURE_CTYPE,
+          onUpdate: (value: CharacteristicValue) => {
+            console.log("Change:", value);
+            execute("Thermostat", "Target Temperature", value);
+          },
+          perms: ["pw", "pr", "ev"],
+          format: "float",
+          initialValue: 20,
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Target Temperature",
+          designedMinValue: 16,
+          designedMaxValue: 38,
+          designedMinStep: 1,
+          unit: "celsius",
+        },
+        {
+          cType: types.TEMPERATURE_UNITS_CTYPE,
+          onUpdate: (value: CharacteristicValue) => {
+            console.log("Change:", value);
+            execute("Thermostat", "Unit", value);
+          },
+          perms: ["pw", "pr", "ev"],
+          format: "uint8",
+          initialValue: 0,
+          supportEvents: false,
+          supportBonjour: false,
+          manfDescription: "Unit",
+        },
+      ],
+    },
+  ],
+};

--- a/src/accessories/Wi-FiRouter_accessory.ts
+++ b/src/accessories/Wi-FiRouter_accessory.ts
@@ -1,20 +1,12 @@
-import {
-  Accessory,
-  AccessoryEventTypes,
-  Categories,
-  Characteristic,
-  Service,
-  uuid,
-  VoidCallback,
-} from '..';
+import { Accessory, AccessoryEventTypes, Categories, Characteristic, Service, uuid, VoidCallback } from "..";
 
-const UUID = uuid.generate('hap-nodejs:accessories:wifi-router');
-export const accessory = new Accessory('Wi-Fi Router', UUID);
+const UUID = uuid.generate("hap-nodejs:accessories:wifi-router");
+export const accessory = new Accessory("Wi-Fi Router", UUID);
 
 // @ts-ignore
-accessory.username = 'FA:3C:ED:D2:1A:A2';
+accessory.username = "FA:3C:ED:D2:1A:A2";
 // @ts-ignore
-accessory.pincode = '031-45-154';
+accessory.pincode = "031-45-154";
 // @ts-ignore
 accessory.category = Categories.ROUTER;
 

--- a/src/accessories/Wi-FiSatellite_accessory.ts
+++ b/src/accessories/Wi-FiSatellite_accessory.ts
@@ -1,20 +1,12 @@
-import {
-  Accessory,
-  AccessoryEventTypes,
-  Categories,
-  Characteristic,
-  Service,
-  uuid,
-  VoidCallback,
-} from '..';
+import { Accessory, AccessoryEventTypes, Categories, Characteristic, Service, uuid, VoidCallback } from "..";
 
-const UUID = uuid.generate('hap-nodejs:accessories:wifi-satellite');
-export const accessory = new Accessory('Wi-Fi Satellite', UUID);
+const UUID = uuid.generate("hap-nodejs:accessories:wifi-satellite");
+export const accessory = new Accessory("Wi-Fi Satellite", UUID);
 
 // @ts-ignore
-accessory.username = 'FA:3C:ED:5A:1A:A2';
+accessory.username = "FA:3C:ED:5A:1A:A2";
 // @ts-ignore
-accessory.pincode = '031-45-154';
+accessory.pincode = "031-45-154";
 // @ts-ignore
 accessory.category = Categories.ROUTER;
 
@@ -25,5 +17,6 @@ accessory.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallb
 
 const satellite = accessory.addService(Service.WiFiSatellite);
 
-satellite.getCharacteristic(Characteristic.WiFiSatelliteStatus)!
+satellite
+  .getCharacteristic(Characteristic.WiFiSatelliteStatus)!
   .updateValue(Characteristic.WiFiSatelliteStatus.CONNECTED);

--- a/src/accessories/types.ts
+++ b/src/accessories/types.ts
@@ -3,7 +3,6 @@
 const stPre = "000000";
 const stPost = "-0000-1000-8000-0026BB765291";
 
-
 //HomeKitTransportCategoryTypes
 export const OTHER_TCTYPE = 1;
 export const FAN_TCTYPE = 3;
@@ -40,7 +39,6 @@ export const HUMIDITY_SENSOR_STYPE = stPre + "82" + stPost;
 export const TEMPERATURE_SENSOR_STYPE = stPre + "8A" + stPost;
 
 //HomeKitCharacteristicsTypes
-
 
 export const ALARM_CURRENT_STATE_CTYPE = stPre + "66" + stPost;
 export const ALARM_TARGET_STATE_CTYPE = stPre + "67" + stPost;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,39 +1,37 @@
-import storage from 'node-persist';
+import storage from "node-persist";
 
-import './lib/gen';
-import * as accessoryLoader from './lib/AccessoryLoader';
-import * as uuidFunctions from './lib/util/uuid';
-import * as legacyTypes from './accessories/types';
+import "./lib/gen";
+import * as accessoryLoader from "./lib/AccessoryLoader";
+import * as uuidFunctions from "./lib/util/uuid";
+import * as legacyTypes from "./accessories/types";
 
 export const AccessoryLoader = accessoryLoader;
 export const uuid = uuidFunctions;
 
-export * from './lib/Accessory';
-export * from './lib/Bridge';
-export * from './lib/Camera';
-export * from './lib/Service';
-export * from './lib/Characteristic';
-export * from './lib/AccessoryLoader';
-export * from './lib/StreamController';
-export * from './lib/HAPServer';
-export * from './lib/gen';
-export * from './lib/datastream';
-export * from './lib/HomeKitRemoteController';
+export * from "./lib/Accessory";
+export * from "./lib/Bridge";
+export * from "./lib/Camera";
+export * from "./lib/Service";
+export * from "./lib/Characteristic";
+export * from "./lib/AccessoryLoader";
+export * from "./lib/StreamController";
+export * from "./lib/HAPServer";
+export * from "./lib/gen";
+export * from "./lib/datastream";
+export * from "./lib/HomeKitRemoteController";
 
-export * from './lib/util/chacha20poly1305';
-export * from './lib/util/clone';
-export * from './lib/util/encryption';
-export * from './lib/util/hkdf';
-export * from './lib/util/once';
-export * from './lib/util/tlv';
+export * from "./lib/util/chacha20poly1305";
+export * from "./lib/util/clone";
+export * from "./lib/util/encryption";
+export * from "./lib/util/hkdf";
+export * from "./lib/util/once";
+export * from "./lib/util/tlv";
 
-export * from './types';
+export * from "./types";
 export const LegacyTypes = legacyTypes;
 
 export function init(storagePath?: string) {
   // initialize our underlying storage system, passing on the directory if needed
-  if (typeof storagePath !== 'undefined')
-    storage.initSync({ dir: storagePath });
-  else
-    storage.initSync(); // use whatever is default
+  if (typeof storagePath !== "undefined") storage.initSync({ dir: storagePath });
+  else storage.initSync(); // use whatever is default
 }

--- a/src/lib/Accessory.spec.ts
+++ b/src/lib/Accessory.spec.ts
@@ -1,46 +1,45 @@
-import { Accessory, Categories } from './Accessory';
-import { Service } from './Service';
-import { Characteristic, CharacteristicEventTypes } from './Characteristic';
-import { generate } from './util/uuid';
-import './gen';
+import { Accessory, Categories } from "./Accessory";
+import { Service } from "./Service";
+import { Characteristic, CharacteristicEventTypes } from "./Characteristic";
+import { generate } from "./util/uuid";
+import "./gen";
 
-describe('Accessory', () => {
-
-  describe('#constructor()', () => {
-
-    it('should identify itself with a valid UUID', () => {
-      const accessory = new Accessory('Test', generate('Foo'));
+describe("Accessory", () => {
+  describe("#constructor()", () => {
+    it("should identify itself with a valid UUID", () => {
+      const accessory = new Accessory("Test", generate("Foo"));
 
       const VALUE = true;
 
-      accessory.getService(Service.AccessoryInformation)!
+      accessory
+        .getService(Service.AccessoryInformation)!
         .getCharacteristic(Characteristic.Identify)!
         .on(CharacteristicEventTypes.SET, (value: any, callback: any) => {
           expect(value).toEqual(VALUE);
         });
     });
 
-    it('should fail to load with no display name', () => {
+    it("should fail to load with no display name", () => {
       expect(() => {
-        new Accessory('', '');
-      }).toThrow('non-empty displayName');
+        new Accessory("", "");
+      }).toThrow("non-empty displayName");
     });
 
-    it('should fail to load with no UUID', () => {
+    it("should fail to load with no UUID", () => {
       expect(() => {
-        new Accessory('Test', '');
-      }).toThrow('valid UUID');
+        new Accessory("Test", "");
+      }).toThrow("valid UUID");
     });
 
-    it('should fail to load with an invalid UUID', () => {
+    it("should fail to load with an invalid UUID", () => {
       expect(() => {
-        new Accessory('Test', 'test');
-      }).toThrow('not a valid UUID');
+        new Accessory("Test", "test");
+      }).toThrow("not a valid UUID");
     });
   });
 
-  describe('#serialize', () => {
-    it('should serialize accessory', () => {
+  describe("#serialize", () => {
+    it("should serialize accessory", () => {
       const accessory = new Accessory("TestAccessory", generate("foo"));
       accessory.category = Categories.LIGHTBULB;
 
@@ -64,9 +63,10 @@ describe('Accessory', () => {
     });
   });
 
-  describe('#deserialize', () => {
-    it('should deserialize legacy json from homebridge', () => {
-      const json = JSON.parse('{"plugin":"homebridge-samplePlatform","platform":"SamplePlatform",' +
+  describe("#deserialize", () => {
+    it("should deserialize legacy json from homebridge", () => {
+      const json = JSON.parse(
+        '{"plugin":"homebridge-samplePlatform","platform":"SamplePlatform",' +
           '"displayName":"2020-01-17T18:45:41.049Z","UUID":"dc3951d8-662e-46f7-b6fe-d1b5b5e1a995","category":1,' +
           '"context":{},"linkedServices":{"0000003E-0000-1000-8000-0026BB765291":[],"00000043-0000-1000-8000-0026BB765291":[]},' +
           '"services":[{"UUID":"0000003E-0000-1000-8000-0026BB765291","characteristics":[' +
@@ -91,7 +91,8 @@ describe('Accessory', () => {
           '"props":{"format":"string","unit":null,"minValue":null,"maxValue":null,"minStep":null,"perms":["pr"]},' +
           '"value":"Test Light","eventOnlyCharacteristic":false},{"displayName":"On",' +
           '"UUID":"00000025-0000-1000-8000-0026BB765291","props":{"format":"bool","unit":null,"minValue":null,' +
-          '"maxValue":null,"minStep":null,"perms":["pr","pw","ev"]},"value":false,"eventOnlyCharacteristic":false}]}]}');
+          '"maxValue":null,"minStep":null,"perms":["pr","pw","ev"]},"value":false,"eventOnlyCharacteristic":false}]}]}'
+      );
 
       const accessory = Accessory.deserialize(json);
 
@@ -103,9 +104,10 @@ describe('Accessory', () => {
       expect(accessory.services.length).toEqual(2);
     });
 
-    it('should deserialize complete json', () => {
+    it("should deserialize complete json", () => {
       // json for a light accessory
-      const json = JSON.parse('{"displayName":"TestAccessory","UUID":"0beec7b5-ea3f-40fd-bc95-d0dd47f3c5bc",' +
+      const json = JSON.parse(
+        '{"displayName":"TestAccessory","UUID":"0beec7b5-ea3f-40fd-bc95-d0dd47f3c5bc",' +
           '"category":5,"services":[{"UUID":"0000003E-0000-1000-8000-0026BB765291","hiddenService":false,' +
           '"primaryService":false,"characteristics":[{"displayName":"Identify","UUID":"00000014-0000-1000-8000-0026BB765291",' +
           '"props":{"format":"bool","unit":null,"minValue":null,"maxValue":null,"minStep":null,"perms":["pw"]},' +
@@ -166,7 +168,8 @@ describe('Accessory', () => {
           '"optionalCharacteristics":[{"displayName":"Name","UUID":"00000023-0000-1000-8000-0026BB765291",' +
           '"props":{"format":"string","unit":null,"minValue":null,"maxValue":null,"minStep":null,"perms":["pr"]},' +
           '"value":"","accessRestrictedToAdmins":[],"eventOnlyCharacteristic":false}]}],' +
-          '"linkedServices":{"00000043-0000-1000-8000-0026BB765291subtype":["00000049-0000-1000-8000-0026BB765291subtype"]}}');
+          '"linkedServices":{"00000043-0000-1000-8000-0026BB765291subtype":["00000049-0000-1000-8000-0026BB765291subtype"]}}'
+      );
 
       const accessory = Accessory.deserialize(json);
 

--- a/src/lib/AccessoryLoader.ts
+++ b/src/lib/AccessoryLoader.ts
@@ -1,19 +1,20 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
-import createDebug from 'debug';
+import createDebug from "debug";
 
-import { Accessory } from './Accessory';
-import { Service } from './Service';
+import { Accessory } from "./Accessory";
+import { Service } from "./Service";
 import {
   Characteristic,
-  CharacteristicEventTypes, CharacteristicGetCallback,
-  CharacteristicSetCallback
-} from './Characteristic';
-import * as uuid from './util/uuid';
-import { CharacteristicValue, NodeCallback, Nullable } from '../types';
+  CharacteristicEventTypes,
+  CharacteristicGetCallback,
+  CharacteristicSetCallback,
+} from "./Characteristic";
+import * as uuid from "./util/uuid";
+import { CharacteristicValue, NodeCallback, Nullable } from "../types";
 
-const debug = createDebug('AccessoryLoader');
+const debug = createDebug("AccessoryLoader");
 
 /**
  * Loads all accessories from the given folder. Handles object-literal-style accessories, "accessory factories",
@@ -21,22 +22,21 @@ const debug = createDebug('AccessoryLoader');
  */
 
 export function loadDirectory(dir: string): Accessory[] {
-
   // exported accessory objects loaded from this dir
   var accessories: Accessory[] = [];
 
-  fs.readdirSync(dir).forEach((file) => {
-    const suffix = file.split('_').pop();
+  fs.readdirSync(dir).forEach(file => {
+    const suffix = file.split("_").pop();
 
     // "Accessories" are modules that export a single accessory.
-    if (suffix === 'accessory.js' || suffix === 'accessory.ts') {
-      debug('Parsing accessory: %s', file);
+    if (suffix === "accessory.js" || suffix === "accessory.ts") {
+      debug("Parsing accessory: %s", file);
       var loadedAccessory = require(path.join(dir, file)).accessory;
       accessories.push(loadedAccessory);
     }
     // "Accessory Factories" are modules that export an array of accessories.
-    else if (suffix === 'accfactory.js' ||suffix === 'accfactory.ts') {
-      debug('Parsing accessory factory: %s', file);
+    else if (suffix === "accfactory.js" || suffix === "accfactory.ts") {
+      debug("Parsing accessory factory: %s", file);
 
       // should return an array of objects { accessory: accessory-json }
       var loadedAccessories = require(path.join(dir, file));
@@ -46,14 +46,19 @@ export function loadDirectory(dir: string): Accessory[] {
 
   // now we need to coerce all accessory objects into instances of Accessory (some or all of them may
   // be object-literal JSON-style accessories)
-  return accessories.map((accessory) => {
-    if(accessory === null || accessory === undefined) { //check if accessory is not empty
-      console.log("Invalid accessory!");
-      return false;
-    } else {
-      return (accessory instanceof Accessory) ? accessory : parseAccessoryJSON(accessory);
-    }
-  }).filter((accessory: Accessory | false) => { return accessory ? true : false; }) as Accessory[];
+  return accessories
+    .map(accessory => {
+      if (accessory === null || accessory === undefined) {
+        //check if accessory is not empty
+        console.log("Invalid accessory!");
+        return false;
+      } else {
+        return accessory instanceof Accessory ? accessory : parseAccessoryJSON(accessory);
+      }
+    })
+    .filter((accessory: Accessory | false) => {
+      return accessory ? true : false;
+    }) as Accessory[];
 }
 
 /**
@@ -62,7 +67,6 @@ export function loadDirectory(dir: string): Accessory[] {
  */
 
 export function parseAccessoryJSON(json: any) {
-
   // parse services first so we can extract the accessory name
   var services: Service[] = [];
 
@@ -74,9 +78,11 @@ export function parseAccessoryJSON(json: any) {
   var displayName = json.displayName;
 
   services.forEach(function(service) {
-    if (service.UUID === '0000003E-0000-1000-8000-0026BB765291') { // Service.AccessoryInformation.UUID
+    if (service.UUID === "0000003E-0000-1000-8000-0026BB765291") {
+      // Service.AccessoryInformation.UUID
       service.characteristics.forEach(function(characteristic) {
-        if (characteristic.UUID === '00000023-0000-1000-8000-0026BB765291') {// Characteristic.Name.UUID
+        if (characteristic.UUID === "00000023-0000-1000-8000-0026BB765291") {
+          // Characteristic.Name.UUID
           displayName = characteristic.value;
         }
       });
@@ -117,7 +123,8 @@ export function parseServiceJSON(json: any) {
 
   // extract the "Name" characteristic to use for 'type' discrimination if necessary
   characteristics.forEach(function(characteristic) {
-    if (characteristic.UUID == '00000023-0000-1000-8000-0026BB765291') // Characteristic.Name.UUID
+    if (characteristic.UUID == "00000023-0000-1000-8000-0026BB765291")
+      // Characteristic.Name.UUID
       displayName = characteristic.value;
   });
 
@@ -125,7 +132,8 @@ export function parseServiceJSON(json: any) {
   var service = new Service(displayName || serviceUUID, serviceUUID, `${displayName}`);
 
   characteristics.forEach(function(characteristic) {
-    if (characteristic.UUID != '00000023-0000-1000-8000-0026BB765291') // Characteristic.Name.UUID, already present in all Services
+    if (characteristic.UUID != "00000023-0000-1000-8000-0026BB765291")
+      // Characteristic.Name.UUID, already present in all Services
       service.addCharacteristic(characteristic);
   });
 
@@ -145,7 +153,7 @@ export function parseCharacteristicJSON(json: any) {
     maxValue: json.designedMaxValue,
     minStep: json.designedMinStep,
     unit: json.unit,
-    perms: json.perms // example: ["pw","pr","ev"]
+    perms: json.perms, // example: ["pw","pr","ev"]
   });
 
   // monkey-patch this characteristic to add the legacy method `updateValue` which used to exist,
@@ -165,10 +173,13 @@ export function parseCharacteristicJSON(json: any) {
   var registerFunc = json.onRegister; // optional function
 
   if (updateFunc) {
-    characteristic.on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-      updateFunc(value);
-      callback && callback();
-    });
+    characteristic.on(
+      CharacteristicEventTypes.SET,
+      (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+        updateFunc(value);
+        callback && callback();
+      }
+    );
   }
 
   if (readFunc) {

--- a/src/lib/Advertiser.spec.ts
+++ b/src/lib/Advertiser.spec.ts
@@ -1,30 +1,30 @@
-import { Advertiser } from './Advertiser';
-import { AccessoryInfo } from './model/AccessoryInfo';
-import './gen';
+import { Advertiser } from "./Advertiser";
+import { AccessoryInfo } from "./model/AccessoryInfo";
+import "./gen";
 
 const createAdvertiser = () => {
-  return new Advertiser(AccessoryInfo.create('00:00:00:00:00:00'), {
+  return new Advertiser(AccessoryInfo.create("00:00:00:00:00:00"), {
     multicast: false,
-    interface: 'ipv6',
+    interface: "ipv6",
     port: 80,
-    ip: '1.1.1.1',
+    ip: "1.1.1.1",
     ttl: 30,
     loopback: true,
     reuseAddr: false,
   });
 };
 
-describe('Advertiser', () => {
-  describe('#constructor()', () => {
-    it('should create a setup hash', () => {
+describe("Advertiser", () => {
+  describe("#constructor()", () => {
+    it("should create a setup hash", () => {
       const advertiser = createAdvertiser();
 
       expect(advertiser._setupHash).toBeTruthy();
     });
   });
 
-  describe('#startAdvertising()', () => {
-    it('should start advertising if not currently doing so', () => {
+  describe("#startAdvertising()", () => {
+    it("should start advertising if not currently doing so", () => {
       const advertiser = createAdvertiser();
 
       expect(advertiser._advertisement).toBeNull();
@@ -33,7 +33,7 @@ describe('Advertiser', () => {
       expect(advertiser._advertisement).not.toBeNull();
     });
 
-    it('should stop advertising if already doing so', () => {
+    it("should stop advertising if already doing so", () => {
       const advertiser = createAdvertiser();
 
       expect(advertiser._advertisement).toBeNull();
@@ -45,21 +45,21 @@ describe('Advertiser', () => {
     });
   });
 
-  describe('#isAdvertising()', () => {
-    it('should be true if currently advertising', () => {
+  describe("#isAdvertising()", () => {
+    it("should be true if currently advertising", () => {
       const advertiser = createAdvertiser();
       advertiser.startAdvertising(80);
       expect(advertiser.isAdvertising()).toBeTruthy();
     });
 
-    it('should be false if not currently advertising', () => {
+    it("should be false if not currently advertising", () => {
       const advertiser = createAdvertiser();
       expect(advertiser.isAdvertising()).toBeFalsy();
     });
   });
 
-  describe('#updateAdvertisement()', () => {
-    it('should send an updated TXT record if currently advertising', () => {
+  describe("#updateAdvertisement()", () => {
+    it("should send an updated TXT record if currently advertising", () => {
       const advertiser = createAdvertiser();
 
       expect(advertiser.isAdvertising()).toBeFalsy();
@@ -71,8 +71,8 @@ describe('Advertiser', () => {
     });
   });
 
-  describe('#stopAdvertising()', () => {
-    it('should stop and destroy all services if currently advertising', () => {
+  describe("#stopAdvertising()", () => {
+    it("should stop and destroy all services if currently advertising", () => {
       const advertiser = createAdvertiser();
 
       expect(advertiser.isAdvertising()).toBeFalsy();
@@ -87,7 +87,7 @@ describe('Advertiser', () => {
       expect(advertiser._bonjourService.destroy).toHaveBeenCalledTimes(1);
     });
 
-    it('should destroy only Bonjour service  if not currently advertising', () => {
+    it("should destroy only Bonjour service  if not currently advertising", () => {
       const advertiser = createAdvertiser();
 
       advertiser.stopAdvertising();

--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -1,9 +1,9 @@
-import crypto from 'crypto';
+import crypto from "crypto";
 
-import bonjour, { BonjourHap, MulticastOptions, Service } from 'bonjour-hap';
+import bonjour, { BonjourHap, MulticastOptions, Service } from "bonjour-hap";
 
-import { Nullable } from '../types';
-import { AccessoryInfo } from './model/AccessoryInfo';
+import { Nullable } from "../types";
+import { AccessoryInfo } from "./model/AccessoryInfo";
 
 /**
  * Advertiser uses mdns to broadcast the presence of an Accessory to the local network.
@@ -14,7 +14,6 @@ import { AccessoryInfo } from './model/AccessoryInfo';
  * mdns payload).
  */
 export class Advertiser {
-
   static protocolVersion: string = "1.1";
   static protocolVersionService: string = "1.1.0";
 
@@ -29,7 +28,6 @@ export class Advertiser {
   }
 
   startAdvertising = (port: number) => {
-
     // stop advertising if necessary
     if (this._advertisement) {
       this.stopAdvertising();
@@ -41,10 +39,10 @@ export class Advertiser {
       id: this.accessoryInfo.username,
       "c#": this.accessoryInfo.configVersion + "", // "accessory conf" - represents the "configuration version" of an Accessory. Increasing this "version number" signals iOS devices to re-fetch /accessories data.
       "s#": "1", // "accessory state"
-      "ff": "0",
-      "ci": this.accessoryInfo.category as unknown as string,
-      "sf": this.accessoryInfo.paired() ? "0" : "1", // "sf == 1" means "discoverable by HomeKit iOS clients"
-      "sh": this._setupHash
+      ff: "0",
+      ci: (this.accessoryInfo.category as unknown) as string,
+      sf: this.accessoryInfo.paired() ? "0" : "1", // "sf == 1" means "discoverable by HomeKit iOS clients"
+      sh: this._setupHash,
     };
 
     /**
@@ -57,10 +55,16 @@ export class Advertiser {
      * probably the problem will also fix a possible problem
      * of having multiple pi's on same network
      */
-    var host = this.accessoryInfo.username.replace(/\:/ig, "_") + '.local';
-    var advertiseName = this.accessoryInfo.displayName
-      + " "
-      + crypto.createHash('sha512').update(this.accessoryInfo.username, 'utf8').digest('hex').slice(0, 4).toUpperCase();
+    var host = this.accessoryInfo.username.replace(/\:/gi, "_") + ".local";
+    var advertiseName =
+      this.accessoryInfo.displayName +
+      " " +
+      crypto
+        .createHash("sha512")
+        .update(this.accessoryInfo.username, "utf8")
+        .digest("hex")
+        .slice(0, 4)
+        .toUpperCase();
 
     // create/recreate our advertisement
     this._advertisement = this._bonjourService.publish({
@@ -68,32 +72,31 @@ export class Advertiser {
       type: "hap",
       port: port,
       txt: txtRecord,
-      host: host
+      host: host,
     });
-  }
+  };
 
   isAdvertising = () => {
-    return (this._advertisement != null);
-  }
+    return this._advertisement != null;
+  };
 
   updateAdvertisement = () => {
     if (this._advertisement) {
-
       var txtRecord = {
         md: this.accessoryInfo.displayName,
         pv: Advertiser.protocolVersion,
         id: this.accessoryInfo.username,
         "c#": this.accessoryInfo.configVersion + "", // "accessory conf" - represents the "configuration version" of an Accessory. Increasing this "version number" signals iOS devices to re-fetch /accessories data.
         "s#": "1", // "accessory state"
-        "ff": "0",
-        "ci": `${this.accessoryInfo.category}`,
-        "sf": this.accessoryInfo.paired() ? "0" : "1", // "sf == 1" means "discoverable by HomeKit iOS clients"
-        "sh": this._setupHash
+        ff: "0",
+        ci: `${this.accessoryInfo.category}`,
+        sf: this.accessoryInfo.paired() ? "0" : "1", // "sf == 1" means "discoverable by HomeKit iOS clients"
+        sh: this._setupHash,
       };
 
       this._advertisement.updateTxt(txtRecord);
     }
-  }
+  };
 
   stopAdvertising = () => {
     if (this._advertisement) {
@@ -103,15 +106,17 @@ export class Advertiser {
     }
 
     this._bonjourService.destroy();
-  }
+  };
 
   _computeSetupHash = () => {
     var setupHashMaterial = this.accessoryInfo.setupID + this.accessoryInfo.username;
-    var hash = crypto.createHash('sha512');
+    var hash = crypto.createHash("sha512");
     hash.update(setupHashMaterial);
-    var setupHash = hash.digest().slice(0, 4).toString('base64');
+    var setupHash = hash
+      .digest()
+      .slice(0, 4)
+      .toString("base64");
 
     return setupHash;
-  }
+  };
 }
-

--- a/src/lib/Bridge.ts
+++ b/src/lib/Bridge.ts
@@ -1,4 +1,4 @@
-import { Accessory } from './Accessory';
+import { Accessory } from "./Accessory";
 
 /**
  * Bridge is a special type of HomeKit Accessory that hosts other Accessories "behind" it. This way you
@@ -6,8 +6,8 @@ import { Accessory } from './Accessory';
  * will be hosted automatically, instead of needed to publish() every single Accessory as a separate server.
  */
 export class Bridge extends Accessory {
-    constructor(displayName: string, serialNumber: string) {
-        super(displayName, serialNumber);
-        this._isBridge = true;
-    }
+  constructor(displayName: string, serialNumber: string) {
+    super(displayName, serialNumber);
+    this._isBridge = true;
+  }
 }

--- a/src/lib/Camera.ts
+++ b/src/lib/Camera.ts
@@ -1,24 +1,25 @@
-import crypto from 'crypto';
-import fs from 'fs';
-import ip from 'ip';
-import { ChildProcess, spawn } from 'child_process';
+import crypto from "crypto";
+import fs from "fs";
+import ip from "ip";
+import { ChildProcess, spawn } from "child_process";
 
-import { Service } from './Service';
+import { Service } from "./Service";
 import {
   PreparedStreamRequestCallback,
   PreparedStreamResponse,
-  PrepareStreamRequest, StreamController,
+  PrepareStreamRequest,
+  StreamController,
   StreamControllerOptions,
   StreamRequest,
-  StreamRequestTypes
+  StreamRequestTypes,
 } from "./StreamController";
-import * as uuid from './util/uuid';
-import { Address, NodeCallback, SessionIdentifier } from '../types';
+import * as uuid from "./util/uuid";
+import { Address, NodeCallback, SessionIdentifier } from "../types";
 
 export type SnapshotRequest = {
   height: number;
   width: number;
-}
+};
 
 export type SessionInfo = {
   address: string;
@@ -28,7 +29,7 @@ export type SessionInfo = {
   video_port: number;
   video_srtp: Buffer;
   video_ssrc: number;
-}
+};
 
 export class Camera {
   services: Service[] = [];
@@ -37,7 +38,6 @@ export class Camera {
   ongoingSessions: Record<string, ChildProcess> = {};
 
   constructor() {
-
     const options: StreamControllerOptions = {
       proxy: false, // Requires RTP/RTCP MUX Proxy
       disable_audio_proxy: false, // If proxy = true, you can opt out audio proxy via this
@@ -58,23 +58,23 @@ export class Camera {
         ],
         codec: {
           profiles: [0, 1, 2], // Enum, please refer StreamController.VideoCodecParamProfileIDTypes
-          levels: [0, 1, 2] // Enum, please refer StreamController.VideoCodecParamLevelTypes
-        }
+          levels: [0, 1, 2], // Enum, please refer StreamController.VideoCodecParamLevelTypes
+        },
       },
       audio: {
         comfort_noise: false,
         codecs: [
           {
             type: "OPUS", // Audio Codec
-            samplerate: 24 // 8, 16, 24 KHz
+            samplerate: 24, // 8, 16, 24 KHz
           },
           {
             type: "AAC-eld",
-            samplerate: 16
-          }
-        ]
-      }
-    }
+            samplerate: 16,
+          },
+        ],
+      },
+    };
 
     this.createCameraControlService();
     this.createSecureVideoService();
@@ -85,15 +85,15 @@ export class Camera {
     // Image request: {width: number, height: number}
     // Please override this and invoke callback(error, image buffer) when the snapshot is ready
 
-    var snapshot = fs.readFileSync(__dirname + '/res/snapshot.jpg');
+    var snapshot = fs.readFileSync(__dirname + "/res/snapshot.jpg");
     callback(undefined, snapshot);
-  }
+  };
 
   handleCloseConnection = (connectionID: string) => {
     this.streamControllers.forEach(function(controller) {
       controller.handleCloseConnection(connectionID);
     });
-  }
+  };
 
   prepareStream = (request: PrepareStreamRequest, callback: PreparedStreamRequestCallback) => {
     // Invoked when iOS device requires stream
@@ -122,7 +122,7 @@ export class Camera {
         port: targetPort,
         ssrc: ssrc,
         srtp_key: srtp_key,
-        srtp_salt: srtp_salt
+        srtp_salt: srtp_salt,
       };
 
       response["video"] = videoResp;
@@ -147,7 +147,7 @@ export class Camera {
         port: targetPort,
         ssrc: ssrc,
         srtp_key: srtp_key,
-        srtp_salt: srtp_salt
+        srtp_salt: srtp_salt,
       };
 
       response["audio"] = audioResp;
@@ -159,7 +159,7 @@ export class Camera {
 
     let currentAddress = ip.address();
     var addressResp: Partial<Address> = {
-      address: currentAddress
+      address: currentAddress,
     };
 
     if (ip.isV4Format(currentAddress)) {
@@ -172,7 +172,7 @@ export class Camera {
     this.pendingSessions[uuid.unparse(sessionID)] = sessionInfo as SessionInfo;
 
     callback(response as PreparedStreamResponse);
-  }
+  };
 
   handleStreamRequest = (request: StreamRequest) => {
     // Invoked when iOS device asks stream to start/stop/reconfigure
@@ -207,46 +207,68 @@ export class Camera {
           let videoKey = sessionInfo["video_srtp"];
           let videoSsrc = sessionInfo["video_ssrc"];
 
-          let ffmpegCommand = '-re -f avfoundation -r 29.970000 -i 0:0 -threads 0 -vcodec libx264 -an -pix_fmt yuv420p -r '+ fps +' -f rawvideo -tune zerolatency -vf scale='+ width +':'+ height +' -b:v '+ bitrate +'k -bufsize '+ bitrate +'k -payload_type 99 -ssrc '+ videoSsrc +' -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params '+videoKey.toString('base64')+' srtp://'+targetAddress+':'+targetVideoPort+'?rtcpport='+targetVideoPort+'&localrtcpport='+targetVideoPort+'&pkt_size=1378';
-          this.ongoingSessions[sessionIdentifier] = spawn('ffmpeg', ffmpegCommand.split(' '), { env: process.env });
+          let ffmpegCommand =
+            "-re -f avfoundation -r 29.970000 -i 0:0 -threads 0 -vcodec libx264 -an -pix_fmt yuv420p -r " +
+            fps +
+            " -f rawvideo -tune zerolatency -vf scale=" +
+            width +
+            ":" +
+            height +
+            " -b:v " +
+            bitrate +
+            "k -bufsize " +
+            bitrate +
+            "k -payload_type 99 -ssrc " +
+            videoSsrc +
+            " -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params " +
+            videoKey.toString("base64") +
+            " srtp://" +
+            targetAddress +
+            ":" +
+            targetVideoPort +
+            "?rtcpport=" +
+            targetVideoPort +
+            "&localrtcpport=" +
+            targetVideoPort +
+            "&pkt_size=1378";
+          this.ongoingSessions[sessionIdentifier] = spawn("ffmpeg", ffmpegCommand.split(" "), { env: process.env });
         }
 
         delete this.pendingSessions[sessionIdentifier];
       } else if (requestType == StreamRequestTypes.STOP) {
         var ffmpegProcess = this.ongoingSessions[sessionIdentifier];
         if (ffmpegProcess) {
-          ffmpegProcess.kill('SIGKILL');
+          ffmpegProcess.kill("SIGKILL");
         }
 
         delete this.ongoingSessions[sessionIdentifier];
       }
     }
-  }
+  };
 
   createCameraControlService = () => {
-    var controlService = new Service.CameraControl('', '');
+    var controlService = new Service.CameraControl("", "");
 
     // Developer can add control characteristics like rotation, night vision at here.
 
     this.services.push(controlService);
-  }
+  };
 
   createSecureVideoService = () => {
-    var myCameraOperatingMode = new Service.CameraOperatingMode('','');
+    var myCameraOperatingMode = new Service.CameraOperatingMode("", "");
     this.services.push(myCameraOperatingMode);
 
-    var myCameraEventRecordingManagement = new Service.CameraEventRecordingManagement('','');
+    var myCameraEventRecordingManagement = new Service.CameraEventRecordingManagement("", "");
     this.services.push(myCameraEventRecordingManagement);
-  }
+  };
 
-// Private
+  // Private
   _createStreamControllers = (maxStreams: number, options: StreamControllerOptions) => {
-
     for (let i = 0; i < maxStreams; i++) {
       const streamController = new StreamController(i, options, this);
 
       this.services.push(streamController.service!);
       this.streamControllers.push(streamController);
     }
-  }
+  };
 }

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -6,34 +6,33 @@ import {
   Formats,
   Perms,
   SerializedCharacteristic,
-  Units
-} from './Characteristic';
-import { generate } from './util/uuid';
-import './gen';
+  Units,
+} from "./Characteristic";
+import { generate } from "./util/uuid";
+import "./gen";
 
 const createCharacteristic = (type: Formats) => {
-  return new Characteristic('Test', generate('Foo'), { format: type, perms: [] });
+  return new Characteristic("Test", generate("Foo"), { format: type, perms: [] });
 };
 
 const createCharacteristicWithProps = (props: CharacteristicProps) => {
-  return new Characteristic('Test', generate('Foo'), props);
+  return new Characteristic("Test", generate("Foo"), props);
 };
 
-describe('Characteristic', () => {
-
-  describe('#setProps()', () => {
-    it('should overwrite existing properties', () => {
+describe("Characteristic", () => {
+  describe("#setProps()", () => {
+    it("should overwrite existing properties", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
 
-      const NEW_PROPS = {format: Formats.STRING, perms: []};
+      const NEW_PROPS = { format: Formats.STRING, perms: [] };
       characteristic.setProps(NEW_PROPS);
 
       expect(characteristic.props).toEqual(NEW_PROPS);
     });
   });
 
-  describe('#subscribe()', () => {
-    it('correctly adds a single subscription', () => {
+  describe("#subscribe()", () => {
+    it("correctly adds a single subscription", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
       const subscribeSpy = jest.fn();
       characteristic.on(CharacteristicEventTypes.SUBSCRIBE, subscribeSpy);
@@ -43,7 +42,7 @@ describe('Characteristic', () => {
       expect(characteristic.subscriptions).toEqual(1);
     });
 
-    it('correctly adds multiple subscriptions', () => {
+    it("correctly adds multiple subscriptions", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
       const subscribeSpy = jest.fn();
       characteristic.on(CharacteristicEventTypes.SUBSCRIBE, subscribeSpy);
@@ -56,8 +55,8 @@ describe('Characteristic', () => {
     });
   });
 
-  describe('#unsubscribe()', () => {
-    it('correctly removes a single subscription', () => {
+  describe("#unsubscribe()", () => {
+    it("correctly removes a single subscription", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
       const subscribeSpy = jest.fn();
       const unsubscribeSpy = jest.fn();
@@ -71,7 +70,7 @@ describe('Characteristic', () => {
       expect(characteristic.subscriptions).toEqual(0);
     });
 
-    it('correctly removes multiple subscriptions', () => {
+    it("correctly removes multiple subscriptions", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
       const subscribeSpy = jest.fn();
       const unsubscribeSpy = jest.fn();
@@ -90,8 +89,8 @@ describe('Characteristic', () => {
     });
   });
 
-  describe('#getValue()', () => {
-    it('should handle special event only characteristics', () => {
+  describe("#getValue()", () => {
+    it("should handle special event only characteristics", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
       characteristic.eventOnlyCharacteristic = true;
 
@@ -101,7 +100,7 @@ describe('Characteristic', () => {
       });
     });
 
-    it('should return cached values if no listeners are registered', () => {
+    it("should return cached values if no listeners are registered", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
 
       characteristic.getValue((status, value) => {
@@ -111,15 +110,14 @@ describe('Characteristic', () => {
     });
   });
 
-  describe('#validateValue()', () => {
-
-    it('should validate an integer property', () => {
+  describe("#validateValue()", () => {
+    it("should validate an integer property", () => {
       const VALUE = 1024;
       const characteristic = createCharacteristic(Formats.INT);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a float property', () => {
+    it("should validate a float property", () => {
       const VALUE = 1.024;
       const characteristic = createCharacteristicWithProps({
         format: Formats.FLOAT,
@@ -129,7 +127,7 @@ describe('Characteristic', () => {
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should cut off decimal places correctly', function () {
+    it("should cut off decimal places correctly", function() {
       const VALUE = 1.5642;
       const characteristic = createCharacteristicWithProps({
         format: Formats.FLOAT,
@@ -139,68 +137,68 @@ describe('Characteristic', () => {
       expect(characteristic.validateValue(VALUE)).toEqual(1.5);
     });
 
-    it('should validate a UINT8 property', () => {
+    it("should validate a UINT8 property", () => {
       const VALUE = 10;
       const characteristic = createCharacteristic(Formats.UINT8);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a UINT16 property', () => {
+    it("should validate a UINT16 property", () => {
       const VALUE = 10;
       const characteristic = createCharacteristic(Formats.UINT16);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a UINT32 property', () => {
+    it("should validate a UINT32 property", () => {
       const VALUE = 10;
       const characteristic = createCharacteristic(Formats.UINT32);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a UINT64 property', () => {
+    it("should validate a UINT64 property", () => {
       const VALUE = 10;
       const characteristic = createCharacteristic(Formats.UINT64);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a boolean property', () => {
+    it("should validate a boolean property", () => {
       const VALUE = true;
       const characteristic = createCharacteristic(Formats.BOOL);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a string property', () => {
-      const VALUE = 'Test';
+    it("should validate a string property", () => {
+      const VALUE = "Test";
       const characteristic = createCharacteristic(Formats.STRING);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a data property', () => {
+    it("should validate a data property", () => {
       const VALUE = {};
       const characteristic = createCharacteristic(Formats.DATA);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a TLV8 property', () => {
-      const VALUE = '';
+    it("should validate a TLV8 property", () => {
+      const VALUE = "";
       const characteristic = createCharacteristic(Formats.TLV8);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate a dictionary property', () => {
+    it("should validate a dictionary property", () => {
       const VALUE = {};
       const characteristic = createCharacteristic(Formats.DICTIONARY);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
 
-    it('should validate an array property', () => {
-      const VALUE = ['asd'];
+    it("should validate an array property", () => {
+      const VALUE = ["asd"];
       const characteristic = createCharacteristic(Formats.ARRAY);
       expect(characteristic.validateValue(VALUE)).toEqual(VALUE);
     });
   });
 
-  describe('#setValue()', () => {
+  describe("#setValue()", () => {
     it(`should set error values as the characteristic's status property`, () => {
       const VALUE = new Error();
       const characteristic = createCharacteristic(Formats.DATA);
@@ -209,7 +207,7 @@ describe('Characteristic', () => {
     });
   });
 
-  describe('#updateValue()', () => {
+  describe("#updateValue()", () => {
     it(`should set error values as the characteristic's status property`, () => {
       const VALUE = new Error();
       const characteristic = createCharacteristic(Formats.DATA);
@@ -218,47 +216,42 @@ describe('Characteristic', () => {
     });
   });
 
-  describe('#getDefaultValue()', () => {
-
-    it('should get the correct default value for a boolean property', () => {
+  describe("#getDefaultValue()", () => {
+    it("should get the correct default value for a boolean property", () => {
       const characteristic = createCharacteristic(Formats.BOOL);
       expect(characteristic.getDefaultValue()).toEqual(false);
     });
 
-    it('should get the correct default value for a string property', () => {
+    it("should get the correct default value for a string property", () => {
       const characteristic = createCharacteristic(Formats.STRING);
-      expect(characteristic.getDefaultValue()).toEqual('');
+      expect(characteristic.getDefaultValue()).toEqual("");
     });
 
-    it('should get the correct default value for a data property', () => {
+    it("should get the correct default value for a data property", () => {
       const characteristic = createCharacteristic(Formats.DATA);
       expect(characteristic.getDefaultValue()).toEqual(null);
     });
 
-    it('should get the correct default value for a TLV8 property', () => {
+    it("should get the correct default value for a TLV8 property", () => {
       const characteristic = createCharacteristic(Formats.TLV8);
       expect(characteristic.getDefaultValue()).toEqual(null);
     });
 
-    it('should get the correct default value for a dictionary property', () => {
+    it("should get the correct default value for a dictionary property", () => {
       const characteristic = createCharacteristic(Formats.DICTIONARY);
       expect(characteristic.getDefaultValue()).toEqual({});
     });
 
-    it('should get the correct default value for an array property', () => {
+    it("should get the correct default value for an array property", () => {
       const characteristic = createCharacteristic(Formats.ARRAY);
       expect(characteristic.getDefaultValue()).toEqual([]);
     });
-
   });
 
-  describe('#toHAP()', () => {
-
-  });
+  describe("#toHAP()", () => {});
 
   describe(`@${CharacteristicEventTypes.GET}`, () => {
-
-    it('should call any listeners for the event', () => {
+    it("should call any listeners for the event", () => {
       const characteristic = createCharacteristic(Formats.STRING);
 
       const listenerCallback = jest.fn();
@@ -274,15 +267,14 @@ describe('Characteristic', () => {
   });
 
   describe(`@${CharacteristicEventTypes.SET}`, () => {
-
-    it('should call any listeners for the event', () => {
+    it("should call any listeners for the event", () => {
       const characteristic = createCharacteristic(Formats.STRING);
 
-      const VALUE = 'NewValue';
+      const VALUE = "NewValue";
       const listenerCallback = jest.fn();
       const setValueCallback = jest.fn();
 
-      characteristic.setValue(VALUE, setValueCallback)
+      characteristic.setValue(VALUE, setValueCallback);
       characteristic.on(CharacteristicEventTypes.SET, listenerCallback);
       characteristic.setValue(VALUE, setValueCallback);
 
@@ -292,33 +284,32 @@ describe('Characteristic', () => {
   });
 
   describe(`@${CharacteristicEventTypes.CHANGE}`, () => {
-
-    it('should call any listeners for the event when the characteristic is event-only, and the value is set', () => {
+    it("should call any listeners for the event when the characteristic is event-only, and the value is set", () => {
       const characteristic = createCharacteristic(Formats.STRING);
       characteristic.eventOnlyCharacteristic = true;
 
-      const VALUE = 'NewValue';
+      const VALUE = "NewValue";
       const listenerCallback = jest.fn();
       const setValueCallback = jest.fn();
 
-      characteristic.setValue(VALUE, setValueCallback)
+      characteristic.setValue(VALUE, setValueCallback);
       characteristic.on(CharacteristicEventTypes.CHANGE, listenerCallback);
-      characteristic.setValue(VALUE, setValueCallback)
+      characteristic.setValue(VALUE, setValueCallback);
 
       expect(listenerCallback).toHaveBeenCalledTimes(1);
       expect(setValueCallback).toHaveBeenCalledTimes(2);
     });
 
-    it('should call any listeners for the event when the characteristic is event-only, and the value is updated', () => {
+    it("should call any listeners for the event when the characteristic is event-only, and the value is updated", () => {
       const characteristic = createCharacteristic(Formats.STRING);
       // characteristic.eventOnlyCharacteristic = true;
 
-      const VALUE = 'NewValue';
+      const VALUE = "NewValue";
       const listenerCallback = jest.fn();
       const updateValueCallback = jest.fn();
 
       characteristic.on(CharacteristicEventTypes.CHANGE, listenerCallback);
-      characteristic.updateValue(VALUE, updateValueCallback)
+      characteristic.updateValue(VALUE, updateValueCallback);
 
       expect(listenerCallback).toHaveBeenCalledTimes(1);
       expect(updateValueCallback).toHaveBeenCalledTimes(1);
@@ -326,8 +317,7 @@ describe('Characteristic', () => {
   });
 
   describe(`@${CharacteristicEventTypes.SUBSCRIBE}`, () => {
-
-    it('should call any listeners for the event', () => {
+    it("should call any listeners for the event", () => {
       const characteristic = createCharacteristic(Formats.STRING);
 
       const cb = jest.fn();
@@ -340,8 +330,7 @@ describe('Characteristic', () => {
   });
 
   describe(`@${CharacteristicEventTypes.UNSUBSCRIBE}`, () => {
-
-    it('should call any listeners for the event', () => {
+    it("should call any listeners for the event", () => {
       const characteristic = createCharacteristic(Formats.STRING);
 
       const cb = jest.fn();
@@ -353,7 +342,7 @@ describe('Characteristic', () => {
       expect(cb).toHaveBeenCalledTimes(1);
     });
 
-    it('should not call any listeners for the event if none are registered', () => {
+    it("should not call any listeners for the event if none are registered", () => {
       const characteristic = createCharacteristic(Formats.STRING);
 
       const cb = jest.fn();
@@ -365,8 +354,8 @@ describe('Characteristic', () => {
     });
   });
 
-  describe('#serialize', () => {
-    it('should serialize characteristic', () => {
+  describe("#serialize", () => {
+    it("should serialize characteristic", () => {
       const props: CharacteristicProps = {
         format: Formats.STRING,
         perms: [Perms.TIMED_WRITE, Perms.READ],
@@ -389,15 +378,17 @@ describe('Characteristic', () => {
         value: "TestValue",
         accessRestrictedToAdmins: [Access.WRITE],
         eventOnlyCharacteristic: true,
-      })
+      });
     });
   });
 
-  describe('#deserialize', () => {
-    it('should deserialize legacy json from homebridge', () => {
-      const json = JSON.parse('{"displayName": "On", "UUID": "00000025-0000-1000-8000-0026BB765291", ' +
+  describe("#deserialize", () => {
+    it("should deserialize legacy json from homebridge", () => {
+      const json = JSON.parse(
+        '{"displayName": "On", "UUID": "00000025-0000-1000-8000-0026BB765291", ' +
           '"props": {"format": "bool", "unit": null, "minValue": null, "maxValue": null, "minStep": null, "perms": ["pr", "pw", "ev"]}, ' +
-          '"value": false, "eventOnlyCharacteristic": false}');
+          '"value": false, "eventOnlyCharacteristic": false}'
+      );
       const characteristic = Characteristic.deserialize(json);
 
       expect(characteristic.displayName).toEqual(json.displayName);
@@ -408,7 +399,7 @@ describe('Characteristic', () => {
       expect(characteristic.accessRestrictedToAdmins).toEqual([]);
     });
 
-    it('should deserialize complete json', () => {
+    it("should deserialize complete json", () => {
       const json: SerializedCharacteristic = {
         displayName: "MyName",
         UUID: "00000001-0000-1000-8000-0026BB765291",

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1,8 +1,8 @@
-import Decimal from 'decimal.js';
+import Decimal from "decimal.js";
 
-import { once } from './util/once';
+import { once } from "./util/once";
 import { clone } from "./util/clone";
-import { IdentifierCache } from './model/IdentifierCache';
+import { IdentifierCache } from "./model/IdentifierCache";
 import {
   CharacteristicChange,
   CharacteristicValue,
@@ -10,48 +10,48 @@ import {
   Nullable,
   ToHAPOptions,
   VoidCallback,
-} from '../types';
-import { EventEmitter } from './EventEmitter';
-import * as HomeKitTypes from './gen';
+} from "../types";
+import { EventEmitter } from "./EventEmitter";
+import * as HomeKitTypes from "./gen";
 
 // Known HomeKit formats
 export enum Formats {
-  BOOL = 'bool',
-  INT = 'int',
-  FLOAT = 'float',
-  STRING = 'string',
-  UINT8 = 'uint8',
-  UINT16 = 'uint16',
-  UINT32 = 'uint32',
-  UINT64 = 'uint64',
-  DATA = 'data',
-  TLV8 = 'tlv8',
-  ARRAY = 'array', //Not in HAP Spec
-  DICTIONARY = 'dict' //Not in HAP Spec
+  BOOL = "bool",
+  INT = "int",
+  FLOAT = "float",
+  STRING = "string",
+  UINT8 = "uint8",
+  UINT16 = "uint16",
+  UINT32 = "uint32",
+  UINT64 = "uint64",
+  DATA = "data",
+  TLV8 = "tlv8",
+  ARRAY = "array", //Not in HAP Spec
+  DICTIONARY = "dict", //Not in HAP Spec
 }
 
 // Known HomeKit unit types
 export enum Units {
   // HomeKit only defines Celsius, for Fahrenheit, it requires iOS app to do the conversion.
-  CELSIUS = 'celsius',
-  PERCENTAGE = 'percentage',
-  ARC_DEGREE = 'arcdegrees',
-  LUX = 'lux',
-  SECONDS = 'seconds'
+  CELSIUS = "celsius",
+  PERCENTAGE = "percentage",
+  ARC_DEGREE = "arcdegrees",
+  LUX = "lux",
+  SECONDS = "seconds",
 }
 
 // Known HomeKit permission types
 export enum Perms {
-  READ = 'pr', //Kept for backwards compatability
-  PAIRED_READ = 'pr', //Added to match HAP's terminology
-  WRITE = 'pw', //Kept for backwards compatability
-  PAIRED_WRITE = 'pw', //Added to match HAP's terminology
-  NOTIFY = 'ev', //Kept for backwards compatability
-  EVENTS = 'ev', //Added to match HAP's terminology
-  ADDITIONAL_AUTHORIZATION = 'aa',
-  TIMED_WRITE = 'tw', //Not currently supported by IP
-  HIDDEN = 'hd',
-  WRITE_RESPONSE = 'wr'
+  READ = "pr", //Kept for backwards compatability
+  PAIRED_READ = "pr", //Added to match HAP's terminology
+  WRITE = "pw", //Kept for backwards compatability
+  PAIRED_WRITE = "pw", //Added to match HAP's terminology
+  NOTIFY = "ev", //Kept for backwards compatability
+  EVENTS = "ev", //Added to match HAP's terminology
+  ADDITIONAL_AUTHORIZATION = "aa",
+  TIMED_WRITE = "tw", //Not currently supported by IP
+  HIDDEN = "hd",
+  WRITE_RESPONSE = "wr",
 }
 
 export interface CharacteristicProps {
@@ -72,16 +72,16 @@ export interface CharacteristicProps {
 export enum Access {
   READ = 0x00,
   WRITE = 0x01,
-  NOTIFY = 0x02
+  NOTIFY = 0x02,
 }
 
 export interface SerializedCharacteristic {
-  displayName?: string,
-  UUID?: string,
-  props: CharacteristicProps,
-  value: Nullable<CharacteristicValue>,
-  accessRestrictedToAdmins: Access[],
-  eventOnlyCharacteristic: boolean,
+  displayName?: string;
+  UUID?: string;
+  props: CharacteristicProps;
+  value: Nullable<CharacteristicValue>;
+  accessRestrictedToAdmins: Access[];
+  eventOnlyCharacteristic: boolean;
 }
 
 export enum CharacteristicEventTypes {
@@ -92,21 +92,31 @@ export enum CharacteristicEventTypes {
   CHANGE = "change",
 }
 
-export type CharacteristicGetCallback<T = Nullable<CharacteristicValue>> = (error?: Error | null , value?: T) => void
-export type CharacteristicSetCallback = (error?: Error | null, value?: CharacteristicValue) => void
+export type CharacteristicGetCallback<T = Nullable<CharacteristicValue>> = (error?: Error | null, value?: T) => void;
+export type CharacteristicSetCallback = (error?: Error | null, value?: CharacteristicValue) => void;
 
 type Events = {
   [CharacteristicEventTypes.CHANGE]: (change: CharacteristicChange) => void;
   [CharacteristicEventTypes.GET]: (cb: CharacteristicGetCallback, context?: any, connectionID?: string) => void;
-  [CharacteristicEventTypes.SET]: (value: CharacteristicValue, cb: CharacteristicSetCallback, context?: any, connectionID?: string) => void;
+  [CharacteristicEventTypes.SET]: (
+    value: CharacteristicValue,
+    cb: CharacteristicSetCallback,
+    context?: any,
+    connectionID?: string
+  ) => void;
   [CharacteristicEventTypes.SUBSCRIBE]: VoidCallback;
   [CharacteristicEventTypes.UNSUBSCRIBE]: VoidCallback;
-}
+};
 
 /**
  * @deprecated Use CharacteristicEventTypes instead
  */
-export type EventCharacteristic = CharacteristicEventTypes.GET | CharacteristicEventTypes.SET | CharacteristicEventTypes.SUBSCRIBE | CharacteristicEventTypes.UNSUBSCRIBE | CharacteristicEventTypes.CHANGE;
+export type EventCharacteristic =
+  | CharacteristicEventTypes.GET
+  | CharacteristicEventTypes.SET
+  | CharacteristicEventTypes.SUBSCRIBE
+  | CharacteristicEventTypes.UNSUBSCRIBE
+  | CharacteristicEventTypes.CHANGE;
 
 /**
  * Characteristic represents a particular typed variable that can be assigned to a Service. For instance, a
@@ -140,7 +150,6 @@ export type EventCharacteristic = CharacteristicEventTypes.GET | CharacteristicE
  *        passed in by the initiator of this change (if known).
  */
 export class Characteristic extends EventEmitter<Events> {
-
   static Formats = Formats;
   static Units = Units;
   static Perms = Perms;
@@ -359,8 +368,8 @@ export class Characteristic extends EventEmitter<Events> {
   props: CharacteristicProps;
   subscriptions: number = 0;
 
-  'valid-values': number[];
-  'valid-values-range': [number, number];
+  "valid-values": number[];
+  "valid-values-range": [number, number];
 
   constructor(public displayName?: string, public UUID?: string, props?: CharacteristicProps) {
     super();
@@ -371,7 +380,7 @@ export class Characteristic extends EventEmitter<Events> {
       minValue: null,
       maxValue: null,
       minStep: null,
-      perms: []
+      perms: [],
     };
   }
 
@@ -395,20 +404,20 @@ export class Characteristic extends EventEmitter<Events> {
    * }
    */
   setProps = (props: Partial<CharacteristicProps>) => {
-    for (var key in (props || {}))
+    for (var key in props || {})
       if (Object.prototype.hasOwnProperty.call(props, key)) {
         // @ts-ignore
         this.props[key] = props[key];
       }
     return this;
-  }
+  };
 
   subscribe = () => {
     if (this.subscriptions === 0) {
       this.emit(CharacteristicEventTypes.SUBSCRIBE);
     }
     this.subscriptions++;
-  }
+  };
 
   unsubscribe = () => {
     var wasOne = this.subscriptions === 1;
@@ -417,7 +426,7 @@ export class Characteristic extends EventEmitter<Events> {
     if (wasOne) {
       this.emit(CharacteristicEventTypes.UNSUBSCRIBE);
     }
-  }
+  };
 
   getValue = (callback?: CharacteristicGetCallback, context?: any, connectionID?: string) => {
     // Handle special event only characteristics.
@@ -429,32 +438,33 @@ export class Characteristic extends EventEmitter<Events> {
     }
     if (this.listeners(CharacteristicEventTypes.GET).length > 0) {
       // allow a listener to handle the fetching of this value, and wait for completion
-      this.emit(CharacteristicEventTypes.GET, once((err: Error, newValue: Nullable<CharacteristicValue>) => {
-        this.status = err;
-        if (err) {
-          // pass the error along to our callback
-          if (callback)
-            callback(err);
-        } else {
-          newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
-          if (newValue === undefined || newValue === null)
-            newValue = this.getDefaultValue();
-          // getting the value was a success; we can pass it along and also update our cached value
-          var oldValue = this.value;
-          this.value = newValue;
-          if (callback)
-            callback(null, newValue);
-          // emit a change event if necessary
-          if (oldValue !== newValue)
-            this.emit(CharacteristicEventTypes.CHANGE, {oldValue: oldValue, newValue: newValue, context: context});
-        }
-      }), context, connectionID);
+      this.emit(
+        CharacteristicEventTypes.GET,
+        once((err: Error, newValue: Nullable<CharacteristicValue>) => {
+          this.status = err;
+          if (err) {
+            // pass the error along to our callback
+            if (callback) callback(err);
+          } else {
+            newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
+            if (newValue === undefined || newValue === null) newValue = this.getDefaultValue();
+            // getting the value was a success; we can pass it along and also update our cached value
+            var oldValue = this.value;
+            this.value = newValue;
+            if (callback) callback(null, newValue);
+            // emit a change event if necessary
+            if (oldValue !== newValue)
+              this.emit(CharacteristicEventTypes.CHANGE, { oldValue: oldValue, newValue: newValue, context: context });
+          }
+        }),
+        context,
+        connectionID
+      );
     } else {
       // no one is listening to the 'get' event, so just return the cached value
-      if (callback)
-        callback(this.status, this.value);
+      if (callback) callback(this.status, this.value);
     }
-  }
+  };
 
   validateValue = (newValue: Nullable<CharacteristicValue>): Nullable<CharacteristicValue> => {
     let isNumericType = false;
@@ -502,22 +512,19 @@ export class Characteristic extends EventEmitter<Events> {
       //All of the following datatypes return from this switch.
       case Formats.BOOL:
         // @ts-ignore
-        return (newValue == true); //We don't need to make sure this returns true or false
+        return newValue == true; //We don't need to make sure this returns true or false
         break;
       case Formats.STRING:
-        let myString = newValue as string || ''; //If null or undefined or anything odd, make it a blank string
+        let myString = (newValue as string) || ""; //If null or undefined or anything odd, make it a blank string
         myString = String(myString);
         var maxLength = this.props.maxLen;
-        if (maxLength === undefined)
-          maxLength = 64; //Default Max Length is 64.
-        if (myString.length > maxLength)
-          myString = myString.substring(0, maxLength); //Truncate strings that are too long
+        if (maxLength === undefined) maxLength = 64; //Default Max Length is 64.
+        if (myString.length > maxLength) myString = myString.substring(0, maxLength); //Truncate strings that are too long
         return myString; //We don't need to do any validation after having truncated the string
         break;
       case Formats.DATA:
         var maxLength = this.props.maxDataLen;
-        if (maxLength === undefined)
-          maxLength = 2097152; //Default Max Length is 2097152.
+        if (maxLength === undefined) maxLength = 2097152; //Default Max Length is 2097152.
         //if (newValue.length>maxLength) //I don't know the best way to handle this since it's unknown binary data.
         //I suspect that it will crash HomeKit for this bridge if the length is too long.
         return newValue;
@@ -525,9 +532,10 @@ export class Characteristic extends EventEmitter<Events> {
       case Formats.TLV8:
         //Should we parse this to make sure the tlv8 is valid?
         break;
-      default: //Datatype out of HAP Spec encountered. We'll assume the developer knows what they're doing.
+      default:
+        //Datatype out of HAP Spec encountered. We'll assume the developer knows what they're doing.
         return newValue;
-    };
+    }
 
     if (isNumericType) {
       if (newValue === false) {
@@ -539,22 +547,18 @@ export class Characteristic extends EventEmitter<Events> {
       if (isNaN(Number.parseInt(newValue as string, 10))) {
         return this.value!;
       } //This is not a number so we'll just pass out the last value.
-      if ((this.props.maxValue && !isNaN(this.props.maxValue)) && (this.props.maxValue !== null))
+      if (this.props.maxValue && !isNaN(this.props.maxValue) && this.props.maxValue !== null)
         maxValue_resolved = this.props.maxValue;
-      if ((this.props.minValue && !isNaN(this.props.minValue)) && (this.props.minValue !== null))
+      if (this.props.minValue && !isNaN(this.props.minValue) && this.props.minValue !== null)
         minValue_resolved = this.props.minValue;
-      if ((this.props.minStep && !isNaN(this.props.minStep)) && (this.props.minStep !== null))
+      if (this.props.minStep && !isNaN(this.props.minStep) && this.props.minStep !== null)
         minStep_resolved = this.props.minStep;
-      if (newValue! < minValue_resolved!)
-        newValue = minValue_resolved!; //Fails Minimum Value Test
-      if (newValue! > maxValue_resolved!)
-        newValue = maxValue_resolved!; //Fails Maximum Value Test
+      if (newValue! < minValue_resolved!) newValue = minValue_resolved!; //Fails Minimum Value Test
+      if (newValue! > maxValue_resolved!) newValue = maxValue_resolved!; //Fails Maximum Value Test
       if (minStep_resolved !== undefined) {
         //Determine how many decimals we need to display
-        if (Math.floor(minStep_resolved) === minStep_resolved)
-          stepDecimals = 0;
-        else
-          stepDecimals = minStep_resolved.toString().split(".")[1].length || 0;
+        if (Math.floor(minStep_resolved) === minStep_resolved) stepDecimals = 0;
+        else stepDecimals = minStep_resolved.toString().split(".")[1].length || 0;
         //Use Decimal to detemine the lowest value within the step.
         try {
           var decimalVal = new Decimal(parseFloat(newValue as string));
@@ -569,20 +573,23 @@ export class Characteristic extends EventEmitter<Events> {
           return this.value!; //If we had an error, return the current value.
         }
       }
-      if (this['valid-values'] !== undefined)
-        if (!this['valid-values'].includes(newValue as number))
-          return this.value!; //Fails Valid Values Test
-      if (this['valid-values-range'] !== undefined) { //This is another way Apple has to handle min/max
-        if (newValue! < this['valid-values-range'][0])
-          newValue = this['valid-values-range'][0];
-        if (newValue! > this['valid-values-range'][1])
-          newValue = this['valid-values-range'][1];
+      if (this["valid-values"] !== undefined)
+        if (!this["valid-values"].includes(newValue as number)) return this.value!; //Fails Valid Values Test
+      if (this["valid-values-range"] !== undefined) {
+        //This is another way Apple has to handle min/max
+        if (newValue! < this["valid-values-range"][0]) newValue = this["valid-values-range"][0];
+        if (newValue! > this["valid-values-range"][1]) newValue = this["valid-values-range"][1];
       }
     }
     return newValue;
-  }
+  };
 
-  setValue = (newValue: Nullable<CharacteristicValue | Error>, callback?: CharacteristicSetCallback, context?: any, connectionID?: string): Characteristic => {
+  setValue = (
+    newValue: Nullable<CharacteristicValue | Error>,
+    callback?: CharacteristicSetCallback,
+    context?: any,
+    connectionID?: string
+  ): Characteristic => {
     if (newValue instanceof Error) {
       this.status = newValue;
     } else {
@@ -592,57 +599,60 @@ export class Characteristic extends EventEmitter<Events> {
     var oldValue = this.value;
     if (this.listeners(CharacteristicEventTypes.SET).length > 0) {
       // allow a listener to handle the setting of this value, and wait for completion
-      this.emit(CharacteristicEventTypes.SET, newValue, once((err: Error, writeResponse?: CharacteristicValue) => {
-        this.status = err;
-        if (err) {
-          // pass the error along to our callback
-          if (callback)
-            callback(err);
-        } else {
-          if (writeResponse !== undefined && this.props.perms.includes(Perms.WRITE_RESPONSE))
-            newValue = writeResponse; // support write response simply by letting the implementor pass the response as second argument to the callback
+      this.emit(
+        CharacteristicEventTypes.SET,
+        newValue,
+        once((err: Error, writeResponse?: CharacteristicValue) => {
+          this.status = err;
+          if (err) {
+            // pass the error along to our callback
+            if (callback) callback(err);
+          } else {
+            if (writeResponse !== undefined && this.props.perms.includes(Perms.WRITE_RESPONSE))
+              newValue = writeResponse; // support write response simply by letting the implementor pass the response as second argument to the callback
 
-          if (newValue === undefined || newValue === null)
-            newValue = this.getDefaultValue() as CharacteristicValue;
-          // setting the value was a success; so we can cache it now
-          this.value = newValue as CharacteristicValue;
-          if (callback)
-            callback();
-          if (this.eventOnlyCharacteristic === true || oldValue !== newValue)
-            this.emit(CharacteristicEventTypes.CHANGE, {oldValue: oldValue, newValue: newValue, context: context});
-        }
-      }), context, connectionID);
+            if (newValue === undefined || newValue === null) newValue = this.getDefaultValue() as CharacteristicValue;
+            // setting the value was a success; so we can cache it now
+            this.value = newValue as CharacteristicValue;
+            if (callback) callback();
+            if (this.eventOnlyCharacteristic === true || oldValue !== newValue)
+              this.emit(CharacteristicEventTypes.CHANGE, { oldValue: oldValue, newValue: newValue, context: context });
+          }
+        }),
+        context,
+        connectionID
+      );
     } else {
-      if (newValue === undefined || newValue === null)
-        newValue = this.getDefaultValue() as CharacteristicValue;
+      if (newValue === undefined || newValue === null) newValue = this.getDefaultValue() as CharacteristicValue;
       // no one is listening to the 'set' event, so just assign the value blindly
       this.value = newValue as string | number;
-      if (callback)
-        callback();
+      if (callback) callback();
       if (this.eventOnlyCharacteristic === true || oldValue !== newValue)
-        this.emit(CharacteristicEventTypes.CHANGE, {oldValue: oldValue, newValue: newValue, context: context});
+        this.emit(CharacteristicEventTypes.CHANGE, { oldValue: oldValue, newValue: newValue, context: context });
     }
     return this; // for chaining
-  }
+  };
 
-  updateValue = (newValue: Nullable<CharacteristicValue | Error>, callback?: () => void, context?: any): Characteristic => {
+  updateValue = (
+    newValue: Nullable<CharacteristicValue | Error>,
+    callback?: () => void,
+    context?: any
+  ): Characteristic => {
     if (newValue instanceof Error) {
       this.status = newValue;
     } else {
       this.status = null;
     }
     newValue = this.validateValue(newValue as Nullable<CharacteristicValue>); //validateValue returns a value that has be cooerced into a valid value.
-    if (newValue === undefined || newValue === null)
-      newValue = this.getDefaultValue() as CharacteristicValue;
+    if (newValue === undefined || newValue === null) newValue = this.getDefaultValue() as CharacteristicValue;
     // no one is listening to the 'set' event, so just assign the value blindly
     var oldValue = this.value;
     this.value = newValue;
-    if (callback)
-      callback();
+    if (callback) callback();
     if (this.eventOnlyCharacteristic === true || oldValue !== newValue)
-      this.emit(CharacteristicEventTypes.CHANGE, {oldValue: oldValue, newValue: newValue, context: context});
+      this.emit(CharacteristicEventTypes.CHANGE, { oldValue: oldValue, newValue: newValue, context: context });
     return this; // for chaining
-  }
+  };
 
   getDefaultValue = (): Nullable<CharacteristicValue> => {
     switch (this.props.format) {
@@ -661,12 +671,17 @@ export class Characteristic extends EventEmitter<Events> {
       default:
         return this.props.minValue || 0;
     }
-  }
+  };
 
-  _assignID = (identifierCache: IdentifierCache, accessoryName: string, serviceUUID: string, serviceSubtype: string) => {
+  _assignID = (
+    identifierCache: IdentifierCache,
+    accessoryName: string,
+    serviceUUID: string,
+    serviceSubtype: string
+  ) => {
     // generate our IID based on our UUID
     this.iid = identifierCache.getIID(accessoryName, serviceUUID, serviceSubtype, this.UUID);
-  }
+  };
 
   /**
    * Returns a JSON representation of this Accessory suitable for delivering to HAP clients.
@@ -675,21 +690,14 @@ export class Characteristic extends EventEmitter<Events> {
     // ensure our value fits within our constraints if present
     var value = this.value;
 
-    if (this.props.minValue != null && value! < this.props.minValue)
-      value = this.props.minValue;
-    if (this.props.maxValue != null && value! > this.props.maxValue)
-      value = this.props.maxValue;
+    if (this.props.minValue != null && value! < this.props.minValue) value = this.props.minValue;
+    if (this.props.maxValue != null && value! > this.props.maxValue) value = this.props.maxValue;
     if (this.props.format != null) {
-      if (this.props.format === Formats.INT)
-        value = parseInt(value as string);
-      else if (this.props.format === Formats.UINT8)
-        value = parseInt(value as string);
-      else if (this.props.format === Formats.UINT16)
-        value = parseInt(value as string);
-      else if (this.props.format === Formats.UINT32)
-        value = parseInt(value as string);
-      else if (this.props.format === Formats.UINT64)
-        value = parseInt(value as string);
+      if (this.props.format === Formats.INT) value = parseInt(value as string);
+      else if (this.props.format === Formats.UINT8) value = parseInt(value as string);
+      else if (this.props.format === Formats.UINT16) value = parseInt(value as string);
+      else if (this.props.format === Formats.UINT32) value = parseInt(value as string);
+      else if (this.props.format === Formats.UINT64) value = parseInt(value as string);
       else if (this.props.format === Formats.FLOAT) {
         value = parseFloat(value as string);
         if (this.props.minStep != null) {
@@ -716,38 +724,39 @@ export class Characteristic extends EventEmitter<Events> {
       // bonjour: false
     };
     if (this.props.validValues != null && this.props.validValues.length > 0) {
-      hap['valid-values'] = this.props.validValues;
+      hap["valid-values"] = this.props.validValues;
     }
-    if (this.props.validValueRanges != null && this.props.validValueRanges.length > 0 && !(this.props.validValueRanges.length & 1)) {
-      hap['valid-values-range'] = this.props.validValueRanges;
+    if (
+      this.props.validValueRanges != null &&
+      this.props.validValueRanges.length > 0 &&
+      !(this.props.validValueRanges.length & 1)
+    ) {
+      hap["valid-values-range"] = this.props.validValueRanges;
     }
     // extra properties
-    if (this.props.unit != null)
-      hap.unit = this.props.unit;
-    if (this.props.maxValue != null)
-      hap.maxValue = this.props.maxValue;
-    if (this.props.minValue != null)
-      hap.minValue = this.props.minValue;
-    if (this.props.minStep != null)
-      hap.minStep = this.props.minStep;
+    if (this.props.unit != null) hap.unit = this.props.unit;
+    if (this.props.maxValue != null) hap.maxValue = this.props.maxValue;
+    if (this.props.minValue != null) hap.minValue = this.props.minValue;
+    if (this.props.minStep != null) hap.minStep = this.props.minStep;
     // add maxLen if string length is > 64 bytes and trim to max 256 bytes
     if (this.props.format === Formats.STRING) {
-      var str = Buffer.from(value as string, 'utf8'), len = str.byteLength;
-      if (len > 256) { // 256 bytes is the max allowed length
-        hap.value = str.toString('utf8', 0, 256);
+      var str = Buffer.from(value as string, "utf8"),
+        len = str.byteLength;
+      if (len > 256) {
+        // 256 bytes is the max allowed length
+        hap.value = str.toString("utf8", 0, 256);
         hap.maxLen = 256;
-      } else if (len > 64) { // values below can be ommited
+      } else if (len > 64) {
+        // values below can be ommited
         hap.maxLen = len;
       }
     }
     // if we're not readable, omit the "value" property - otherwise iOS will complain about non-compliance
-    if (this.props.perms.indexOf(Perms.READ) == -1)
-      delete hap.value;
+    if (this.props.perms.indexOf(Perms.READ) == -1) delete hap.value;
     // delete the "value" property anyway if we were asked to
-    if (opt && opt.omitValues)
-      delete hap.value;
+    if (opt && opt.omitValues) delete hap.value;
     return hap as HapCharacteristic;
-  }
+  };
 
   static serialize = (characteristic: Characteristic): SerializedCharacteristic => {
     return {
@@ -757,7 +766,7 @@ export class Characteristic extends EventEmitter<Events> {
       value: characteristic.value,
       accessRestrictedToAdmins: characteristic.accessRestrictedToAdmins,
       eventOnlyCharacteristic: characteristic.eventOnlyCharacteristic,
-    }
+    };
   };
 
   static deserialize = (json: SerializedCharacteristic): Characteristic => {
@@ -769,18 +778,20 @@ export class Characteristic extends EventEmitter<Events> {
 
     return characteristic;
   };
-
 }
 
 // Mike Samuel
 // http://stackoverflow.com/questions/10454518/javascript-how-to-retrieve-the-number-of-decimals-of-a-string-number
 function decimalPlaces(num: number) {
-  var match = (''+num).match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
-  if (!match) { return 0; }
+  var match = ("" + num).match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
+  if (!match) {
+    return 0;
+  }
   return Math.max(
-       0,
-       // Number of digits right of decimal point.
-       (match[1] ? match[1].length : 0)
-       // Adjust for scientific notation.
-       - (match[2] ? +match[2] : 0));
+    0,
+    // Number of digits right of decimal point.
+    (match[1] ? match[1].length : 0) -
+      // Adjust for scientific notation.
+      (match[2] ? +match[2] : 0)
+  );
 }

--- a/src/lib/EventEmitter.ts
+++ b/src/lib/EventEmitter.ts
@@ -1,5 +1,5 @@
 import { EventEmitter as BaseEventEmitter } from "events";
-import { Callback } from '../types';
+import { Callback } from "../types";
 
 export type EventKey = string | symbol;
 export type Event<T> = T & EventKey;
@@ -8,7 +8,7 @@ export type EventMap = { [name: string]: Callback };
 export class EventEmitter<T extends EventMap, K extends Event<keyof T> = Event<keyof T>> extends BaseEventEmitter {
   addListener(event: K, listener: T[K]): this {
     return super.addListener(event, listener);
-  };
+  }
 
   on(event: K, listener: T[K]): this {
     return super.on(event, listener);
@@ -34,7 +34,7 @@ export class EventEmitter<T extends EventMap, K extends Event<keyof T> = Event<k
     return super.getMaxListeners();
   }
 
-  listeners(event: K): T[K] [] {
+  listeners(event: K): T[K][] {
     return super.listeners(event) as T[K][];
   }
 

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -1,23 +1,23 @@
-import crypto from 'crypto';
+import crypto from "crypto";
 
-import createDebug from 'debug';
-import srp from 'fast-srp-hap';
-import tweetnacl from 'tweetnacl';
-import url from 'url';
+import createDebug from "debug";
+import srp from "fast-srp-hap";
+import tweetnacl from "tweetnacl";
+import url from "url";
 
-import * as encryption from './util/encryption';
-import * as hkdf from './util/hkdf';
-import * as tlv from './util/tlv';
-import { EventedHTTPServer, EventedHTTPServerEvents, Session } from './util/eventedhttp';
-import { once } from './util/once';
+import * as encryption from "./util/encryption";
+import * as hkdf from "./util/hkdf";
+import * as tlv from "./util/tlv";
+import { EventedHTTPServer, EventedHTTPServerEvents, Session } from "./util/eventedhttp";
+import { once } from "./util/once";
 import { IncomingMessage, ServerResponse } from "http";
-import { Characteristic } from './Characteristic';
-import { Accessory, CharacteristicEvents, Resource } from './Accessory';
-import { CharacteristicData, NodeCallback, PairingsCallback, SessionIdentifier, VoidCallback } from '../types';
-import { EventEmitter } from './EventEmitter';
+import { Characteristic } from "./Characteristic";
+import { Accessory, CharacteristicEvents, Resource } from "./Accessory";
+import { CharacteristicData, NodeCallback, PairingsCallback, SessionIdentifier, VoidCallback } from "../types";
+import { EventEmitter } from "./EventEmitter";
 import { PairingInformation, PermissionTypes } from "./model/AccessoryInfo";
 
-const debug = createDebug('HAPServer');
+const debug = createDebug("HAPServer");
 
 // Various "type" constants for HAP's TLV encoding.
 export type Types = TLVValues; // backwards compatibility
@@ -35,12 +35,12 @@ export enum TLVValues {
   ERROR_CODE = 0x07,
   RETRY_DELAY = 0x08,
   CERTIFICATE = 0x09, // x.509 certificate
-  PROOF = 0x0A,
-  SIGNATURE = 0x0A,  // apple authentication coprocessor
-  PERMISSIONS = 0x0B, // None (0x00): regular user, 0x01: Admin (able to add/remove/list pairings)
-  FRAGMENT_DATA = 0x0C,
-  FRAGMENT_LAST = 0x0D,
-  SEPARATOR = 0x0FF // Zero-length TLV that separates different TLVs in a list.
+  PROOF = 0x0a,
+  SIGNATURE = 0x0a, // apple authentication coprocessor
+  PERMISSIONS = 0x0b, // None (0x00): regular user, 0x01: Admin (able to add/remove/list pairings)
+  FRAGMENT_DATA = 0x0c,
+  FRAGMENT_LAST = 0x0d,
+  SEPARATOR = 0x0ff, // Zero-length TLV that separates different TLVs in a list.
 }
 
 export enum Methods {
@@ -49,7 +49,7 @@ export enum Methods {
   PAIR_VERIFY = 0x02,
   ADD_PAIRING = 0x03,
   REMOVE_PAIRING = 0x04,
-  LIST_PAIRINGS = 0x05
+  LIST_PAIRINGS = 0x05,
 }
 
 export enum States {
@@ -58,7 +58,7 @@ export enum States {
   M3 = 0x03,
   M4 = 0x04,
   M5 = 0x05,
-  M6 = 0x06
+  M6 = 0x06,
 }
 
 // Error codes and the like, guessed by packet inspection
@@ -70,7 +70,7 @@ export enum Codes {
   MAX_PEERS = 0x04, // server cannot accept any more pairings
   MAX_TRIES = 0x05, // server reached maximum number of authentication attempts
   UNAVAILABLE = 0x06, // server pairing method is unavailable
-  BUSY = 0x07 // cannot accept pairing request at this time
+  BUSY = 0x07, // cannot accept pairing request at this time
 }
 
 // Status codes for underlying HAP calls
@@ -86,55 +86,65 @@ export enum Status {
   OPERATION_TIMED_OUT = -70408,
   RESOURCE_DOES_NOT_EXIST = -70409,
   INVALID_VALUE_IN_REQUEST = -70410,
-  INSUFFICIENT_AUTHORIZATION = -70411
+  INSUFFICIENT_AUTHORIZATION = -70411,
 }
 
 export enum HapRequestMessageTypes {
-  PAIR_VERIFY = 'pair-verify',
-  DISCOVERY = 'discovery',
-  WRITE_CHARACTERISTICS = 'write-characteristics',
-  READ_CHARACTERISTICS = 'read-characteristics'
+  PAIR_VERIFY = "pair-verify",
+  DISCOVERY = "discovery",
+  WRITE_CHARACTERISTICS = "write-characteristics",
+  READ_CHARACTERISTICS = "read-characteristics",
 }
 
 export type RemoteSession = {
   responseMessage(request: HapRequest, data: Buffer): void;
-}
+};
 
 export type HapRequest = {
-  messageType: HapRequestMessageTypes
+  messageType: HapRequestMessageTypes;
   requestBody: any;
-}
+};
 
 export type CharacteristicsWriteRequest = {
-  characteristics: CharacteristicData[],
-  pid?: number
-}
+  characteristics: CharacteristicData[];
+  pid?: number;
+};
 
 export type PrepareWriteRequest = {
-  ttl: number,
-  pid: number
-}
+  ttl: number;
+  pid: number;
+};
 
 export enum HAPServerEventTypes {
   IDENTIFY = "identify",
   LISTENING = "listening",
-  PAIR = 'pair',
-  ADD_PAIRING = 'add-pairing',
-  REMOVE_PAIRING = 'remove_pairing',
-  LIST_PAIRINGS = 'list-pairings',
-  ACCESSORIES = 'accessories',
-  GET_CHARACTERISTICS = 'get-characteristics',
-  SET_CHARACTERISTICS = 'set-characteristics',
+  PAIR = "pair",
+  ADD_PAIRING = "add-pairing",
+  REMOVE_PAIRING = "remove_pairing",
+  LIST_PAIRINGS = "list-pairings",
+  ACCESSORIES = "accessories",
+  GET_CHARACTERISTICS = "get-characteristics",
+  SET_CHARACTERISTICS = "set-characteristics",
   SESSION_CLOSE = "session-close",
-  REQUEST_RESOURCE = 'request-resource'
+  REQUEST_RESOURCE = "request-resource",
 }
 
 export type Events = {
   [HAPServerEventTypes.IDENTIFY]: (cb: VoidCallback) => void;
   [HAPServerEventTypes.LISTENING]: (port: number) => void;
   [HAPServerEventTypes.PAIR]: (clientUsername: string, clientLTPK: Buffer, cb: VoidCallback) => void;
-  [HAPServerEventTypes.ADD_PAIRING]: (controller: Session, username: string, publicKey: Buffer, permission: number, callback: PairingsCallback<void>) => void;
-  [HAPServerEventTypes.REMOVE_PAIRING]: (controller: Session, username: string, callback: PairingsCallback<void>) => void;
+  [HAPServerEventTypes.ADD_PAIRING]: (
+    controller: Session,
+    username: string,
+    publicKey: Buffer,
+    permission: number,
+    callback: PairingsCallback<void>
+  ) => void;
+  [HAPServerEventTypes.REMOVE_PAIRING]: (
+    controller: Session,
+    username: string,
+    callback: PairingsCallback<void>
+  ) => void;
   [HAPServerEventTypes.LIST_PAIRINGS]: (controller: Session, callback: PairingsCallback<PairingInformation[]>) => void;
   [HAPServerEventTypes.ACCESSORIES]: (cb: NodeCallback<Accessory[]>) => void;
   [HAPServerEventTypes.GET_CHARACTERISTICS]: (
@@ -142,18 +152,18 @@ export type Events = {
     events: CharacteristicEvents,
     cb: NodeCallback<CharacteristicData[]>,
     remote: boolean,
-    session: Session,
+    session: Session
   ) => void;
   [HAPServerEventTypes.SET_CHARACTERISTICS]: (
     writeRequest: CharacteristicsWriteRequest,
     events: CharacteristicEvents,
     cb: NodeCallback<CharacteristicData[]>,
     remote: boolean,
-    session: Session,
+    session: Session
   ) => void;
   [HAPServerEventTypes.SESSION_CLOSE]: (sessionID: string, events: CharacteristicEvents) => void;
   [HAPServerEventTypes.REQUEST_RESOURCE]: (data: Resource, cb: NodeCallback<Buffer>) => void;
-}
+};
 
 /**
  * The actual HAP server that iOS devices talk to.
@@ -213,21 +223,20 @@ export type Events = {
  *        the provided callback when the request has been processed.
  */
 export class HAPServer extends EventEmitter<Events> {
-
   static Types = TLVValues; // backwards compatibility
   static TLVValues = TLVValues;
   static Codes = Codes;
   static Status = Status;
 
   static handlers: Record<string, string> = {
-    '/identify': '_handleIdentify',
-    '/pair-setup': '_handlePair',
-    '/pair-verify': '_handlePairVerify',
-    '/pairings': '_handlePairings',
-    '/accessories': '_handleAccessories',
-    '/characteristics': '_handleCharacteristics',
-    '/prepare': '_prepareWrite',
-    '/resource': '_handleResource'
+    "/identify": "_handleIdentify",
+    "/pair-setup": "_handlePair",
+    "/pair-verify": "_handlePairVerify",
+    "/pairings": "_handlePairings",
+    "/accessories": "_handleAccessories",
+    "/characteristics": "_handleCharacteristics",
+    "/prepare": "_prepareWrite",
+    "/resource": "_handleResource",
   };
 
   _httpServer: EventedHTTPServer;
@@ -249,9 +258,9 @@ export class HAPServer extends EventEmitter<Events> {
     this._httpServer.on(EventedHTTPServerEvents.SESSION_CLOSE, this._onSessionClose);
     if (relayServer) {
       this._relayServer = relayServer;
-      this._relayServer.on('request', this._onRemoteRequest);
-      this._relayServer.on('encrypt', this._onEncrypt);
-      this._relayServer.on('decrypt', this._onDecrypt);
+      this._relayServer.on("request", this._onRemoteRequest);
+      this._relayServer.on("encrypt", this._onEncrypt);
+      this._relayServer.on("decrypt", this._onDecrypt);
     }
     // so iOS is very reluctant to actually disconnect HAP connections (as in, sending a FIN packet).
     // For instance, if you turn off wifi on your phone, it will not close the connection, instead
@@ -266,18 +275,18 @@ export class HAPServer extends EventEmitter<Events> {
 
   listen = (port: number) => {
     this._httpServer.listen(port);
-  }
+  };
 
   stop = () => {
     this._httpServer.stop();
     clearInterval(this._keepAliveTimerID);
-  }
+  };
 
   _onKeepAliveTimerTick = () => {
     // send out a "keepalive" event which all connections automatically sign up for once pairVerify is
     // completed. The event contains no actual data, so iOS devices will simply ignore it.
-    this.notifyClients('keepalive', {characteristics: []});
-  }
+    this.notifyClients("keepalive", { characteristics: [] });
+  };
 
   /**
    * Notifies connected clients who have subscribed to a particular event.
@@ -289,43 +298,44 @@ export class HAPServer extends EventEmitter<Events> {
     // encode notification data as JSON, set content-type, and hand it off to the server.
     this._httpServer.sendEvent(event, JSON.stringify(data), "application/hap+json", excludeEvents);
     if (this._relayServer) {
-      if (event !== 'keepalive') {
+      if (event !== "keepalive") {
         this._relayServer.sendEvent(event, data, excludeEvents);
       }
     }
-  }
+  };
 
   _onListening = (port: number) => {
     this.emit(HAPServerEventTypes.LISTENING, port);
-  }
+  };
 
   // Called when an HTTP request was detected.
   _onRequest = (request: IncomingMessage, response: ServerResponse, session: Session, events: any) => {
     debug("[%s] HAP Request: %s %s", this.accessoryInfo.username, request.method, request.url);
     // collect request data, if any
     var requestData = Buffer.alloc(0);
-    request.on('data', (data) => {
+    request.on("data", data => {
       requestData = Buffer.concat([requestData, data]);
     });
-    request.on('end', () => {
+    request.on("end", () => {
       // parse request.url (which can contain querystring, etc.) into components, then extract just the path
       var pathname = url.parse(request.url!).pathname!;
       // all request data received; now process this request
       for (var path in HAPServer.handlers)
-        if (new RegExp('^' + path + '/?$').test(pathname)) { // match exact string and allow trailing slash
+        if (new RegExp("^" + path + "/?$").test(pathname)) {
+          // match exact string and allow trailing slash
           const handler = HAPServer.handlers[path] as keyof HAPServer;
           this[handler](request, response, session, events, requestData);
           return;
         }
       // nobody handled this? reply 404
       debug("[%s] WARNING: Handler for %s not implemented", this.accessoryInfo.username, request.url);
-      response.writeHead(404, "Not found", {'Content-Type': 'text/html'});
+      response.writeHead(404, "Not found", { "Content-Type": "text/html" });
       response.end();
     });
-  }
+  };
 
   _onRemoteRequest = (request: HapRequest, remoteSession: RemoteSession, session: Session, events: any) => {
-    debug('[%s] Remote Request: %s', this.accessoryInfo.username, request.messageType);
+    debug("[%s] Remote Request: %s", this.accessoryInfo.username, request.messageType);
     if (request.messageType === HapRequestMessageTypes.PAIR_VERIFY)
       this._handleRemotePairVerify(request, remoteSession, session);
     else if (request.messageType === HapRequestMessageTypes.DISCOVERY)
@@ -335,13 +345,17 @@ export class HAPServer extends EventEmitter<Events> {
     else if (request.messageType === HapRequestMessageTypes.READ_CHARACTERISTICS)
       this._handleRemoteCharacteristicsRead(request, remoteSession, session, events);
     else
-      debug('[%s] Remote Request Detail: %s', this.accessoryInfo.username, require('util').inspect(request, {
-        showHidden: false,
-        depth: null
-      }));
-  }
+      debug(
+        "[%s] Remote Request Detail: %s",
+        this.accessoryInfo.username,
+        require("util").inspect(request, {
+          showHidden: false,
+          depth: null,
+        })
+      );
+  };
 
-  _onEncrypt = (data: Buffer, encrypted: { data: Buffer; }, session: Session) => {
+  _onEncrypt = (data: Buffer, encrypted: { data: Buffer }, session: Session) => {
     // instance of HAPEncryption (created in handlePairVerifyStepOne)
     var enc = session.encryption;
     // if accessoryToControllerKey is not empty, then encryption is enabled for this connection. However, we'll
@@ -352,7 +366,7 @@ export class HAPServer extends EventEmitter<Events> {
     if (enc && enc.accessoryToControllerKey.length > 0 && enc.controllerToAccessoryCount.value > 0) {
       encrypted.data = encryption.layerEncrypt(data, enc.accessoryToControllerCount, enc.accessoryToControllerKey);
     }
-  }
+  };
 
   _onDecrypt = (data: Buffer, decrypted: { data: number | Buffer; error: Error | null }, session: Session) => {
     // possibly an instance of HAPEncryption (created in handlePairVerifyStepOne)
@@ -360,65 +374,84 @@ export class HAPServer extends EventEmitter<Events> {
     // if controllerToAccessoryKey is not empty, then encryption is enabled for this connection.
     if (enc && enc.controllerToAccessoryKey.length > 0) {
       try {
-        decrypted.data = encryption.layerDecrypt(data, enc.controllerToAccessoryCount, enc.controllerToAccessoryKey, enc.extraInfo);
+        decrypted.data = encryption.layerDecrypt(
+          data,
+          enc.controllerToAccessoryCount,
+          enc.controllerToAccessoryKey,
+          enc.extraInfo
+        );
       } catch (error) {
         decrypted.error = error;
       }
     }
-  }
+  };
 
   _onSessionClose = (sessionID: SessionIdentifier, events: any) => {
     this.emit(HAPServerEventTypes.SESSION_CLOSE, sessionID, events);
-  }
+  };
 
   /**
    * Unpaired Accessory identification.
    */
-  _handleIdentify = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: any) => {
+  _handleIdentify = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: any
+  ) => {
     // /identify only works if the accesory is not paired
     if (!this.allowInsecureRequest && this.accessoryInfo.paired()) {
-      response.writeHead(400, {"Content-Type": "application/hap+json"});
-      response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
+      response.writeHead(400, { "Content-Type": "application/hap+json" });
+      response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
       return;
     }
-    this.emit(HAPServerEventTypes.IDENTIFY, once((err: Error) => {
-      if (!err) {
-        debug("[%s] Identification success", this.accessoryInfo.username);
-        response.writeHead(204);
-        response.end();
-      } else {
-        debug("[%s] Identification error: %s", this.accessoryInfo.username, err.message);
-        response.writeHead(500);
-        response.end();
-      }
-    }));
-  }
+    this.emit(
+      HAPServerEventTypes.IDENTIFY,
+      once((err: Error) => {
+        if (!err) {
+          debug("[%s] Identification success", this.accessoryInfo.username);
+          response.writeHead(204);
+          response.end();
+        } else {
+          debug("[%s] Identification error: %s", this.accessoryInfo.username, err.message);
+          response.writeHead(500);
+          response.end();
+        }
+      })
+    );
+  };
 
   /**
    * iOS <-> Accessory pairing process.
    */
-  _handlePair = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: Buffer) => {
+  _handlePair = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: Buffer
+  ) => {
     // Can only be directly paired with one iOS device
     if (!this.allowInsecureRequest && this.accessoryInfo.paired()) {
-        response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-        response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, Codes.UNAVAILABLE));
-        return;
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, Codes.UNAVAILABLE));
+      return;
     }
     var objects = tlv.decode(requestData);
     var sequence = objects[TLVValues.SEQUENCE_NUM][0]; // value is single byte with sequence number
-    if (sequence == States.M1)
-      this._handlePairStepOne(request, response, session);
+    if (sequence == States.M1) this._handlePairStepOne(request, response, session);
     else if (sequence == States.M3 && session._pairSetupState === States.M2)
       this._handlePairStepTwo(request, response, session, objects);
     else if (sequence == States.M5 && session._pairSetupState === States.M4)
       this._handlePairStepThree(request, response, session, objects);
     else {
       // Invalid state/sequence number
-      response.writeHead(400, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(400, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, sequence + 1, TLVValues.ERROR_CODE, Codes.UNKNOWN));
       return;
     }
-  }
+  };
 
   // M1 + M2
   _handlePairStepOne = (request: IncomingMessage, response: ServerResponse, session: Session) => {
@@ -427,18 +460,29 @@ export class HAPServer extends EventEmitter<Events> {
     var srpParams = srp.params["3072"];
     srp.genKey(32, (error: Error, key: Buffer) => {
       // create a new SRP server
-      var srpServer = new srp.Server(srpParams, Buffer.from(salt), Buffer.from("Pair-Setup"), Buffer.from(this.accessoryInfo.pincode), key);
+      var srpServer = new srp.Server(
+        srpParams,
+        Buffer.from(salt),
+        Buffer.from("Pair-Setup"),
+        Buffer.from(this.accessoryInfo.pincode),
+        key
+      );
       var srpB = srpServer.computeB();
       // attach it to the current TCP session
       session.srpServer = srpServer;
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M2, TLVValues.SALT, salt, TLVValues.PUBLIC_KEY, srpB));
       session._pairSetupState = States.M2;
     });
-  }
+  };
 
   // M3 + M4
-  _handlePairStepTwo = (request: IncomingMessage, response: ServerResponse, session: Session, objects: Record<number, Buffer>) => {
+  _handlePairStepTwo = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    objects: Record<number, Buffer>
+  ) => {
     debug("[%s] Pair step 2/5", this.accessoryInfo.username);
     var A = objects[TLVValues.PUBLIC_KEY]; // "A is a public key that exists only for a single login session."
     var M1 = objects[TLVValues.PASSWORD_PROOF]; // "M1 is the proof that you actually know your own password."
@@ -450,20 +494,25 @@ export class HAPServer extends EventEmitter<Events> {
     } catch (err) {
       // most likely the client supplied an incorrect pincode.
       debug("[%s] Error while checking pincode: %s", this.accessoryInfo.username, err.message);
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
       session._pairSetupState = undefined;
       return;
     }
     // "M2 is the proof that the server actually knows your password."
     var M2 = srpServer.computeM2();
-    response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+    response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
     response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M4, TLVValues.PASSWORD_PROOF, M2));
     session._pairSetupState = States.M4;
-  }
+  };
 
   // M5-1
-  _handlePairStepThree = (request: IncomingMessage, response: ServerResponse, session: Session, objects: Record<number, Buffer>) => {
+  _handlePairStepThree = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    objects: Record<number, Buffer>
+  ) => {
     debug("[%s] Pair step 3/5", this.accessoryInfo.username);
     // pull the SRP server we created in stepOne out of the current session
     var srpServer = session.srpServer!;
@@ -477,9 +526,11 @@ export class HAPServer extends EventEmitter<Events> {
     var encInfo = Buffer.from("Pair-Setup-Encrypt-Info");
     var outputKey = hkdf.HKDF("sha512", encSalt, S_private, encInfo, 32);
     var plaintextBuffer = Buffer.alloc(messageData.length);
-    if (!encryption.verifyAndDecrypt(outputKey, Buffer.from("PS-Msg05"), messageData, authTagData, null, plaintextBuffer)) {
+    if (
+      !encryption.verifyAndDecrypt(outputKey, Buffer.from("PS-Msg05"), messageData, authTagData, null, plaintextBuffer)
+    ) {
       debug("[%s] Error while decrypting and verifying M5 subTlv: %s", this.accessoryInfo.username);
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
       session._pairSetupState = undefined;
       return;
@@ -491,10 +542,18 @@ export class HAPServer extends EventEmitter<Events> {
     var clientProof = M5Packet[TLVValues.PROOF];
     var hkdfEncKey = outputKey;
     this._handlePairStepFour(request, response, session, clientUsername, clientLTPK, clientProof, hkdfEncKey);
-  }
+  };
 
   // M5-2
-  _handlePairStepFour = (request: IncomingMessage, response: ServerResponse, session: Session, clientUsername: Buffer, clientLTPK: Buffer, clientProof: Buffer, hkdfEncKey: Buffer) => {
+  _handlePairStepFour = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    clientUsername: Buffer,
+    clientLTPK: Buffer,
+    clientProof: Buffer,
+    hkdfEncKey: Buffer
+  ) => {
     debug("[%s] Pair step 4/5", this.accessoryInfo.username);
     var S_private = session.srpServer!.computeK();
     var controllerSalt = Buffer.from("Pair-Setup-Controller-Sign-Salt");
@@ -503,16 +562,23 @@ export class HAPServer extends EventEmitter<Events> {
     var completeData = Buffer.concat([outputKey, clientUsername, clientLTPK]);
     if (!tweetnacl.sign.detached.verify(completeData, clientProof, clientLTPK)) {
       debug("[%s] Invalid signature", this.accessoryInfo.username);
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M6, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
       session._pairSetupState = undefined;
       return;
     }
     this._handlePairStepFive(request, response, session, clientUsername, clientLTPK, hkdfEncKey);
-  }
+  };
 
   // M5 - F + M6
-  _handlePairStepFive = (request: IncomingMessage, response: ServerResponse, session: Session, clientUsername: Buffer, clientLTPK: Buffer, hkdfEncKey: Buffer) => {
+  _handlePairStepFive = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    clientUsername: Buffer,
+    clientLTPK: Buffer,
+    hkdfEncKey: Buffer
+  ) => {
     debug("[%s] Pair step 5/5", this.accessoryInfo.username);
     var S_private = session.srpServer!.computeK();
     var accessorySalt = Buffer.from("Pair-Setup-Accessory-Sign-Salt");
@@ -523,45 +589,74 @@ export class HAPServer extends EventEmitter<Events> {
     var material = Buffer.concat([outputKey, usernameData, serverLTPK]);
     var privateKey = Buffer.from(this.accessoryInfo.signSk);
     var serverProof = tweetnacl.sign.detached(material, privateKey);
-    var message = tlv.encode(TLVValues.USERNAME, usernameData, TLVValues.PUBLIC_KEY, serverLTPK, TLVValues.PROOF, serverProof);
+    var message = tlv.encode(
+      TLVValues.USERNAME,
+      usernameData,
+      TLVValues.PUBLIC_KEY,
+      serverLTPK,
+      TLVValues.PROOF,
+      serverProof
+    );
     var ciphertextBuffer = Buffer.alloc(message.length);
     var macBuffer = Buffer.alloc(16);
     encryption.encryptAndSeal(hkdfEncKey, Buffer.from("PS-Msg06"), message, null, ciphertextBuffer, macBuffer);
     // finally, notify listeners that we have been paired with a client
-    this.emit(HAPServerEventTypes.PAIR, clientUsername.toString(), clientLTPK, once((err?: Error) => {
-      if (err) {
-        debug("[%s] Error adding pairing info: %s", this.accessoryInfo.username, err.message);
-        response.writeHead(500, "Server Error");
-        response.end();
+    this.emit(
+      HAPServerEventTypes.PAIR,
+      clientUsername.toString(),
+      clientLTPK,
+      once((err?: Error) => {
+        if (err) {
+          debug("[%s] Error adding pairing info: %s", this.accessoryInfo.username, err.message);
+          response.writeHead(500, "Server Error");
+          response.end();
+          session._pairSetupState = undefined;
+          return;
+        }
+        // send final pairing response to client
+        response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+        response.end(
+          tlv.encode(
+            TLVValues.SEQUENCE_NUM,
+            0x06,
+            TLVValues.ENCRYPTED_DATA,
+            Buffer.concat([ciphertextBuffer, macBuffer])
+          )
+        );
         session._pairSetupState = undefined;
-        return;
-      }
-      // send final pairing response to client
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-      response.end(tlv.encode(TLVValues.SEQUENCE_NUM, 0x06, TLVValues.ENCRYPTED_DATA, Buffer.concat([ciphertextBuffer, macBuffer])));
-      session._pairSetupState = undefined;
-    }));
-  }
+      })
+    );
+  };
 
   /**
    * iOS <-> Accessory pairing verification.
    */
-  _handlePairVerify = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: Buffer) => {
+  _handlePairVerify = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: Buffer
+  ) => {
     var objects = tlv.decode(requestData);
     var sequence = objects[TLVValues.SEQUENCE_NUM][0]; // value is single byte with sequence number
-    if (sequence == States.M1)
-      this._handlePairVerifyStepOne(request, response, session, objects);
+    if (sequence == States.M1) this._handlePairVerifyStepOne(request, response, session, objects);
     else if (sequence == States.M3 && session._pairVerifyState === States.M2)
       this._handlePairVerifyStepTwo(request, response, session, events, objects);
     else {
       // Invalid state/sequence number
-      response.writeHead(400, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(400, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, sequence + 1, TLVValues.ERROR_CODE, Codes.UNKNOWN));
       return;
     }
-  }
+  };
 
-  _handlePairVerifyStepOne = (request: IncomingMessage, response: ServerResponse, session: Session, objects: Record<number, Buffer>) => {
+  _handlePairVerifyStepOne = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    objects: Record<number, Buffer>
+  ) => {
     debug("[%s] Pair verify step 1/2", this.accessoryInfo.username);
     var clientPublicKey = objects[TLVValues.PUBLIC_KEY]; // Buffer
     // generate new encryption keys for this session
@@ -591,12 +686,27 @@ export class HAPServer extends EventEmitter<Events> {
     var ciphertextBuffer = Buffer.alloc(message.length);
     var macBuffer = Buffer.alloc(16);
     encryption.encryptAndSeal(outputKey, Buffer.from("PV-Msg02"), message, null, ciphertextBuffer, macBuffer);
-    response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-    response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M2, TLVValues.ENCRYPTED_DATA, Buffer.concat([ciphertextBuffer, macBuffer]), TLVValues.PUBLIC_KEY, publicKey));
+    response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+    response.end(
+      tlv.encode(
+        TLVValues.SEQUENCE_NUM,
+        States.M2,
+        TLVValues.ENCRYPTED_DATA,
+        Buffer.concat([ciphertextBuffer, macBuffer]),
+        TLVValues.PUBLIC_KEY,
+        publicKey
+      )
+    );
     session._pairVerifyState = States.M2;
-  }
+  };
 
-  _handlePairVerifyStepTwo = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, objects: Record<number, Buffer>) => {
+  _handlePairVerifyStepTwo = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    objects: Record<number, Buffer>
+  ) => {
     debug("[%s] Pair verify step 2/2", this.accessoryInfo.username);
     var encryptedData = objects[TLVValues.ENCRYPTED_DATA];
     var messageData = Buffer.alloc(encryptedData.length - 16);
@@ -606,9 +716,18 @@ export class HAPServer extends EventEmitter<Events> {
     var plaintextBuffer = Buffer.alloc(messageData.length);
     // instance of HAPEncryption (created in handlePairVerifyStepOne)
     var enc = session.encryption!;
-    if (!encryption.verifyAndDecrypt(enc.hkdfPairEncKey, Buffer.from("PV-Msg03"), messageData, authTagData, null, plaintextBuffer)) {
+    if (
+      !encryption.verifyAndDecrypt(
+        enc.hkdfPairEncKey,
+        Buffer.from("PV-Msg03"),
+        messageData,
+        authTagData,
+        null,
+        plaintextBuffer
+      )
+    ) {
       debug("[%s] M3: Invalid signature", this.accessoryInfo.username);
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
       session._pairVerifyState = undefined;
       return;
@@ -622,21 +741,25 @@ export class HAPServer extends EventEmitter<Events> {
     // if we're not actually paired, then there's nothing to verify - this client thinks it's paired with us but we
     // disagree. Respond with invalid request (seems to match HomeKit Accessory Simulator behavior)
     if (!clientPublicKey) {
-      debug("[%s] Client %s attempting to verify, but we are not paired; rejecting client", this.accessoryInfo.username, clientUsername);
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+      debug(
+        "[%s] Client %s attempting to verify, but we are not paired; rejecting client",
+        this.accessoryInfo.username,
+        clientUsername
+      );
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
       session._pairVerifyState = undefined;
       return;
     }
     if (!tweetnacl.sign.detached.verify(material, proof, clientPublicKey)) {
       debug("[%s] Client %s provided an invalid signature", this.accessoryInfo.username, clientUsername);
-      response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+      response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
       session._pairVerifyState = undefined;
       return;
     }
     debug("[%s] Client %s verification complete", this.accessoryInfo.username, clientUsername);
-    response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
+    response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
     response.end(tlv.encode(TLVValues.SEQUENCE_NUM, 0x04));
     // now that the client has been verified, we must "upgrade" our pesudo-HTTP connection to include
     // TCP-level encryption. We'll do this by adding some more encryption vars to the session, and using them
@@ -648,21 +771,24 @@ export class HAPServer extends EventEmitter<Events> {
     enc.controllerToAccessoryKey = hkdf.HKDF("sha512", encSalt, enc.sharedSec, infoWrite, 32);
     // Our connection is now completely setup. We now want to subscribe this connection to special
     // "keepalive" events for detecting when connections are closed by the client.
-    events['keepalive'] = true;
+    events["keepalive"] = true;
     session.establishSession(clientUsername.toString());
     session._pairVerifyState = undefined;
-  }
+  };
 
   _handleRemotePairVerify = (request: HapRequest, remoteSession: RemoteSession, session: Session) => {
     var objects = tlv.decode(request.requestBody);
     var sequence = objects[TLVValues.SEQUENCE_NUM][0]; // value is single byte with sequence number
-    if (sequence == 0x01)
-      this._handleRemotePairVerifyStepOne(request, remoteSession, session, objects);
-    else if (sequence == 0x03)
-      this._handleRemotePairVerifyStepTwo(request, remoteSession, session, objects);
-  }
+    if (sequence == 0x01) this._handleRemotePairVerifyStepOne(request, remoteSession, session, objects);
+    else if (sequence == 0x03) this._handleRemotePairVerifyStepTwo(request, remoteSession, session, objects);
+  };
 
-  _handleRemotePairVerifyStepOne = (request: HapRequest, remoteSession: RemoteSession, session: Session, objects: Record<number, Buffer>) => {
+  _handleRemotePairVerifyStepOne = (
+    request: HapRequest,
+    remoteSession: RemoteSession,
+    session: Session,
+    objects: Record<number, Buffer>
+  ) => {
     debug("[%s] Remote Pair verify step 1/2", this.accessoryInfo.username);
     var clientPublicKey = objects[TLVValues.PUBLIC_KEY]; // Buffer
     // generate new encryption keys for this session
@@ -692,11 +818,23 @@ export class HAPServer extends EventEmitter<Events> {
     var ciphertextBuffer = Buffer.alloc(message.length);
     var macBuffer = Buffer.alloc(16);
     encryption.encryptAndSeal(outputKey, Buffer.from("PV-Msg02"), message, null, ciphertextBuffer, macBuffer);
-    var response = tlv.encode(TLVValues.SEQUENCE_NUM, 0x02, TLVValues.ENCRYPTED_DATA, Buffer.concat([ciphertextBuffer, macBuffer]), TLVValues.PUBLIC_KEY, publicKey);
+    var response = tlv.encode(
+      TLVValues.SEQUENCE_NUM,
+      0x02,
+      TLVValues.ENCRYPTED_DATA,
+      Buffer.concat([ciphertextBuffer, macBuffer]),
+      TLVValues.PUBLIC_KEY,
+      publicKey
+    );
     remoteSession.responseMessage(request, response);
-  }
+  };
 
-  _handleRemotePairVerifyStepTwo = (request: HapRequest, remoteSession: RemoteSession, session: Session, objects: Record<number, Buffer>) => {
+  _handleRemotePairVerifyStepTwo = (
+    request: HapRequest,
+    remoteSession: RemoteSession,
+    session: Session,
+    objects: Record<number, Buffer>
+  ) => {
     debug("[%s] Remote Pair verify step 2/2", this.accessoryInfo.username);
     var encryptedData = objects[TLVValues.ENCRYPTED_DATA];
     var messageData = Buffer.alloc(encryptedData.length - 16);
@@ -706,7 +844,16 @@ export class HAPServer extends EventEmitter<Events> {
     var plaintextBuffer = Buffer.alloc(messageData.length);
     // instance of HAPEncryption (created in handlePairVerifyStepOne)
     var enc = session.encryption!;
-    if (!encryption.verifyAndDecrypt(enc.hkdfPairEncKey, Buffer.from("PV-Msg03"), messageData, authTagData, null, plaintextBuffer)) {
+    if (
+      !encryption.verifyAndDecrypt(
+        enc.hkdfPairEncKey,
+        Buffer.from("PV-Msg03"),
+        messageData,
+        authTagData,
+        null,
+        plaintextBuffer
+      )
+    ) {
       debug("[%s] M3: Invalid signature", this.accessoryInfo.username);
       var response = tlv.encode(TLVValues.STATE, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION);
       remoteSession.responseMessage(request, response);
@@ -721,7 +868,11 @@ export class HAPServer extends EventEmitter<Events> {
     // if we're not actually paired, then there's nothing to verify - this client thinks it's paired with us but we
     // disagree. Respond with invalid request (seems to match HomeKit Accessory Simulator behavior)
     if (!clientPublicKey) {
-      debug("[%s] Client %s attempting to verify, but we are not paired; rejecting client", this.accessoryInfo.username, clientUsername);
+      debug(
+        "[%s] Client %s attempting to verify, but we are not paired; rejecting client",
+        this.accessoryInfo.username,
+        clientUsername
+      );
       var response = tlv.encode(TLVValues.STATE, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION);
       remoteSession.responseMessage(request, response);
       return;
@@ -741,16 +892,22 @@ export class HAPServer extends EventEmitter<Events> {
     var response = tlv.encode(TLVValues.SEQUENCE_NUM, 0x04);
     remoteSession.responseMessage(request, response);
     session.establishSession(clientUsername.toString());
-  }
+  };
 
   /**
    * Pair add/remove/list
    */
-  _handlePairings = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: Buffer) => {
+  _handlePairings = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: Buffer
+  ) => {
     // Only accept /pairing request if there is a secure session
     if (!this.allowInsecureRequest && !session.authenticated) {
-      response.writeHead(470, {"Content-Type": "application/hap+json"});
-      response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
+      response.writeHead(470, { "Content-Type": "application/hap+json" });
+      response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
       return;
     }
 
@@ -767,120 +924,157 @@ export class HAPServer extends EventEmitter<Events> {
       const publicKey = objects[TLVValues.PUBLIC_KEY];
       const permissions = objects[TLVValues.PERMISSIONS][0] as PermissionTypes;
 
-      this.emit(HAPServerEventTypes.ADD_PAIRING, session, identifier, publicKey, permissions, once((errorCode: number, data?: void) => {
-        if (errorCode > 0) {
-          debug("[%s] Pairings: failed ADD_PAIRING with code %d", this.accessoryInfo.username, errorCode);
-          response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-          response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, errorCode));
-          return;
-        }
+      this.emit(
+        HAPServerEventTypes.ADD_PAIRING,
+        session,
+        identifier,
+        publicKey,
+        permissions,
+        once((errorCode: number, data?: void) => {
+          if (errorCode > 0) {
+            debug("[%s] Pairings: failed ADD_PAIRING with code %d", this.accessoryInfo.username, errorCode);
+            response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+            response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, errorCode));
+            return;
+          }
 
-        response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-        response.end(tlv.encode(TLVValues.STATE, States.M2));
-        debug("[%s] Pairings: successfully executed ADD_PAIRING", this.accessoryInfo.username);
-      }));
+          response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+          response.end(tlv.encode(TLVValues.STATE, States.M2));
+          debug("[%s] Pairings: successfully executed ADD_PAIRING", this.accessoryInfo.username);
+        })
+      );
     } else if (method === Methods.REMOVE_PAIRING) {
       const identifier = objects[TLVValues.IDENTIFIER].toString();
 
-      this.emit(HAPServerEventTypes.REMOVE_PAIRING, session, identifier, once((errorCode: number, data?: void) => {
-        if (errorCode > 0) {
-          debug("[%s] Pairings: failed REMOVE_PAIRING with code %d", this.accessoryInfo.username, errorCode);
-          response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-          response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, errorCode));
-          return;
-        }
-
-        response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-        response.end(tlv.encode(TLVValues.STATE, States.M2));
-        debug("[%s] Pairings: successfully executed REMOVE_PAIRING", this.accessoryInfo.username);
-      }));
-    } else if (method === Methods.LIST_PAIRINGS) {
-      this.emit(HAPServerEventTypes.LIST_PAIRINGS, session, once((errorCode: number, data?: PairingInformation[]) => {
-        if (errorCode > 0) {
-          debug("[%s] Pairings: failed LIST_PAIRINGS with code %d", this.accessoryInfo.username, errorCode);
-          response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-          response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, errorCode));
-          return;
-        }
-
-        const tlvList = [] as any[];
-        data!.forEach((value: PairingInformation, index: number) => {
-          if (index > 0) {
-            tlvList.push(TLVValues.SEPARATOR, Buffer.alloc(0));
+      this.emit(
+        HAPServerEventTypes.REMOVE_PAIRING,
+        session,
+        identifier,
+        once((errorCode: number, data?: void) => {
+          if (errorCode > 0) {
+            debug("[%s] Pairings: failed REMOVE_PAIRING with code %d", this.accessoryInfo.username, errorCode);
+            response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+            response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, errorCode));
+            return;
           }
 
-          tlvList.push(
-              TLVValues.IDENTIFIER, value.username,
-              TLVValues.PUBLIC_KEY, value.publicKey,
-              TLVValues.PERMISSIONS, value.permission
-          );
-        });
+          response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+          response.end(tlv.encode(TLVValues.STATE, States.M2));
+          debug("[%s] Pairings: successfully executed REMOVE_PAIRING", this.accessoryInfo.username);
+        })
+      );
+    } else if (method === Methods.LIST_PAIRINGS) {
+      this.emit(
+        HAPServerEventTypes.LIST_PAIRINGS,
+        session,
+        once((errorCode: number, data?: PairingInformation[]) => {
+          if (errorCode > 0) {
+            debug("[%s] Pairings: failed LIST_PAIRINGS with code %d", this.accessoryInfo.username, errorCode);
+            response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+            response.end(tlv.encode(TLVValues.STATE, States.M2, TLVValues.ERROR_CODE, errorCode));
+            return;
+          }
 
-        const list = tlv.encode(TLVValues.STATE, States.M2, ...tlvList);
-        response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
-        response.end(list);
-        debug("[%s] Pairings: successfully executed LIST_PAIRINGS", this.accessoryInfo.username);
-      }));
+          const tlvList = [] as any[];
+          data!.forEach((value: PairingInformation, index: number) => {
+            if (index > 0) {
+              tlvList.push(TLVValues.SEPARATOR, Buffer.alloc(0));
+            }
+
+            tlvList.push(
+              TLVValues.IDENTIFIER,
+              value.username,
+              TLVValues.PUBLIC_KEY,
+              value.publicKey,
+              TLVValues.PERMISSIONS,
+              value.permission
+            );
+          });
+
+          const list = tlv.encode(TLVValues.STATE, States.M2, ...tlvList);
+          response.writeHead(200, { "Content-Type": "application/pairing+tlv8" });
+          response.end(list);
+          debug("[%s] Pairings: successfully executed LIST_PAIRINGS", this.accessoryInfo.username);
+        })
+      );
     }
-  }
+  };
 
   /*
    * Handlers for all after-pairing communication, or the bulk of HAP.
    */
 
   // Called when the client wishes to fetch all data regarding our published Accessories.
-  _handleAccessories = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: any) => {
+  _handleAccessories = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: any
+  ) => {
     if (!this.allowInsecureRequest && !session.authenticated) {
-      response.writeHead(470, {"Content-Type": "application/hap+json"});
-      response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
+      response.writeHead(470, { "Content-Type": "application/hap+json" });
+      response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
       return;
     }
     // call out to listeners to retrieve the latest accessories JSON
-    this.emit(HAPServerEventTypes.ACCESSORIES, once((err: Error, accessories: Accessory[]) => {
-      if (err) {
-        debug("[%s] Error getting accessories: %s", this.accessoryInfo.username, err.message);
-        response.writeHead(500, "Server Error");
-        response.end();
-        return;
-      }
-      response.writeHead(200, {"Content-Type": "application/hap+json"});
-      response.end(JSON.stringify(accessories));
-    }));
-  }
+    this.emit(
+      HAPServerEventTypes.ACCESSORIES,
+      once((err: Error, accessories: Accessory[]) => {
+        if (err) {
+          debug("[%s] Error getting accessories: %s", this.accessoryInfo.username, err.message);
+          response.writeHead(500, "Server Error");
+          response.end();
+          return;
+        }
+        response.writeHead(200, { "Content-Type": "application/hap+json" });
+        response.end(JSON.stringify(accessories));
+      })
+    );
+  };
 
   _handleRemoteAccessories = (request: HapRequest, remoteSession: RemoteSession, session: Session) => {
     var deserializedRequest = JSON.parse(request.requestBody);
-    if (!deserializedRequest['attribute-database']) {
+    if (!deserializedRequest["attribute-database"]) {
       var response = {
-        'configuration-number': this.accessoryInfo.configVersion
+        "configuration-number": this.accessoryInfo.configVersion,
       };
       remoteSession.responseMessage(request, Buffer.from(JSON.stringify(response)));
     } else {
       var self = this;
       // call out to listeners to retrieve the latest accessories JSON
-      this.emit(HAPServerEventTypes.ACCESSORIES, once((err: Error, accessories: Accessory[]) => {
-        if (err) {
-          debug("[%s] Error getting accessories: %s", this.accessoryInfo.username, err.message);
-          return;
-        }
-        var response = {
-          'configuration-number': self.accessoryInfo.configVersion,
-          'attribute-database': accessories
-        };
-        remoteSession.responseMessage(request, Buffer.from(JSON.stringify(response)));
-      }));
+      this.emit(
+        HAPServerEventTypes.ACCESSORIES,
+        once((err: Error, accessories: Accessory[]) => {
+          if (err) {
+            debug("[%s] Error getting accessories: %s", this.accessoryInfo.username, err.message);
+            return;
+          }
+          var response = {
+            "configuration-number": self.accessoryInfo.configVersion,
+            "attribute-database": accessories,
+          };
+          remoteSession.responseMessage(request, Buffer.from(JSON.stringify(response)));
+        })
+      );
     }
-  }
+  };
 
   // Called when the client wishes to get or set particular characteristics
-  _handleCharacteristics = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: { length: number; toString: () => string; }) => {
+  _handleCharacteristics = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: { length: number; toString: () => string }
+  ) => {
     if (!this.allowInsecureRequest && !session.authenticated) {
-      response.writeHead(470, {"Content-Type": "application/hap+json"});
-      response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
+      response.writeHead(470, { "Content-Type": "application/hap+json" });
+      response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
       return;
     }
 
-    type Characteristics = Pick<CharacteristicData, 'aid' | 'iid'> & {
+    type Characteristics = Pick<CharacteristicData, "aid" | "iid"> & {
       status?: any;
     };
 
@@ -893,15 +1087,257 @@ export class HAPServer extends EventEmitter<Events> {
         response.end();
         return;
       }
-      var sets = (query.id as string).split(','); // ["1.9","2.14"]
+      var sets = (query.id as string).split(","); // ["1.9","2.14"]
       var data: CharacteristicData[] = []; // [{aid:1,iid:9},{aid:2,iid:14}]
       for (var i in sets) {
-        var ids = sets[i].split('.'); // ["1","9"]
+        var ids = sets[i].split("."); // ["1","9"]
         var aid = parseInt(ids[0]); // accessory ID
         var iid = parseInt(ids[1]); // instance ID (for characteristic)
-        data.push({aid: aid, iid: iid});
+        data.push({ aid: aid, iid: iid });
       }
-      this.emit(HAPServerEventTypes.GET_CHARACTERISTICS, data, events, once((err: Error, characteristics: CharacteristicData[]) => {
+      this.emit(
+        HAPServerEventTypes.GET_CHARACTERISTICS,
+        data,
+        events,
+        once((err: Error, characteristics: CharacteristicData[]) => {
+          if (!characteristics && !err)
+            err = new Error("characteristics not supplied by the get-characteristics event callback");
+          if (err) {
+            debug("[%s] Error getting characteristics: %s", this.accessoryInfo.username, err.stack);
+            // rewrite characteristics array to include error status for each characteristic requested
+            characteristics = [];
+            for (var i in data) {
+              characteristics.push({
+                aid: data[i].aid,
+                iid: data[i].iid,
+                status: Status.SERVICE_COMMUNICATION_FAILURE,
+              });
+            }
+          }
+
+          let errorOccurred = false;
+          for (let i = 0; i < characteristics.length; i++) {
+            const value = characteristics[i];
+            if ((value.status !== undefined && value.status !== 0) || (value.s !== undefined && value.s !== 0)) {
+              errorOccurred = true;
+              break;
+            }
+          }
+
+          // 207 "multi-status" is returned when an error occurs reading a characteristic. otherwise 200 is returned
+          response.writeHead(errorOccurred ? 207 : 200, { "Content-Type": "application/hap+json" });
+          response.end(JSON.stringify({ characteristics: characteristics }));
+        }),
+        false,
+        session
+      );
+    } else if (request.method == "PUT") {
+      if (!session.authenticated) {
+        if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
+          response.writeHead(470, { "Content-Type": "application/hap+json" });
+          response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
+          return;
+        }
+      }
+      if (requestData.length == 0) {
+        response.writeHead(400, { "Content-Type": "application/hap+json" });
+        response.end(JSON.stringify({ status: Status.INVALID_VALUE_IN_REQUEST }));
+        return;
+      }
+      // requestData is a JSON payload like { characteristics: [ { aid: 1, iid: 8, value: true, ev: true } ] }
+      var writeRequest = JSON.parse(requestData.toString()) as CharacteristicsWriteRequest;
+      var data = writeRequest.characteristics; // pull out characteristics array
+      // call out to listeners to retrieve the latest accessories JSON
+      this.emit(
+        HAPServerEventTypes.SET_CHARACTERISTICS,
+        writeRequest,
+        events,
+        once((err: Error, characteristics: CharacteristicData[]) => {
+          if (err) {
+            debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
+            // rewrite characteristics array to include error status for each characteristic requested
+            characteristics = [];
+            for (var i in data) {
+              characteristics.push({
+                aid: data[i].aid,
+                iid: data[i].iid,
+                // @ts-ignore
+                status: Status.SERVICE_COMMUNICATION_FAILURE,
+              });
+            }
+          }
+
+          let multiStatus = false;
+          for (let i = 0; i < characteristics.length; i++) {
+            const characteristic = characteristics[i];
+            if (
+              (characteristic.status !== undefined && characteristic.status !== 0) ||
+              (characteristic.s !== undefined && characteristic.s !== 0) ||
+              characteristic.value !== undefined
+            ) {
+              // also send multiStatus on write response requests
+              multiStatus = true;
+              break;
+            }
+          }
+
+          if (multiStatus) {
+            // 207 is "multi-status" since HomeKit may be setting multiple things and any one can fail independently
+            response.writeHead(207, { "Content-Type": "application/hap+json" });
+            response.end(JSON.stringify({ characteristics: characteristics }));
+          } else {
+            // if everything went fine send 204 no content response
+            response.writeHead(204); // 204 "No content"
+            response.end();
+          }
+        }),
+        false,
+        session
+      );
+    }
+  };
+
+  // Called when controller requests a timed write
+  _prepareWrite = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: { length: number; toString: () => string }
+  ) => {
+    if (!this.allowInsecureRequest && !session.authenticated) {
+      response.writeHead(470, { "Content-Type": "application/hap+json" });
+      response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
+      return;
+    }
+
+    if (request.method == "PUT") {
+      if (requestData.length == 0) {
+        response.writeHead(400, { "Content-Type": "application/hap+json" });
+        response.end(JSON.stringify({ status: Status.INVALID_VALUE_IN_REQUEST }));
+        return;
+      }
+
+      const data = JSON.parse(requestData.toString()) as PrepareWriteRequest;
+
+      if (data.pid && data.ttl) {
+        debug(
+          "[%s] Received prepare write request with pid %d and ttl %d",
+          this.accessoryInfo.username,
+          data.pid,
+          data.ttl
+        );
+
+        if (session.timedWriteTimeout)
+          // clear any currently existing timeouts
+          clearTimeout(session.timedWriteTimeout);
+
+        session.timedWritePid = data.pid;
+        session.timedWriteTimeout = setTimeout(() => {
+          debug("[%s] Timed write request timed out for pid %d", this.accessoryInfo.username, data.pid);
+          session.timedWritePid = undefined;
+          session.timedWriteTimeout = undefined;
+        }, data.ttl);
+
+        response.writeHead(200, { "Content-Type": "application/hap+json" });
+        response.end(JSON.stringify({ status: Status.SUCCESS }));
+        return;
+      }
+    }
+  };
+
+  // Called when controller request snapshot
+  _handleResource = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any,
+    requestData: { length: number; toString: () => string }
+  ) => {
+    if (!this.allowInsecureRequest && !session.authenticated) {
+      response.writeHead(470, { "Content-Type": "application/hap+json" });
+      response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
+      return;
+    }
+    if (request.method == "POST") {
+      if (!session.authenticated) {
+        if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
+          response.writeHead(470, { "Content-Type": "application/hap+json" });
+          response.end(JSON.stringify({ status: Status.INSUFFICIENT_PRIVILEGES }));
+          return;
+        }
+      }
+      if (requestData.length == 0) {
+        response.writeHead(400, { "Content-Type": "application/hap+json" });
+        response.end(JSON.stringify({ status: Status.INVALID_VALUE_IN_REQUEST }));
+        return;
+      }
+      // requestData is a JSON payload
+      var data = JSON.parse(requestData.toString());
+      // call out to listeners to retrieve the resource, snapshot only right now
+      this.emit(
+        HAPServerEventTypes.REQUEST_RESOURCE,
+        data,
+        once((err: Error, resource: any) => {
+          if (err) {
+            debug("[%s] Error getting snapshot: %s", this.accessoryInfo.username, err.message);
+            response.writeHead(405);
+            response.end();
+          } else {
+            response.writeHead(200, { "Content-Type": "image/jpeg" });
+            response.end(resource);
+          }
+        })
+      );
+    } else {
+      response.writeHead(405);
+      response.end();
+    }
+  };
+
+  _handleRemoteCharacteristicsWrite = (
+    request: HapRequest,
+    remoteSession: RemoteSession,
+    session: Session,
+    events: any
+  ) => {
+    var data = JSON.parse(request.requestBody.toString());
+    // call out to listeners to retrieve the latest accessories JSON
+    this.emit(
+      HAPServerEventTypes.SET_CHARACTERISTICS,
+      data,
+      events,
+      once((err: Error, characteristics: CharacteristicData[]) => {
+        if (err) {
+          debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
+          // rewrite characteristics array to include error status for each characteristic requested
+          characteristics = [];
+          for (var i in data) {
+            characteristics.push({
+              aid: data[i].aid,
+              iid: data[i].iid,
+              s: Status.SERVICE_COMMUNICATION_FAILURE,
+            } as any);
+          }
+        }
+        remoteSession.responseMessage(request, Buffer.from(JSON.stringify(characteristics)));
+      }),
+      true
+    );
+  };
+
+  _handleRemoteCharacteristicsRead = (
+    request: HapRequest,
+    remoteSession: RemoteSession,
+    session: Session,
+    events: any
+  ) => {
+    var data = JSON.parse(request.requestBody.toString());
+    this.emit(
+      HAPServerEventTypes.GET_CHARACTERISTICS,
+      data,
+      events,
+      (err: Error, characteristics: CharacteristicData[]) => {
         if (!characteristics && !err)
           err = new Error("characteristics not supplied by the get-characteristics event callback");
         if (err) {
@@ -912,213 +1348,29 @@ export class HAPServer extends EventEmitter<Events> {
             characteristics.push({
               aid: data[i].aid,
               iid: data[i].iid,
-              status: Status.SERVICE_COMMUNICATION_FAILURE
-            });
+              s: Status.SERVICE_COMMUNICATION_FAILURE,
+            } as any);
           }
         }
-
-        let errorOccurred = false;
-        for (let i = 0; i < characteristics.length; i++) {
-          const value = characteristics[i];
-          if ((value.status !== undefined && value.status !== 0)
-              || (value.s !== undefined && value.s !== 0)) {
-            errorOccurred = true;
-            break;
-          }
-        }
-
-        // 207 "multi-status" is returned when an error occurs reading a characteristic. otherwise 200 is returned
-        response.writeHead(errorOccurred? 207: 200, {"Content-Type": "application/hap+json"});
-        response.end(JSON.stringify({characteristics: characteristics}));
-      }), false, session);
-    } else if (request.method == "PUT") {
-      if (!session.authenticated) {
-        if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
-          response.writeHead(470, {"Content-Type": "application/hap+json"});
-          response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
-          return;
-        }
-      }
-      if (requestData.length == 0) {
-        response.writeHead(400, {"Content-Type": "application/hap+json"});
-        response.end(JSON.stringify({status: Status.INVALID_VALUE_IN_REQUEST}));
-        return;
-      }
-      // requestData is a JSON payload like { characteristics: [ { aid: 1, iid: 8, value: true, ev: true } ] }
-      var writeRequest = JSON.parse(requestData.toString()) as CharacteristicsWriteRequest;
-      var data = writeRequest.characteristics; // pull out characteristics array
-      // call out to listeners to retrieve the latest accessories JSON
-      this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, writeRequest, events, once((err: Error, characteristics: CharacteristicData[]) => {
-        if (err) {
-          debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
-          // rewrite characteristics array to include error status for each characteristic requested
-          characteristics = [];
-          for (var i in data) {
-            characteristics.push({
-              aid: data[i].aid,
-              iid: data[i].iid,
-              // @ts-ignore
-              status: Status.SERVICE_COMMUNICATION_FAILURE
-            });
-          }
-        }
-
-        let multiStatus = false;
-        for (let i = 0; i < characteristics.length; i++) {
-          const characteristic = characteristics[i];
-          if ((characteristic.status !== undefined && characteristic.status !== 0)
-              || (characteristic.s !== undefined && characteristic.s !== 0)
-              || characteristic.value !== undefined) { // also send multiStatus on write response requests
-            multiStatus = true;
-            break;
-          }
-        }
-
-        if (multiStatus) {
-          // 207 is "multi-status" since HomeKit may be setting multiple things and any one can fail independently
-          response.writeHead(207, {"Content-Type": "application/hap+json"});
-          response.end(JSON.stringify({characteristics: characteristics}));
-        } else {
-          // if everything went fine send 204 no content response
-          response.writeHead(204); // 204 "No content"
-          response.end();
-        }
-      }), false, session);
-    }
-  }
-
-  // Called when controller requests a timed write
-  _prepareWrite = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: { length: number; toString: () => string; }) => {
-    if (!this.allowInsecureRequest && !session.authenticated) {
-      response.writeHead(470, {"Content-Type": "application/hap+json"});
-      response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
-      return;
-    }
-
-    if (request.method == "PUT") {
-      if (requestData.length == 0) {
-        response.writeHead(400, {"Content-Type": "application/hap+json"});
-        response.end(JSON.stringify({status: Status.INVALID_VALUE_IN_REQUEST}));
-        return;
-      }
-
-      const data = JSON.parse(requestData.toString()) as PrepareWriteRequest;
-
-      if (data.pid && data.ttl) {
-        debug("[%s] Received prepare write request with pid %d and ttl %d", this.accessoryInfo.username, data.pid, data.ttl);
-
-        if (session.timedWriteTimeout) // clear any currently existing timeouts
-          clearTimeout(session.timedWriteTimeout);
-
-        session.timedWritePid = data.pid;
-        session.timedWriteTimeout = setTimeout(() => {
-          debug("[%s] Timed write request timed out for pid %d", this.accessoryInfo.username, data.pid);
-          session.timedWritePid = undefined;
-          session.timedWriteTimeout = undefined;
-        }, data.ttl);
-
-        response.writeHead(200, {"Content-Type": "application/hap+json"});
-        response.end(JSON.stringify({status: Status.SUCCESS}));
-        return;
-      }
-    }
+        remoteSession.responseMessage(request, Buffer.from(JSON.stringify(characteristics)));
+      },
+      true
+    );
   };
-
-  // Called when controller request snapshot
-  _handleResource = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: { length: number; toString: () => string; }) => {
-    if (!this.allowInsecureRequest && !session.authenticated) {
-      response.writeHead(470, {"Content-Type": "application/hap+json"});
-      response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
-      return;
-    }
-    if (request.method == "POST") {
-      if (!session.authenticated) {
-        if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
-          response.writeHead(470, {"Content-Type": "application/hap+json"});
-          response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
-          return;
-        }
-      }
-      if (requestData.length == 0) {
-        response.writeHead(400, {"Content-Type": "application/hap+json"});
-        response.end(JSON.stringify({status: Status.INVALID_VALUE_IN_REQUEST}));
-        return;
-      }
-      // requestData is a JSON payload
-      var data = JSON.parse(requestData.toString());
-      // call out to listeners to retrieve the resource, snapshot only right now
-      this.emit(HAPServerEventTypes.REQUEST_RESOURCE, data, once((err: Error, resource: any) => {
-        if (err) {
-          debug("[%s] Error getting snapshot: %s", this.accessoryInfo.username, err.message);
-          response.writeHead(405);
-          response.end();
-        } else {
-          response.writeHead(200, {"Content-Type": "image/jpeg"});
-          response.end(resource);
-        }
-      }));
-    } else {
-      response.writeHead(405);
-      response.end();
-    }
-  }
-
-  _handleRemoteCharacteristicsWrite = (request: HapRequest, remoteSession: RemoteSession, session: Session, events: any) => {
-    var data = JSON.parse(request.requestBody.toString());
-    // call out to listeners to retrieve the latest accessories JSON
-    this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, data, events, once((err: Error, characteristics: CharacteristicData[]) => {
-      if (err) {
-        debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
-        // rewrite characteristics array to include error status for each characteristic requested
-        characteristics = [];
-        for (var i in data) {
-          characteristics.push({
-            aid: data[i].aid,
-            iid: data[i].iid,
-            s: Status.SERVICE_COMMUNICATION_FAILURE
-          } as any);
-        }
-      }
-      remoteSession.responseMessage(request, Buffer.from(JSON.stringify(characteristics)));
-    }), true);
-  }
-
-  _handleRemoteCharacteristicsRead = (request: HapRequest, remoteSession: RemoteSession, session: Session, events: any) => {
-    var data = JSON.parse(request.requestBody.toString());
-    this.emit(HAPServerEventTypes.GET_CHARACTERISTICS, data, events, (err: Error, characteristics: CharacteristicData[]) => {
-      if (!characteristics && !err)
-        err = new Error("characteristics not supplied by the get-characteristics event callback");
-      if (err) {
-        debug("[%s] Error getting characteristics: %s", this.accessoryInfo.username, err.stack);
-        // rewrite characteristics array to include error status for each characteristic requested
-        characteristics = [];
-        for (var i in data) {
-          characteristics.push({
-            aid: data[i].aid,
-            iid: data[i].iid,
-            s: Status.SERVICE_COMMUNICATION_FAILURE
-          } as any);
-        }
-      }
-      remoteSession.responseMessage(request, Buffer.from(JSON.stringify(characteristics)));
-    }, true);
-  }
 }
-
 
 /**
  * Simple struct to hold vars needed to support HAP encryption.
  */
 
 export class HAPEncryption {
-
   clientPublicKey: Buffer;
   secretKey: Buffer;
   publicKey: Buffer;
   sharedSec: Buffer;
   hkdfPairEncKey: Buffer;
-  accessoryToControllerCount: { value: number; };
-  controllerToAccessoryCount: { value: number; };
+  accessoryToControllerCount: { value: number };
+  controllerToAccessoryCount: { value: number };
   accessoryToControllerKey: Buffer;
   controllerToAccessoryKey: Buffer;
   extraInfo: Record<string, any>;

--- a/src/lib/HomeKitRemoteController.ts
+++ b/src/lib/HomeKitRemoteController.ts
@@ -1,259 +1,250 @@
-import * as tlv from './util/tlv';
-import createDebug from 'debug';
-import assert from 'assert';
+import * as tlv from "./util/tlv";
+import createDebug from "debug";
+import assert from "assert";
 
-import {Service} from "./Service";
+import { Service } from "./Service";
 import {
-    Characteristic,
-    CharacteristicEventTypes,
-    CharacteristicGetCallback,
-    CharacteristicSetCallback
+  Characteristic,
+  CharacteristicEventTypes,
+  CharacteristicGetCallback,
+  CharacteristicSetCallback,
 } from "./Characteristic";
-import {CharacteristicValue} from "../types";
-import {Status} from "./HAPServer";
-import {Accessory, AccessoryEventTypes} from "./Accessory";
+import { CharacteristicValue } from "../types";
+import { Status } from "./HAPServer";
+import { Accessory, AccessoryEventTypes } from "./Accessory";
 import {
-    DataSendCloseReason,
-    DataStreamConnection,
-    DataStreamConnectionEvents,
-    DataStreamManagement,
-    DataStreamProtocolHandler,
-    DataStreamServerEvents,
-    EventHandler,
-    Float32, HDSStatus,
-    Int64,
-    Protocols,
-    RequestHandler,
-    Topics
+  DataSendCloseReason,
+  DataStreamConnection,
+  DataStreamConnectionEvents,
+  DataStreamManagement,
+  DataStreamProtocolHandler,
+  DataStreamServerEvents,
+  EventHandler,
+  Float32,
+  HDSStatus,
+  Int64,
+  Protocols,
+  RequestHandler,
+  Topics,
 } from "./datastream";
 import {
-    AudioCodecParamBitRateTypes,
-    AudioCodecParamSampleRateTypes,
-    AudioCodecParamTypes,
-    AudioCodecTypes,
-    AudioTypes
+  AudioCodecParamBitRateTypes,
+  AudioCodecParamSampleRateTypes,
+  AudioCodecParamTypes,
+  AudioCodecTypes,
+  AudioTypes,
 } from "./StreamController";
-import {EventEmitter} from "./EventEmitter";
-import {HAPSessionEvents, Session} from "./util/eventedhttp";
+import { EventEmitter } from "./EventEmitter";
+import { HAPSessionEvents, Session } from "./util/eventedhttp";
 import Timeout = NodeJS.Timeout;
 
-const debug = createDebug('Remote:Controller');
+const debug = createDebug("Remote:Controller");
 
 export enum TargetControlCommands {
-    MAXIMUM_TARGETS = 0x01,
-    TICKS_PER_SECOND = 0x02,
-    SUPPORTED_BUTTON_CONFIGURATION = 0x03,
-    TYPE = 0x04
+  MAXIMUM_TARGETS = 0x01,
+  TICKS_PER_SECOND = 0x02,
+  SUPPORTED_BUTTON_CONFIGURATION = 0x03,
+  TYPE = 0x04,
 }
 
 export enum SupportedButtonConfigurationTypes {
-    BUTTON_ID = 0x01,
-    BUTTON_TYPE = 0x02
+  BUTTON_ID = 0x01,
+  BUTTON_TYPE = 0x02,
 }
 
 export enum ButtonType {
-    UNDEFINED = 0x00,
-    MENU = 0x01,
-    PLAY_PAUSE = 0x02,
-    TV_HOME = 0x03,
-    SELECT = 0x04,
-    ARROW_UP = 0x05,
-    ARROW_RIGHT = 0x06,
-    ARROW_DOWN = 0x07,
-    ARROW_LEFT = 0x08,
-    VOLUME_UP = 0x09,
-    VOLUME_DOWN = 0x0A,
-    SIRI = 0x0B,
-    POWER = 0x0C,
-    GENERIC = 0x0D
+  UNDEFINED = 0x00,
+  MENU = 0x01,
+  PLAY_PAUSE = 0x02,
+  TV_HOME = 0x03,
+  SELECT = 0x04,
+  ARROW_UP = 0x05,
+  ARROW_RIGHT = 0x06,
+  ARROW_DOWN = 0x07,
+  ARROW_LEFT = 0x08,
+  VOLUME_UP = 0x09,
+  VOLUME_DOWN = 0x0a,
+  SIRI = 0x0b,
+  POWER = 0x0c,
+  GENERIC = 0x0d,
 }
 
-
 export enum TargetControlList {
-    OPERATION = 0x01,
-    TARGET_CONFIGURATION = 0x02
+  OPERATION = 0x01,
+  TARGET_CONFIGURATION = 0x02,
 }
 
 export enum Operation {
-    UNDEFINED = 0x00,
-    LIST = 0x01,
-    ADD = 0x02,
-    REMOVE = 0x03,
-    RESET = 0x04,
-    UPDATE = 0x05
+  UNDEFINED = 0x00,
+  LIST = 0x01,
+  ADD = 0x02,
+  REMOVE = 0x03,
+  RESET = 0x04,
+  UPDATE = 0x05,
 }
 
 export enum TargetConfigurationTypes {
-    TARGET_IDENTIFIER = 0x01,
-    TARGET_NAME = 0x02,
-    TARGET_CATEGORY = 0x03,
-    BUTTON_CONFIGURATION = 0x04
+  TARGET_IDENTIFIER = 0x01,
+  TARGET_NAME = 0x02,
+  TARGET_CATEGORY = 0x03,
+  BUTTON_CONFIGURATION = 0x04,
 }
 
 export enum TargetCategory {
-    UNDEFINED = 0x00,
-    APPLE_TV = 0x18
+  UNDEFINED = 0x00,
+  APPLE_TV = 0x18,
 }
 
 export enum ButtonConfigurationTypes {
-    BUTTON_ID = 0x01,
-    BUTTON_TYPE = 0x02,
-    BUTTON_NAME = 0x03,
+  BUTTON_ID = 0x01,
+  BUTTON_TYPE = 0x02,
+  BUTTON_NAME = 0x03,
 }
 
 export enum ButtonEvent {
-    BUTTON_ID = 0x01,
-    BUTTON_STATE = 0x02,
-    TIMESTAMP = 0x03,
-    ACTIVE_IDENTIFIER = 0x04,
+  BUTTON_ID = 0x01,
+  BUTTON_STATE = 0x02,
+  TIMESTAMP = 0x03,
+  ACTIVE_IDENTIFIER = 0x04,
 }
 
 export enum ButtonState {
-    UP = 0x00,
-    DOWN = 0x01
+  UP = 0x00,
+  DOWN = 0x01,
 }
-
 
 export type SupportedConfiguration = {
-    maximumTargets: number,
-    ticksPerSecond: number,
-    supportedButtonConfiguration: SupportedButtonConfiguration[],
-    hardwareImplemented: boolean
-}
+  maximumTargets: number;
+  ticksPerSecond: number;
+  supportedButtonConfiguration: SupportedButtonConfiguration[];
+  hardwareImplemented: boolean;
+};
 
 export type SupportedButtonConfiguration = {
-    buttonID: number,
-    buttonType: ButtonType
-}
+  buttonID: number;
+  buttonType: ButtonType;
+};
 
 export type TargetConfiguration = {
-    targetIdentifier: number,
-    targetName?: string, // on Operation.UPDATE targetName is left out
-    targetCategory?: TargetCategory, // on Operation.UPDATE targetCategory is left out
-    buttonConfiguration: Record<number, ButtonConfiguration> // button configurations indexed by their ID
-}
+  targetIdentifier: number;
+  targetName?: string; // on Operation.UPDATE targetName is left out
+  targetCategory?: TargetCategory; // on Operation.UPDATE targetCategory is left out
+  buttonConfiguration: Record<number, ButtonConfiguration>; // button configurations indexed by their ID
+};
 
 export type ButtonConfiguration = {
-    buttonID: number,
-    buttonType: ButtonType,
-    buttonName?: string
-}
-
+  buttonID: number;
+  buttonType: ButtonType;
+  buttonName?: string;
+};
 
 export enum SiriInputType {
-    PUSH_BUTTON_TRIGGERED_APPLE_TV = 0,
+  PUSH_BUTTON_TRIGGERED_APPLE_TV = 0,
 }
 
-
 export enum SupportedAudioStreamConfigurationTypes {
-    AUDIO_CODEC_CONFIGURATION = 0x01,
-    COMFORT_NOISE_SUPPORT = 0x02,
+  AUDIO_CODEC_CONFIGURATION = 0x01,
+  COMFORT_NOISE_SUPPORT = 0x02,
 }
 
 export enum SelectedAudioInputStreamConfigurationTypes {
-    SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION = 0x01,
+  SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION = 0x01,
 }
 
 export type SupportedAudioStreamConfiguration = {
-    audioCodecConfiguration: AudioCodecConfiguration,
-}
+  audioCodecConfiguration: AudioCodecConfiguration;
+};
 
 export type SelectedAudioStreamConfiguration = {
-    audioCodecConfiguration: AudioCodecConfiguration,
-}
+  audioCodecConfiguration: AudioCodecConfiguration;
+};
 
 export type AudioCodecConfiguration = {
-    codecType: AudioCodecTypes,
-    parameters: AudioCodecParameters,
-}
+  codecType: AudioCodecTypes;
+  parameters: AudioCodecParameters;
+};
 
 export type AudioCodecParameters = {
-    channels: number, // number of audio channels, default is 1
-    bitrate: AudioCodecParamBitRateTypes,
-    samplerate: AudioCodecParamSampleRateTypes,
-    rtpTime?: RTPTime, // only present in SelectedAudioCodecParameters TLV
-}
+  channels: number; // number of audio channels, default is 1
+  bitrate: AudioCodecParamBitRateTypes;
+  samplerate: AudioCodecParamSampleRateTypes;
+  rtpTime?: RTPTime; // only present in SelectedAudioCodecParameters TLV
+};
 
 export type RTPTime = 20 | 30 | 40 | 60;
 
-
 export enum SiriAudioSessionState {
-    STARTING = 0, // we are currently waiting for a response for the start request
-    SENDING = 1, // we are sending data
-    CLOSING = 2, // we are currently waiting for the acknowledgment event
-    CLOSED = 3, // the close event was sent
+  STARTING = 0, // we are currently waiting for a response for the start request
+  SENDING = 1, // we are sending data
+  CLOSING = 2, // we are currently waiting for the acknowledgment event
+  CLOSED = 3, // the close event was sent
 }
 
 export type DataSendMessageData = {
-    packets: AudioFramePacket[],
-    streamId: Int64,
-    endOfStream: boolean,
-}
+  packets: AudioFramePacket[];
+  streamId: Int64;
+  endOfStream: boolean;
+};
 
 export type AudioFrame = {
-    data: Buffer,
-    rms: number, // root mean square
-}
+  data: Buffer;
+  rms: number; // root mean square
+};
 
 export type AudioFramePacket = {
-    data: Buffer,
-    metadata: {
-        rms: Float32, // root mean square
-        sequenceNumber: Int64,
-    },
-}
-
+  data: Buffer;
+  metadata: {
+    rms: Float32; // root mean square
+    sequenceNumber: Int64;
+  };
+};
 
 export type FrameHandler = (frame: AudioFrame) => void;
 export type ErrorHandler = (error: DataSendCloseReason) => void;
 
 export interface SiriAudioStreamProducer {
+  startAudioProduction(selectedAudioConfiguration: AudioCodecConfiguration): void;
 
-    startAudioProduction(selectedAudioConfiguration: AudioCodecConfiguration): void;
-
-    stopAudioProduction(): void;
-
+  stopAudioProduction(): void;
 }
 
 export interface SiriAudioStreamProducerConstructor {
-
-    /**
-     * Creates a new instance of a SiriAudioStreamProducer
-     *
-     * @param frameHandler {FrameHandler} - called for every opus frame recorded
-     * @param errorHandler {ErrorHandler} - should be called with a appropriate reason when the producing process errored
-     * @param options - optional parameter for passing any configuration related options
-     */
-    new(frameHandler: FrameHandler, errorHandler: ErrorHandler, options?: any): SiriAudioStreamProducer;
-
+  /**
+   * Creates a new instance of a SiriAudioStreamProducer
+   *
+   * @param frameHandler {FrameHandler} - called for every opus frame recorded
+   * @param errorHandler {ErrorHandler} - should be called with a appropriate reason when the producing process errored
+   * @param options - optional parameter for passing any configuration related options
+   */
+  new (frameHandler: FrameHandler, errorHandler: ErrorHandler, options?: any): SiriAudioStreamProducer;
 }
 
 export enum RemoteControllerEvents {
-    ACTIVE_CHANGE = "active-change",
-    ACTIVE_IDENTIFIER_CHANGE = "active-identifier-change",
+  ACTIVE_CHANGE = "active-change",
+  ACTIVE_IDENTIFIER_CHANGE = "active-identifier-change",
 
-    TARGET_ADDED = "target-add",
-    TARGET_UPDATED = "target-update",
-    TARGET_REMOVED = "target-remove",
-    TARGETS_RESET = "targets-reset",
+  TARGET_ADDED = "target-add",
+  TARGET_UPDATED = "target-update",
+  TARGET_REMOVED = "target-remove",
+  TARGETS_RESET = "targets-reset",
 }
 
 export enum TargetUpdates {
-    NAME,
-    CATEGORY,
-    UPDATED_BUTTONS,
-    REMOVED_BUTTONS,
+  NAME,
+  CATEGORY,
+  UPDATED_BUTTONS,
+  REMOVED_BUTTONS,
 }
 
 export type RemoteControllerEventMap = {
-    [RemoteControllerEvents.ACTIVE_CHANGE]: (active: boolean) => void;
-    [RemoteControllerEvents.ACTIVE_IDENTIFIER_CHANGE]: (activeIdentifier: number) => void;
+  [RemoteControllerEvents.ACTIVE_CHANGE]: (active: boolean) => void;
+  [RemoteControllerEvents.ACTIVE_IDENTIFIER_CHANGE]: (activeIdentifier: number) => void;
 
-    [RemoteControllerEvents.TARGET_ADDED]: (targetConfiguration: TargetConfiguration) => void;
-    [RemoteControllerEvents.TARGET_UPDATED]: (targetConfiguration: TargetConfiguration, updates: TargetUpdates[]) => void;
-    [RemoteControllerEvents.TARGET_REMOVED]: (targetIdentifier: number) => void;
-    [RemoteControllerEvents.TARGETS_RESET]: () => void;
-}
+  [RemoteControllerEvents.TARGET_ADDED]: (targetConfiguration: TargetConfiguration) => void;
+  [RemoteControllerEvents.TARGET_UPDATED]: (targetConfiguration: TargetConfiguration, updates: TargetUpdates[]) => void;
+  [RemoteControllerEvents.TARGET_REMOVED]: (targetIdentifier: number) => void;
+  [RemoteControllerEvents.TARGETS_RESET]: () => void;
+};
 
 /**
  * Handles everything need to implement a fully working HomeKit remote controller.
@@ -285,1155 +276,1264 @@ export type RemoteControllerEventMap = {
  *        With this event every configuration made should be reset. This event is also called
  *        when the accessory gets unpaired.
  */
-export class HomeKitRemoteController extends EventEmitter<RemoteControllerEventMap> implements DataStreamProtocolHandler {
+export class HomeKitRemoteController extends EventEmitter<RemoteControllerEventMap>
+  implements DataStreamProtocolHandler {
+  audioSupported: boolean;
+  audioProducerConstructor?: SiriAudioStreamProducerConstructor;
+  audioProducerOptions?: any;
 
-    audioSupported: boolean;
-    audioProducerConstructor?: SiriAudioStreamProducerConstructor;
-    audioProducerOptions?: any;
+  accessoryConfigured: boolean = false;
+  targetControlManagementService?: Service;
+  targetControlService?: Service;
 
-    accessoryConfigured: boolean = false;
-    targetControlManagementService?: Service;
-    targetControlService?: Service;
+  siriService?: Service;
+  audioStreamManagementService?: Service;
+  dataStreamManagement?: DataStreamManagement;
 
-    siriService?: Service;
-    audioStreamManagementService?: Service;
-    dataStreamManagement?: DataStreamManagement;
-
-    private buttons: Record<number, number> = {}; // internal mapping of buttonId to buttonType for supported buttons
-    private readonly supportedConfiguration: string;
-    /*
+  private buttons: Record<number, number> = {}; // internal mapping of buttonId to buttonType for supported buttons
+  private readonly supportedConfiguration: string;
+  /*
         It is advice to persistently store this configuration below, but HomeKit seems to just reconfigure itself
         after an reboot of the accessory.
         If someone has the time to implement persistent storage 'activeIdentifier' and 'active'
         should probably be included as well. Also a check at startup if we are still paired could be useful :thinking:
      */
-    targetConfigurations: Record<number, TargetConfiguration> = {};
-    private  targetConfigurationsString: string = "";
+  targetConfigurations: Record<number, TargetConfiguration> = {};
+  private targetConfigurationsString: string = "";
 
-    private lastButtonEvent: string = "";
+  private lastButtonEvent: string = "";
 
-    activeIdentifier: number = 0; // id of 0 means no device selected
-    private activeSession?: Session; // session which marked this remote as active and listens for events and siri
-    private activeSessionDisconnectionListener?: () => void;
+  activeIdentifier: number = 0; // id of 0 means no device selected
+  private activeSession?: Session; // session which marked this remote as active and listens for events and siri
+  private activeSessionDisconnectionListener?: () => void;
 
-    supportedAudioConfiguration: string;
-    selectedAudioConfiguration: AudioCodecConfiguration;
-    selectedAudioConfigurationString: string;
+  supportedAudioConfiguration: string;
+  selectedAudioConfiguration: AudioCodecConfiguration;
+  selectedAudioConfigurationString: string;
 
-    dataStreamConnections: Record<number, DataStreamConnection> = {}; // maps targetIdentifiers to active data stream connections
-    activeAudioSession?: SiriAudioSession;
-    nextAudioSession?: SiriAudioSession;
+  dataStreamConnections: Record<number, DataStreamConnection> = {}; // maps targetIdentifiers to active data stream connections
+  activeAudioSession?: SiriAudioSession;
+  nextAudioSession?: SiriAudioSession;
 
-    eventHandler?: Record<string, EventHandler>;
-    requestHandler?: Record<string, RequestHandler>;
+  eventHandler?: Record<string, EventHandler>;
+  requestHandler?: Record<string, RequestHandler>;
 
-    /**
-     * Creates a new HomeKitRemoteController.
-     * If siri voice input is supported the constructor to an SiriAudioStreamProducer needs to be supplied.
-     * Otherwise a remote without voice support will be created.
-     *
-     * For every audio session a new SiriAudioStreamProducer will be constructed.
-     *
-     * @param audioProducerConstructor {SiriAudioStreamProducerConstructor} - constructor for a SiriAudioStreamProducer
-     * @param producerOptions - if supplied this argument will be supplied as third argument of the SiriAudioStreamProducer
-     *                          constructor. This should be used to supply configurations to the stream producer.
-     */
-    constructor(audioProducerConstructor?: SiriAudioStreamProducerConstructor, producerOptions?: any) {
-        super();
-        this.audioSupported = audioProducerConstructor !== undefined;
-        this.audioProducerConstructor = audioProducerConstructor;
-        this.audioProducerOptions = producerOptions;
+  /**
+   * Creates a new HomeKitRemoteController.
+   * If siri voice input is supported the constructor to an SiriAudioStreamProducer needs to be supplied.
+   * Otherwise a remote without voice support will be created.
+   *
+   * For every audio session a new SiriAudioStreamProducer will be constructed.
+   *
+   * @param audioProducerConstructor {SiriAudioStreamProducerConstructor} - constructor for a SiriAudioStreamProducer
+   * @param producerOptions - if supplied this argument will be supplied as third argument of the SiriAudioStreamProducer
+   *                          constructor. This should be used to supply configurations to the stream producer.
+   */
+  constructor(audioProducerConstructor?: SiriAudioStreamProducerConstructor, producerOptions?: any) {
+    super();
+    this.audioSupported = audioProducerConstructor !== undefined;
+    this.audioProducerConstructor = audioProducerConstructor;
+    this.audioProducerOptions = producerOptions;
 
-        const configuration: SupportedConfiguration = this.constructSupportedConfiguration();
-        this.supportedConfiguration = this.buildTargetControlSupportedConfigurationTLV(configuration);
+    const configuration: SupportedConfiguration = this.constructSupportedConfiguration();
+    this.supportedConfiguration = this.buildTargetControlSupportedConfigurationTLV(configuration);
 
-        const audioConfiguration: SupportedAudioStreamConfiguration = this.constructSupportedAudioConfiguration();
-        this.supportedAudioConfiguration = this.buildSupportedAudioConfigurationTLV(audioConfiguration);
+    const audioConfiguration: SupportedAudioStreamConfiguration = this.constructSupportedAudioConfiguration();
+    this.supportedAudioConfiguration = this.buildSupportedAudioConfigurationTLV(audioConfiguration);
 
-        this.selectedAudioConfiguration = { // set the required defaults
-            codecType: AudioCodecTypes.OPUS,
-            parameters: {
-                channels: 1,
-                bitrate: AudioCodecParamBitRateTypes.VARIABLE,
-                samplerate: AudioCodecParamSampleRateTypes.KHZ_16,
-                rtpTime: 20,
-            }
-        };
-        this.selectedAudioConfigurationString = this.buildSelectedAudioConfigurationTLV({
-            audioCodecConfiguration: this.selectedAudioConfiguration,
-        });
+    this.selectedAudioConfiguration = {
+      // set the required defaults
+      codecType: AudioCodecTypes.OPUS,
+      parameters: {
+        channels: 1,
+        bitrate: AudioCodecParamBitRateTypes.VARIABLE,
+        samplerate: AudioCodecParamSampleRateTypes.KHZ_16,
+        rtpTime: 20,
+      },
+    };
+    this.selectedAudioConfigurationString = this.buildSelectedAudioConfigurationTLV({
+      audioCodecConfiguration: this.selectedAudioConfiguration,
+    });
 
-        this._createServices();
+    this._createServices();
 
-        if (this.audioSupported) { // subscribe to necessary events if siri is enabled
-            this.dataStreamManagement!
-                .onEventMessage(Protocols.TARGET_CONTROL, Topics.WHOAMI, this.handleTargetControlWhoAmI.bind(this))
-                .onServerEvent(DataStreamServerEvents.CONNECTION_CLOSED, this.handleDataStreamConnectionClosed.bind(this));
+    if (this.audioSupported) {
+      // subscribe to necessary events if siri is enabled
+      this.dataStreamManagement!.onEventMessage(
+        Protocols.TARGET_CONTROL,
+        Topics.WHOAMI,
+        this.handleTargetControlWhoAmI.bind(this)
+      ).onServerEvent(DataStreamServerEvents.CONNECTION_CLOSED, this.handleDataStreamConnectionClosed.bind(this));
 
-            this.eventHandler = {
-                [Topics.ACK]: this.handleDataSendAckEvent.bind(this),
-                [Topics.CLOSE]: this.handleDataSendCloseEvent.bind(this),
-            };
-        }
+      this.eventHandler = {
+        [Topics.ACK]: this.handleDataSendAckEvent.bind(this),
+        [Topics.CLOSE]: this.handleDataSendCloseEvent.bind(this),
+      };
+    }
+  }
+
+  /**
+   * Set a new target as active target. A value of 0 indicates that no target is selected currently.
+   *
+   * @param activeIdentifier {number} - target identifier
+   */
+  setActiveIdentifier = (activeIdentifier: number) => {
+    if (activeIdentifier === this.activeIdentifier) {
+      return;
     }
 
-    /**
-     * Set a new target as active target. A value of 0 indicates that no target is selected currently.
-     *
-     * @param activeIdentifier {number} - target identifier
-     */
-    setActiveIdentifier = (activeIdentifier: number) => {
-        if (activeIdentifier === this.activeIdentifier) {
-            return;
-        }
-
-        if (activeIdentifier !== 0 && !this.targetConfigurations[activeIdentifier]) {
-            throw Error("Tried setting unconfigured targetIdentifier to active");
-        }
-
-        debug("%d is now the active target", activeIdentifier);
-        this.activeIdentifier = activeIdentifier;
-        this.targetControlService!.getCharacteristic(Characteristic.ActiveIdentifier)!.updateValue(activeIdentifier);
-
-        if (this.activeAudioSession) {
-            this.handleSiriAudioStop();
-        }
-
-        setTimeout(() => this.emit(RemoteControllerEvents.ACTIVE_IDENTIFIER_CHANGE, activeIdentifier), 0);
-        this.setInactive();
-    };
-
-    /**
-     * @returns if the current target is active, meaning the active device is listening for button events or audio sessions
-     */
-    isActive = () => {
-        return !!this.activeSession;
-    };
-
-    /**
-     * Checks if the supplied targetIdentifier is configured.
-     *
-     * @param targetIdentifier {number}
-     */
-    isConfigured = (targetIdentifier: number) => {
-        return this.targetConfigurations[targetIdentifier] !== undefined;
-    };
-
-    /**
-     * Returns the targetIdentifier for a give device name
-     *
-     * @param name {string} - the name of the device
-     * @returns the targetIdentifier of the device or undefined if not existent
-     */
-    getTargetIdentifierByName = (name: string) => {
-        for (const activeIdentifier in this.targetConfigurations) {
-            const configuration = this.targetConfigurations[activeIdentifier];
-            if (configuration.targetName === name) {
-                return parseInt(activeIdentifier);
-            }
-        }
-        return undefined;
-    };
-
-    /**
-     * Sends a button event to press the supplied button.
-     *
-     * @param button {ButtonType} - button to be pressed
-     */
-    pushButton = (button: ButtonType) => {
-        debug("Pressing button %s", ButtonType[button]);
-        this.sendButtonEvent(button, ButtonState.DOWN);
-    };
-
-    /**
-     * Sends a button event that the supplied button was released.
-     *
-     * @param button {ButtonType} - button which was released
-     */
-    releaseButton = (button: ButtonType) => {
-        debug("Released button %s", ButtonType[button]);
-        this.sendButtonEvent(button, ButtonState.UP);
-    };
-
-    /**
-     * Presses a supplied button for a given time.
-     *
-     * @param button {ButtonType} - button to be pressed and released
-     * @param time {number} - time in milliseconds (defaults to 200ms)
-     */
-    pushAndReleaseButton = (button: ButtonType, time: number = 200) => {
-        this.pushButton(button);
-        setTimeout(() => this.releaseButton(button), time);
-    };
-
-    /**
-     * This method adds and configures the remote services for a give accessory.
-     *
-     * @param accessory {Accessory} - the give accessory this remote should be added to
-     */
-    addServicesToAccessory = (accessory: Accessory) => {
-        if (!this.targetControlManagementService || !this.targetControlService) {
-            throw new Error("Unexpected state: Services not configured!"); // playing it save
-        }
-        if (this.accessoryConfigured) {
-            throw new Error("Remote was already added to an accessory");
-        }
-
-        accessory.addService(this.targetControlManagementService);
-        accessory.setPrimaryService(this.targetControlManagementService);
-        accessory.addService(this.targetControlService);
-
-        if (this.audioSupported) {
-            accessory.addService(this.siriService!);
-            accessory.addService(this.audioStreamManagementService!);
-            accessory.addService(this.dataStreamManagement!.getService());
-        }
-
-        const primaryAccessory = accessory.getPrimaryAccessory();
-        primaryAccessory.on(AccessoryEventTypes.UNPAIRED, () => {
-            debug("Accessory was unpaired. Resetting targets...");
-            this.handleResetTargets(undefined);
-        });
-
-        this.accessoryConfigured = true;
-    };
-
-    // ---------------------------------- CONFIGURATION ----------------------------------
-    // override methods if you would like to change anything (but should not be necessary most likely)
-
-    constructSupportedConfiguration = () => {
-        const configuration: SupportedConfiguration = {
-            maximumTargets: 10, // some random number. (ten should be okay?)
-            ticksPerSecond: 1000, // we rely on unix timestamps
-            supportedButtonConfiguration: [],
-            hardwareImplemented: this.audioSupported // siri is only allowed for hardware implemented remotes
-        };
-
-        const supportedButtons = [
-            ButtonType.MENU, ButtonType.PLAY_PAUSE, ButtonType.TV_HOME, ButtonType.SELECT,
-            ButtonType.ARROW_UP, ButtonType.ARROW_RIGHT, ButtonType.ARROW_DOWN, ButtonType.ARROW_LEFT,
-            ButtonType.VOLUME_UP, ButtonType.VOLUME_DOWN, ButtonType.POWER, ButtonType.GENERIC
-        ];
-        if (this.audioSupported) { // add siri button if this remote supports it
-            supportedButtons.push(ButtonType.SIRI);
-        }
-
-        supportedButtons.forEach(button => {
-            const buttonConfiguration: SupportedButtonConfiguration = {
-                buttonID: 100 + button,
-                buttonType: button
-            };
-            configuration.supportedButtonConfiguration.push(buttonConfiguration);
-            this.buttons[button] = buttonConfiguration.buttonID; // also saving mapping of type to id locally
-        });
-
-        return configuration;
-    };
-
-    constructSupportedAudioConfiguration = (): SupportedAudioStreamConfiguration => {
-        // the following parameters are expected from HomeKit for a remote
-        return {
-            audioCodecConfiguration: {
-                codecType: AudioCodecTypes.OPUS,
-                parameters: {
-                    channels: 1,
-                    bitrate: AudioCodecParamBitRateTypes.VARIABLE,
-                    samplerate: AudioCodecParamSampleRateTypes.KHZ_16,
-                }
-            },
-        }
-    };
-
-    // --------------------------------- TARGET CONTROL ----------------------------------
-
-    private handleTargetControlWrite = (value: any, callback: CharacteristicSetCallback) => {
-        const data = Buffer.from(value, 'base64');
-        const objects = tlv.decode(data);
-
-        const operation = objects[TargetControlList.OPERATION][0] as Operation;
-
-        let targetConfiguration: TargetConfiguration | undefined = undefined;
-        if (objects[TargetControlList.TARGET_CONFIGURATION]) { // if target configuration was sent, parse it
-            targetConfiguration = this.parseTargetConfigurationTLV(objects[TargetControlList.TARGET_CONFIGURATION]);
-        }
-
-        debug("Received TargetControl write operation %s", Operation[operation]);
-
-        let handler: (targetConfiguration?: TargetConfiguration) => Status;
-        switch (operation) {
-            case Operation.ADD:
-                handler = this.handleAddTarget;
-                break;
-            case Operation.UPDATE:
-                handler = this.handleUpdateTarget;
-                break;
-            case Operation.REMOVE:
-                handler = this.handleRemoveTarget;
-                break;
-            case Operation.RESET:
-                handler = this.handleResetTargets;
-                break;
-            case Operation.LIST:
-                handler = this.handleListTargets;
-                break;
-            default:
-                callback(new Error(Status.INVALID_VALUE_IN_REQUEST+""), undefined);
-                return;
-        }
-
-        const status = handler(targetConfiguration);
-        if (status === Status.SUCCESS) {
-            callback(undefined, this.targetConfigurationsString); // passing value for write response
-
-            if (operation === Operation.ADD && this.activeIdentifier === 0) {
-                this.setActiveIdentifier(targetConfiguration!.targetIdentifier);
-            }
-        } else {
-            callback(new Error(status + ""));
-        }
-    };
-
-    private handleAddTarget = (targetConfiguration?: TargetConfiguration): Status => {
-        if (!targetConfiguration) {
-            return Status.INVALID_VALUE_IN_REQUEST;
-        }
-
-        this.targetConfigurations[targetConfiguration.targetIdentifier] = targetConfiguration;
-
-        debug("Configured new target '" + targetConfiguration.targetName + "' with targetIdentifier '" + targetConfiguration.targetIdentifier + "'");
-
-        setTimeout(() => this.emit(RemoteControllerEvents.TARGET_ADDED, targetConfiguration), 0);
-
-        this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
-        return Status.SUCCESS;
-    };
-
-    private handleUpdateTarget = (targetConfiguration?: TargetConfiguration): Status => {
-        if (!targetConfiguration) {
-            return Status.INVALID_VALUE_IN_REQUEST;
-        }
-
-        const updates: TargetUpdates[] = [];
-
-        const configuredTarget = this.targetConfigurations[targetConfiguration.targetIdentifier];
-        if (targetConfiguration.targetName) {
-            debug("Target name was updated '%s' => '%s' (%d)",
-                configuredTarget.targetName, targetConfiguration.targetName, configuredTarget.targetIdentifier);
-
-            configuredTarget.targetName = targetConfiguration.targetName;
-            updates.push(TargetUpdates.NAME);
-        }
-        if (targetConfiguration.targetCategory) {
-            debug("Target category was updated '%d' => '%d' for target '%s' (%d)",
-                configuredTarget.targetCategory, targetConfiguration.targetCategory,
-                configuredTarget.targetName, configuredTarget.targetIdentifier);
-
-            configuredTarget.targetCategory = targetConfiguration.targetCategory;
-            updates.push(TargetUpdates.CATEGORY);
-        }
-        if (targetConfiguration.buttonConfiguration) {
-            debug("%d button configurations were updated for target '%s' (%d)",
-                Object.keys(targetConfiguration.buttonConfiguration).length,
-                configuredTarget.targetName, configuredTarget.targetIdentifier);
-
-            for (const key in targetConfiguration.buttonConfiguration) {
-                const configuration = targetConfiguration.buttonConfiguration[key];
-                const savedConfiguration = configuredTarget.buttonConfiguration[configuration.buttonID];
-
-                savedConfiguration.buttonType = configuration.buttonType;
-                savedConfiguration.buttonName = configuration.buttonName;
-            }
-            updates.push(TargetUpdates.UPDATED_BUTTONS);
-        }
-
-        setTimeout(() => this.emit(RemoteControllerEvents.TARGET_UPDATED, targetConfiguration, updates), 0);
-
-        this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
-        return Status.SUCCESS;
-    };
-
-    private handleRemoveTarget = (targetConfiguration?: TargetConfiguration): Status => {
-        if (!targetConfiguration) {
-            return Status.INVALID_VALUE_IN_REQUEST;
-        }
-
-        const configuredTarget = this.targetConfigurations[targetConfiguration.targetIdentifier];
-        if (!configuredTarget) {
-            return Status.INVALID_VALUE_IN_REQUEST;
-        }
-
-        if (targetConfiguration.buttonConfiguration) {
-            for (const key in targetConfiguration.buttonConfiguration) {
-                delete configuredTarget.buttonConfiguration[key];
-            }
-
-            debug("Removed %d button configurations of target '%s' (%d)",
-                Object.keys(targetConfiguration.buttonConfiguration).length, configuredTarget.targetName, configuredTarget.targetIdentifier);
-            setTimeout(() => this.emit(RemoteControllerEvents.TARGET_UPDATED, configuredTarget, [TargetUpdates.REMOVED_BUTTONS]), 0);
-        } else {
-            delete this.targetConfigurations[targetConfiguration.targetIdentifier];
-
-            debug ("Target '%s' (%d) was removed", configuredTarget.targetName, configuredTarget.targetIdentifier);
-            setTimeout(() => this.emit(RemoteControllerEvents.TARGET_REMOVED, targetConfiguration.targetIdentifier), 0);
-
-            const keys = Object.keys(this.targetConfigurations);
-            this.setActiveIdentifier(keys.length === 0? 0: parseInt(keys[0])); // switch to next available remote
-        }
-
-        this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
-        return Status.SUCCESS;
-    };
-
-    private handleResetTargets = (targetConfiguration?: TargetConfiguration): Status => {
-        if (targetConfiguration) {
-            return Status.INVALID_VALUE_IN_REQUEST;
-        }
-
-        debug("Resetting all target configurations");
-        this.targetConfigurations = {};
-
-        setTimeout(() => this.emit(RemoteControllerEvents.TARGETS_RESET), 0);
-        this.setActiveIdentifier(0); // resetting active identifier (also sets active to false)
-
-        this.targetConfigurationsString = ""; // set response
-        return Status.SUCCESS;
-    };
-
-    private handleListTargets = (targetConfiguration?: TargetConfiguration): Status => {
-        if (targetConfiguration) {
-            return Status.INVALID_VALUE_IN_REQUEST;
-        }
-
-        // this.targetConfigurationsString is updated after each change, so we basically don't need to do anything here
-        debug("Returning " + Object.keys(this.targetConfigurations).length + " target configurations");
-        return Status.SUCCESS;
-    };
-
-    private handleActiveWrite = (value: CharacteristicValue, callback: CharacteristicSetCallback, connectionID?: string) => {
-        if (!connectionID) {
-            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
-            return;
-        }
-        const session: Session = Session.getSession(connectionID);
-        if (!session) {
-            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
-            return;
-        }
-
-        if (this.activeIdentifier === 0) {
-            debug("Tried to change active state. There is no active target set though");
-            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
-            return;
-        }
-
-        if (this.activeSession) {
-            this.activeSession.removeListener(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener!);
-            this.activeSession = undefined;
-            this.activeSessionDisconnectionListener = undefined;
-        }
-
-        this.activeSession = value? session: undefined;
-        if (this.activeSession) { // register listener when hap session disconnects
-            this.activeSessionDisconnectionListener = this.handleActiveSessionDisconnected.bind(this, this.activeSession);
-            this.activeSession.on(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener);
-        }
-
-        const activeName = this.targetConfigurations[this.activeIdentifier].targetName;
-        debug("Remote with activeTarget '%s' (%d) was set to %s", activeName, this.activeIdentifier, value ? "ACTIVE" : "INACTIVE");
-
-        callback();
-
-        this.emit(RemoteControllerEvents.ACTIVE_CHANGE, value as boolean);
-    };
-
-    private setInactive = () => {
-        if (this.activeSession === undefined) {
-            return;
-        }
-
-        this.activeSession.removeListener(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener!);
-        this.activeSession = undefined;
-        this.activeSessionDisconnectionListener = undefined;
-
-        this.targetControlService!.getCharacteristic(Characteristic.Active)!.updateValue(false);
-        debug("Remote was set to INACTIVE");
-
-        setTimeout(() => this.emit(RemoteControllerEvents.ACTIVE_CHANGE, false), 0);
-    };
-
-    private handleActiveSessionDisconnected = (session: Session) => {
-        if (session !== this.activeSession) {
-            return;
-        }
-
-        debug("Active hap session disconnected!");
-        this.setInactive();
-    };
-
-    private sendButtonEvent = (button: ButtonType, buttonState: ButtonState) => {
-        const buttonID = this.buttons[button];
-        if (buttonID === undefined || buttonID === 0) {
-            throw new Error("Tried sending button event for unsupported button (" + button + ")");
-        }
-
-        if (this.activeIdentifier === 0) { // cannot press button if no device is selected
-            throw new Error("Tried sending button event although no target was selected");
-        }
-
-        if (!this.isActive()) { // cannot press button if device is not active (aka no apple tv is listening)
-            throw new Error("Tried sending button event although target was not marked as active");
-        }
-
-        if (button === ButtonType.SIRI && this.audioSupported) {
-            if (buttonState === ButtonState.DOWN) { // start streaming session
-                this.handleSiriAudioStart();
-            } else if (buttonState === ButtonState.UP) { // stop streaming session
-                this.handleSiriAudioStop();
-            }
-            return;
-        }
-
-        const buttonIdTlv = tlv.encode(
-            ButtonEvent.BUTTON_ID, buttonID
-        );
-
-        const buttonStateTlv = tlv.encode(
-            ButtonEvent.BUTTON_STATE, buttonState
-        );
-
-        const timestampTlv = tlv.encode(
-            ButtonEvent.TIMESTAMP, tlv.writeUInt64(new Date().getTime())
-            // timestamp should be uint64. bigint though is only supported by node 10.4.0 and above
-            // thus we just interpret timestamp as a regular number
-        );
-
-        const activeIdentifierTlv = tlv.encode(
-            ButtonEvent.ACTIVE_IDENTIFIER, tlv.writeUInt32(this.activeIdentifier)
-        );
-
-        this.lastButtonEvent = Buffer.concat([
-            buttonIdTlv, buttonStateTlv, timestampTlv, activeIdentifierTlv
-        ]).toString('base64');
-        this.targetControlService!.getCharacteristic(Characteristic.ButtonEvent)!.updateValue(this.lastButtonEvent);
-    };
-
-    private parseTargetConfigurationTLV = (data: Buffer): TargetConfiguration => {
-        const configTLV = tlv.decode(data);
-
-        const identifier = tlv.readUInt32(configTLV[TargetConfigurationTypes.TARGET_IDENTIFIER]);
-
-        let name = undefined;
-        if (configTLV[TargetConfigurationTypes.TARGET_NAME])
-            name = configTLV[TargetConfigurationTypes.TARGET_NAME].toString();
-
-        let category = undefined;
-        if (configTLV[TargetConfigurationTypes.TARGET_CATEGORY])
-            category = tlv.readUInt16(configTLV[TargetConfigurationTypes.TARGET_CATEGORY]);
-
-        const buttonConfiguration: Record<number, ButtonConfiguration> = {};
-
-        if (configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION]) {
-            const buttonConfigurationTLV = tlv.decodeList(configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION], ButtonConfigurationTypes.BUTTON_ID);
-            buttonConfigurationTLV.forEach(entry => {
-                const buttonId = entry[ButtonConfigurationTypes.BUTTON_ID][0];
-                const buttonType = tlv.readUInt16(entry[ButtonConfigurationTypes.BUTTON_TYPE]);
-                let buttonName;
-                if (entry[ButtonConfigurationTypes.BUTTON_NAME]) {
-                    buttonName = entry[ButtonConfigurationTypes.BUTTON_NAME].toString();
-                } else {
-                    buttonName = ButtonType[buttonType as ButtonType];
-                }
-
-                buttonConfiguration[buttonId] = {
-                    buttonID: buttonId,
-                    buttonType: buttonType,
-                    buttonName: buttonName
-                };
-            });
-        }
-
-        return {
-            targetIdentifier: identifier,
-            targetName: name,
-            targetCategory: category,
-            buttonConfiguration: buttonConfiguration
-        };
-    };
-
-    private buildTargetConfigurationsTLV = (configurations: Record<number, TargetConfiguration>) => {
-        const bufferList = [];
-        for (const key in configurations) {
-            // noinspection JSUnfilteredForInLoop
-            const configuration = configurations[key];
-
-            const targetIdentifier = tlv.encode(
-                TargetConfigurationTypes.TARGET_IDENTIFIER, tlv.writeUInt32(configuration.targetIdentifier)
-            );
-
-            const targetName = tlv.encode(
-                TargetConfigurationTypes.TARGET_NAME, configuration.targetName!
-            );
-
-            const targetCategory = tlv.encode(
-                TargetConfigurationTypes.TARGET_CATEGORY, tlv.writeUInt16(configuration.targetCategory!)
-            );
-
-            const buttonConfigurationBuffers: Buffer[] = [];
-            Object.values(configuration.buttonConfiguration).forEach(value => {
-                let tlvBuffer = tlv.encode(
-                    ButtonConfigurationTypes.BUTTON_ID, value.buttonID,
-                    ButtonConfigurationTypes.BUTTON_TYPE, tlv.writeUInt16(value.buttonType)
-                );
-
-                if (value.buttonName) {
-                    tlvBuffer = Buffer.concat([
-                        tlvBuffer,
-                        tlv.encode(
-                            ButtonConfigurationTypes.BUTTON_NAME, value.buttonName
-                        )
-                    ])
-                }
-
-                buttonConfigurationBuffers.push(tlvBuffer);
-            });
-
-            const buttonConfiguration = tlv.encode(
-                TargetConfigurationTypes.BUTTON_CONFIGURATION, Buffer.concat(buttonConfigurationBuffers)
-            );
-
-            const targetConfiguration = Buffer.concat(
-                [targetIdentifier, targetName, targetCategory, buttonConfiguration]
-            );
-
-            bufferList.push(tlv.encode(TargetControlList.TARGET_CONFIGURATION, targetConfiguration));
-        }
-
-        return Buffer.concat(bufferList).toString('base64');
-    };
-
-    private buildTargetControlSupportedConfigurationTLV = (configuration: SupportedConfiguration) => {
-        const maximumTargets = tlv.encode(
-            TargetControlCommands.MAXIMUM_TARGETS, configuration.maximumTargets
-        );
-
-        const ticksPerSecond = tlv.encode(
-            TargetControlCommands.TICKS_PER_SECOND, tlv.writeUInt64(configuration.ticksPerSecond)
-        );
-
-        const supportedButtonConfigurationBuffers: Uint8Array[] = [];
-        configuration.supportedButtonConfiguration.forEach(value => {
-            const tlvBuffer = tlv.encode(
-                SupportedButtonConfigurationTypes.BUTTON_ID, value.buttonID,
-                SupportedButtonConfigurationTypes.BUTTON_TYPE, tlv.writeUInt16(value.buttonType)
-            );
-            supportedButtonConfigurationBuffers.push(tlvBuffer);
-        });
-        const supportedButtonConfiguration = tlv.encode(
-            TargetControlCommands.SUPPORTED_BUTTON_CONFIGURATION, Buffer.concat(supportedButtonConfigurationBuffers)
-        );
-
-        const type = tlv.encode(TargetControlCommands.TYPE, configuration.hardwareImplemented ? 1 : 0);
-
-        return Buffer.concat(
-            [maximumTargets, ticksPerSecond, supportedButtonConfiguration, type]
-        ).toString('base64');
-    };
-
-    // --------------------------------- SIRI/DATA STREAM --------------------------------
-
-    private handleTargetControlWhoAmI = (connection: DataStreamConnection, message: Record<any, any>) => {
-        const targetIdentifier = message["identifier"];
-        this.dataStreamConnections[targetIdentifier] = connection;
-        debug("Discovered HDS connection for targetIdentifier %s", targetIdentifier);
-
-        connection.addProtocolHandler(Protocols.DATA_SEND, this);
-    };
-
-    private handleSiriAudioStart = () => {
-        if (!this.audioSupported) {
-            throw new Error("Cannot start siri stream on remote where siri is not supported");
-        }
-
-        if (!this.isActive()) {
-            debug("Tried opening Siri audio stream, however no controller is connected!");
-            return;
-        }
-
-        if (this.activeAudioSession && (!this.activeAudioSession.isClosing() || this.nextAudioSession)) {
-            // there is already a session running, which is not in closing state and/or there is even already a
-            // nextAudioSession running. ignoring start request
-            debug("Tried opening Siri audio stream, however there is already one in progress");
-            return;
-        }
-
-        const connection = this.dataStreamConnections[this.activeIdentifier]; // get connection for current target
-        if (connection === undefined) { // target seems not connected, ignore it
-            debug("Tried opening Siri audio stream however target is not connected via HDS");
-            return;
-        }
-
-        const audioSession = new SiriAudioSession(connection, this.selectedAudioConfiguration, this.audioProducerConstructor!, this.audioProducerOptions);
-        if (!this.activeAudioSession) {
-            this.activeAudioSession = audioSession;
-        } else {
-            // we checked above that this only happens if the activeAudioSession is in closing state,
-            // so no collision with the input device can happen
-            this.nextAudioSession = audioSession;
-        }
-
-        audioSession.on(SiriAudioSessionEvents.CLOSE, this.handleSiriAudioSessionClosed.bind(this, audioSession));
-        audioSession.start();
-    };
-
-    private handleSiriAudioStop = () => {
-        if (this.activeAudioSession) {
-            if (!this.activeAudioSession.isClosing()) {
-                this.activeAudioSession.stop();
-                return;
-            } else if (this.nextAudioSession && !this.nextAudioSession.isClosing()) {
-                this.nextAudioSession.stop();
-                return;
-            }
-        }
-
-        debug("handleSiriAudioStop called although no audio session was started");
-    };
-
-    private handleDataSendAckEvent = (message: Record<any, any>) => { // transfer was successful
-        const streamId = message["streamId"];
-        const endOfStream = message["endOfStream"];
-
-        if (this.activeAudioSession && this.activeAudioSession.streamId === streamId) {
-            this.activeAudioSession.handleDataSendAckEvent(endOfStream);
-        } else if (this.nextAudioSession && this.nextAudioSession.streamId === streamId) {
-            this.nextAudioSession.handleDataSendAckEvent(endOfStream);
-        } else {
-            debug("Received dataSend acknowledgment event for unknown streamId '%s'", streamId);
-        }
-    };
-
-    private handleDataSendCloseEvent = (message: Record<any, any>) => { // controller indicates he can't handle audio request currently
-        const streamId = message["streamId"];
-        const reason = message["reason"] as DataSendCloseReason;
-
-        if (this.activeAudioSession && this.activeAudioSession.streamId === streamId) {
-            this.activeAudioSession.handleDataSendCloseEvent(reason);
-        } else if (this.nextAudioSession && this.nextAudioSession.streamId === streamId) {
-            this.nextAudioSession.handleDataSendCloseEvent(reason);
-        } else {
-            debug("Received dataSend close event for unknown streamId '%s'", streamId);
-        }
-    };
-
-    private handleSiriAudioSessionClosed = (session: SiriAudioSession) => {
-        if (session === this.activeAudioSession) {
-            this.activeAudioSession = this.nextAudioSession;
-            this.nextAudioSession = undefined;
-        } else if (session === this.nextAudioSession) {
-            this.nextAudioSession = undefined;
-        }
-    };
-
-    private handleDataStreamConnectionClosed = (connection: DataStreamConnection) => {
-        for (const targetIdentifier in this.dataStreamConnections) {
-            const connection0 = this.dataStreamConnections[targetIdentifier];
-            if (connection === connection0) {
-                debug("HDS connection disconnected for targetIdentifier %s", targetIdentifier);
-                delete this.dataStreamConnections[targetIdentifier];
-                break;
-            }
-        }
-    };
-
-    // ------------------------------- AUDIO CONFIGURATION -------------------------------
-
-    private handleSelectedAudioConfigurationWrite = (value: any, callback: CharacteristicSetCallback) => {
-        const data = Buffer.from(value, 'base64');
-        const objects = tlv.decode(data);
-
-        const selectedAudioStreamConfiguration = tlv.decode(
-            objects[SelectedAudioInputStreamConfigurationTypes.SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION]
-        );
-
-        const codec = selectedAudioStreamConfiguration[AudioTypes.CODEC][0];
-        const parameters = tlv.decode(selectedAudioStreamConfiguration[AudioTypes.CODEC_PARAM]);
-
-        const channels = parameters[AudioCodecParamTypes.CHANNEL][0];
-        const bitrate = parameters[AudioCodecParamTypes.BIT_RATE][0];
-        const samplerate = parameters[AudioCodecParamTypes.SAMPLE_RATE][0];
-
-        this.selectedAudioConfiguration = {
-            codecType: codec,
-            parameters: {
-                channels: channels,
-                bitrate: bitrate,
-                samplerate: samplerate,
-                rtpTime: 20
-            }
-        };
-        this.selectedAudioConfigurationString = this.buildSelectedAudioConfigurationTLV({
-            audioCodecConfiguration: this.selectedAudioConfiguration,
-        });
-
-        callback();
-    };
-
-    private buildSupportedAudioConfigurationTLV = (configuration: SupportedAudioStreamConfiguration) => {
-        const codecConfigurationTLV = this.buildCodecConfigurationTLV(configuration.audioCodecConfiguration);
-
-        const supportedAudioStreamConfiguration = tlv.encode(
-            SupportedAudioStreamConfigurationTypes.AUDIO_CODEC_CONFIGURATION, codecConfigurationTLV
-        );
-        return supportedAudioStreamConfiguration.toString('base64');
-    };
-
-    private buildSelectedAudioConfigurationTLV = (configuration: SelectedAudioStreamConfiguration) => {
-        const codecConfigurationTLV = this.buildCodecConfigurationTLV(configuration.audioCodecConfiguration);
-
-        const supportedAudioStreamConfiguration = tlv.encode(
-            SelectedAudioInputStreamConfigurationTypes.SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION, codecConfigurationTLV,
-        );
-        return supportedAudioStreamConfiguration.toString('base64');
-    };
-
-    private buildCodecConfigurationTLV = (codecConfiguration: AudioCodecConfiguration) => {
-        const parameters = codecConfiguration.parameters;
-
-        let parametersTLV = tlv.encode(
-            AudioCodecParamTypes.CHANNEL, parameters.channels,
-            AudioCodecParamTypes.BIT_RATE, parameters.bitrate,
-            AudioCodecParamTypes.SAMPLE_RATE, parameters.samplerate,
-        );
-        if (parameters.rtpTime) {
-            parametersTLV = Buffer.concat([
-                parametersTLV,
-                tlv.encode(AudioCodecParamTypes.PACKET_TIME, parameters.rtpTime)
-            ]);
-        }
-
-        return tlv.encode(
-            AudioTypes.CODEC, codecConfiguration.codecType,
-            AudioTypes.CODEC_PARAM, parametersTLV
-        );
-    };
-
-    // -----------------------------------------------------------------------------------
-
-    _createServices = () => {
-        this.targetControlManagementService = new Service.TargetControlManagement('', '');
-        this.targetControlManagementService.getCharacteristic(Characteristic.TargetControlSupportedConfiguration)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(null, this.supportedConfiguration);
-            }).getValue();
-        this.targetControlManagementService.getCharacteristic(Characteristic.TargetControlList)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(null, this.targetConfigurationsString);
-            })
-            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                this.handleTargetControlWrite(value, callback);
-            }).getValue();
-
-        // you can also expose multiple TargetControl services to control multiple apple tvs simultaneously.
-        // should we extend this class to support multiple TargetControl services or should users just create a second accessory?
-        this.targetControlService = new Service.TargetControl('', '');
-        this.targetControlService.getCharacteristic(Characteristic.ActiveIdentifier)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.activeIdentifier);
-            }).getValue();
-        this.targetControlService.getCharacteristic(Characteristic.Active)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.isActive());
-            })
-            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
-                this.handleActiveWrite(value, callback, connectionID);
-            }).getValue();
-        this.targetControlService.getCharacteristic(Characteristic.ButtonEvent)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.lastButtonEvent);
-            }).getValue();
-
-        if (this.audioSupported) {
-            this.siriService = new Service.Siri('', '');
-            this.siriService.getCharacteristic(Characteristic.SiriInputType)!
-                .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                    callback(undefined, SiriInputType.PUSH_BUTTON_TRIGGERED_APPLE_TV);
-                });
-
-            this.audioStreamManagementService = new Service.AudioStreamManagement('', '');
-            this.audioStreamManagementService.getCharacteristic(Characteristic.SupportedAudioStreamConfiguration)!
-                .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                    callback(undefined, this.supportedAudioConfiguration);
-                }).getValue();
-            this.audioStreamManagementService.getCharacteristic(Characteristic.SelectedAudioStreamConfiguration)!
-                .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                    callback(null, this.selectedAudioConfigurationString);
-                })
-                .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                    this.handleSelectedAudioConfigurationWrite(value, callback);
-                }).getValue();
-
-            this.dataStreamManagement = new DataStreamManagement();
-
-            this.siriService.addLinkedService(this.dataStreamManagement.getService());
-            this.siriService.addLinkedService(this.audioStreamManagementService);
-        }
+    if (activeIdentifier !== 0 && !this.targetConfigurations[activeIdentifier]) {
+      throw Error("Tried setting unconfigured targetIdentifier to active");
     }
+
+    debug("%d is now the active target", activeIdentifier);
+    this.activeIdentifier = activeIdentifier;
+    this.targetControlService!.getCharacteristic(Characteristic.ActiveIdentifier)!.updateValue(activeIdentifier);
+
+    if (this.activeAudioSession) {
+      this.handleSiriAudioStop();
+    }
+
+    setTimeout(() => this.emit(RemoteControllerEvents.ACTIVE_IDENTIFIER_CHANGE, activeIdentifier), 0);
+    this.setInactive();
+  };
+
+  /**
+   * @returns if the current target is active, meaning the active device is listening for button events or audio sessions
+   */
+  isActive = () => {
+    return !!this.activeSession;
+  };
+
+  /**
+   * Checks if the supplied targetIdentifier is configured.
+   *
+   * @param targetIdentifier {number}
+   */
+  isConfigured = (targetIdentifier: number) => {
+    return this.targetConfigurations[targetIdentifier] !== undefined;
+  };
+
+  /**
+   * Returns the targetIdentifier for a give device name
+   *
+   * @param name {string} - the name of the device
+   * @returns the targetIdentifier of the device or undefined if not existent
+   */
+  getTargetIdentifierByName = (name: string) => {
+    for (const activeIdentifier in this.targetConfigurations) {
+      const configuration = this.targetConfigurations[activeIdentifier];
+      if (configuration.targetName === name) {
+        return parseInt(activeIdentifier);
+      }
+    }
+    return undefined;
+  };
+
+  /**
+   * Sends a button event to press the supplied button.
+   *
+   * @param button {ButtonType} - button to be pressed
+   */
+  pushButton = (button: ButtonType) => {
+    debug("Pressing button %s", ButtonType[button]);
+    this.sendButtonEvent(button, ButtonState.DOWN);
+  };
+
+  /**
+   * Sends a button event that the supplied button was released.
+   *
+   * @param button {ButtonType} - button which was released
+   */
+  releaseButton = (button: ButtonType) => {
+    debug("Released button %s", ButtonType[button]);
+    this.sendButtonEvent(button, ButtonState.UP);
+  };
+
+  /**
+   * Presses a supplied button for a given time.
+   *
+   * @param button {ButtonType} - button to be pressed and released
+   * @param time {number} - time in milliseconds (defaults to 200ms)
+   */
+  pushAndReleaseButton = (button: ButtonType, time: number = 200) => {
+    this.pushButton(button);
+    setTimeout(() => this.releaseButton(button), time);
+  };
+
+  /**
+   * This method adds and configures the remote services for a give accessory.
+   *
+   * @param accessory {Accessory} - the give accessory this remote should be added to
+   */
+  addServicesToAccessory = (accessory: Accessory) => {
+    if (!this.targetControlManagementService || !this.targetControlService) {
+      throw new Error("Unexpected state: Services not configured!"); // playing it save
+    }
+    if (this.accessoryConfigured) {
+      throw new Error("Remote was already added to an accessory");
+    }
+
+    accessory.addService(this.targetControlManagementService);
+    accessory.setPrimaryService(this.targetControlManagementService);
+    accessory.addService(this.targetControlService);
+
+    if (this.audioSupported) {
+      accessory.addService(this.siriService!);
+      accessory.addService(this.audioStreamManagementService!);
+      accessory.addService(this.dataStreamManagement!.getService());
+    }
+
+    const primaryAccessory = accessory.getPrimaryAccessory();
+    primaryAccessory.on(AccessoryEventTypes.UNPAIRED, () => {
+      debug("Accessory was unpaired. Resetting targets...");
+      this.handleResetTargets(undefined);
+    });
+
+    this.accessoryConfigured = true;
+  };
+
+  // ---------------------------------- CONFIGURATION ----------------------------------
+  // override methods if you would like to change anything (but should not be necessary most likely)
+
+  constructSupportedConfiguration = () => {
+    const configuration: SupportedConfiguration = {
+      maximumTargets: 10, // some random number. (ten should be okay?)
+      ticksPerSecond: 1000, // we rely on unix timestamps
+      supportedButtonConfiguration: [],
+      hardwareImplemented: this.audioSupported, // siri is only allowed for hardware implemented remotes
+    };
+
+    const supportedButtons = [
+      ButtonType.MENU,
+      ButtonType.PLAY_PAUSE,
+      ButtonType.TV_HOME,
+      ButtonType.SELECT,
+      ButtonType.ARROW_UP,
+      ButtonType.ARROW_RIGHT,
+      ButtonType.ARROW_DOWN,
+      ButtonType.ARROW_LEFT,
+      ButtonType.VOLUME_UP,
+      ButtonType.VOLUME_DOWN,
+      ButtonType.POWER,
+      ButtonType.GENERIC,
+    ];
+    if (this.audioSupported) {
+      // add siri button if this remote supports it
+      supportedButtons.push(ButtonType.SIRI);
+    }
+
+    supportedButtons.forEach(button => {
+      const buttonConfiguration: SupportedButtonConfiguration = {
+        buttonID: 100 + button,
+        buttonType: button,
+      };
+      configuration.supportedButtonConfiguration.push(buttonConfiguration);
+      this.buttons[button] = buttonConfiguration.buttonID; // also saving mapping of type to id locally
+    });
+
+    return configuration;
+  };
+
+  constructSupportedAudioConfiguration = (): SupportedAudioStreamConfiguration => {
+    // the following parameters are expected from HomeKit for a remote
+    return {
+      audioCodecConfiguration: {
+        codecType: AudioCodecTypes.OPUS,
+        parameters: {
+          channels: 1,
+          bitrate: AudioCodecParamBitRateTypes.VARIABLE,
+          samplerate: AudioCodecParamSampleRateTypes.KHZ_16,
+        },
+      },
+    };
+  };
+
+  // --------------------------------- TARGET CONTROL ----------------------------------
+
+  private handleTargetControlWrite = (value: any, callback: CharacteristicSetCallback) => {
+    const data = Buffer.from(value, "base64");
+    const objects = tlv.decode(data);
+
+    const operation = objects[TargetControlList.OPERATION][0] as Operation;
+
+    let targetConfiguration: TargetConfiguration | undefined = undefined;
+    if (objects[TargetControlList.TARGET_CONFIGURATION]) {
+      // if target configuration was sent, parse it
+      targetConfiguration = this.parseTargetConfigurationTLV(objects[TargetControlList.TARGET_CONFIGURATION]);
+    }
+
+    debug("Received TargetControl write operation %s", Operation[operation]);
+
+    let handler: (targetConfiguration?: TargetConfiguration) => Status;
+    switch (operation) {
+      case Operation.ADD:
+        handler = this.handleAddTarget;
+        break;
+      case Operation.UPDATE:
+        handler = this.handleUpdateTarget;
+        break;
+      case Operation.REMOVE:
+        handler = this.handleRemoveTarget;
+        break;
+      case Operation.RESET:
+        handler = this.handleResetTargets;
+        break;
+      case Operation.LIST:
+        handler = this.handleListTargets;
+        break;
+      default:
+        callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""), undefined);
+        return;
+    }
+
+    const status = handler(targetConfiguration);
+    if (status === Status.SUCCESS) {
+      callback(undefined, this.targetConfigurationsString); // passing value for write response
+
+      if (operation === Operation.ADD && this.activeIdentifier === 0) {
+        this.setActiveIdentifier(targetConfiguration!.targetIdentifier);
+      }
+    } else {
+      callback(new Error(status + ""));
+    }
+  };
+
+  private handleAddTarget = (targetConfiguration?: TargetConfiguration): Status => {
+    if (!targetConfiguration) {
+      return Status.INVALID_VALUE_IN_REQUEST;
+    }
+
+    this.targetConfigurations[targetConfiguration.targetIdentifier] = targetConfiguration;
+
+    debug(
+      "Configured new target '" +
+        targetConfiguration.targetName +
+        "' with targetIdentifier '" +
+        targetConfiguration.targetIdentifier +
+        "'"
+    );
+
+    setTimeout(() => this.emit(RemoteControllerEvents.TARGET_ADDED, targetConfiguration), 0);
+
+    this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
+    return Status.SUCCESS;
+  };
+
+  private handleUpdateTarget = (targetConfiguration?: TargetConfiguration): Status => {
+    if (!targetConfiguration) {
+      return Status.INVALID_VALUE_IN_REQUEST;
+    }
+
+    const updates: TargetUpdates[] = [];
+
+    const configuredTarget = this.targetConfigurations[targetConfiguration.targetIdentifier];
+    if (targetConfiguration.targetName) {
+      debug(
+        "Target name was updated '%s' => '%s' (%d)",
+        configuredTarget.targetName,
+        targetConfiguration.targetName,
+        configuredTarget.targetIdentifier
+      );
+
+      configuredTarget.targetName = targetConfiguration.targetName;
+      updates.push(TargetUpdates.NAME);
+    }
+    if (targetConfiguration.targetCategory) {
+      debug(
+        "Target category was updated '%d' => '%d' for target '%s' (%d)",
+        configuredTarget.targetCategory,
+        targetConfiguration.targetCategory,
+        configuredTarget.targetName,
+        configuredTarget.targetIdentifier
+      );
+
+      configuredTarget.targetCategory = targetConfiguration.targetCategory;
+      updates.push(TargetUpdates.CATEGORY);
+    }
+    if (targetConfiguration.buttonConfiguration) {
+      debug(
+        "%d button configurations were updated for target '%s' (%d)",
+        Object.keys(targetConfiguration.buttonConfiguration).length,
+        configuredTarget.targetName,
+        configuredTarget.targetIdentifier
+      );
+
+      for (const key in targetConfiguration.buttonConfiguration) {
+        const configuration = targetConfiguration.buttonConfiguration[key];
+        const savedConfiguration = configuredTarget.buttonConfiguration[configuration.buttonID];
+
+        savedConfiguration.buttonType = configuration.buttonType;
+        savedConfiguration.buttonName = configuration.buttonName;
+      }
+      updates.push(TargetUpdates.UPDATED_BUTTONS);
+    }
+
+    setTimeout(() => this.emit(RemoteControllerEvents.TARGET_UPDATED, targetConfiguration, updates), 0);
+
+    this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
+    return Status.SUCCESS;
+  };
+
+  private handleRemoveTarget = (targetConfiguration?: TargetConfiguration): Status => {
+    if (!targetConfiguration) {
+      return Status.INVALID_VALUE_IN_REQUEST;
+    }
+
+    const configuredTarget = this.targetConfigurations[targetConfiguration.targetIdentifier];
+    if (!configuredTarget) {
+      return Status.INVALID_VALUE_IN_REQUEST;
+    }
+
+    if (targetConfiguration.buttonConfiguration) {
+      for (const key in targetConfiguration.buttonConfiguration) {
+        delete configuredTarget.buttonConfiguration[key];
+      }
+
+      debug(
+        "Removed %d button configurations of target '%s' (%d)",
+        Object.keys(targetConfiguration.buttonConfiguration).length,
+        configuredTarget.targetName,
+        configuredTarget.targetIdentifier
+      );
+      setTimeout(
+        () => this.emit(RemoteControllerEvents.TARGET_UPDATED, configuredTarget, [TargetUpdates.REMOVED_BUTTONS]),
+        0
+      );
+    } else {
+      delete this.targetConfigurations[targetConfiguration.targetIdentifier];
+
+      debug("Target '%s' (%d) was removed", configuredTarget.targetName, configuredTarget.targetIdentifier);
+      setTimeout(() => this.emit(RemoteControllerEvents.TARGET_REMOVED, targetConfiguration.targetIdentifier), 0);
+
+      const keys = Object.keys(this.targetConfigurations);
+      this.setActiveIdentifier(keys.length === 0 ? 0 : parseInt(keys[0])); // switch to next available remote
+    }
+
+    this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
+    return Status.SUCCESS;
+  };
+
+  private handleResetTargets = (targetConfiguration?: TargetConfiguration): Status => {
+    if (targetConfiguration) {
+      return Status.INVALID_VALUE_IN_REQUEST;
+    }
+
+    debug("Resetting all target configurations");
+    this.targetConfigurations = {};
+
+    setTimeout(() => this.emit(RemoteControllerEvents.TARGETS_RESET), 0);
+    this.setActiveIdentifier(0); // resetting active identifier (also sets active to false)
+
+    this.targetConfigurationsString = ""; // set response
+    return Status.SUCCESS;
+  };
+
+  private handleListTargets = (targetConfiguration?: TargetConfiguration): Status => {
+    if (targetConfiguration) {
+      return Status.INVALID_VALUE_IN_REQUEST;
+    }
+
+    // this.targetConfigurationsString is updated after each change, so we basically don't need to do anything here
+    debug("Returning " + Object.keys(this.targetConfigurations).length + " target configurations");
+    return Status.SUCCESS;
+  };
+
+  private handleActiveWrite = (
+    value: CharacteristicValue,
+    callback: CharacteristicSetCallback,
+    connectionID?: string
+  ) => {
+    if (!connectionID) {
+      callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+      return;
+    }
+    const session: Session = Session.getSession(connectionID);
+    if (!session) {
+      callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+      return;
+    }
+
+    if (this.activeIdentifier === 0) {
+      debug("Tried to change active state. There is no active target set though");
+      callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+      return;
+    }
+
+    if (this.activeSession) {
+      this.activeSession.removeListener(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener!);
+      this.activeSession = undefined;
+      this.activeSessionDisconnectionListener = undefined;
+    }
+
+    this.activeSession = value ? session : undefined;
+    if (this.activeSession) {
+      // register listener when hap session disconnects
+      this.activeSessionDisconnectionListener = this.handleActiveSessionDisconnected.bind(this, this.activeSession);
+      this.activeSession.on(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener);
+    }
+
+    const activeName = this.targetConfigurations[this.activeIdentifier].targetName;
+    debug(
+      "Remote with activeTarget '%s' (%d) was set to %s",
+      activeName,
+      this.activeIdentifier,
+      value ? "ACTIVE" : "INACTIVE"
+    );
+
+    callback();
+
+    this.emit(RemoteControllerEvents.ACTIVE_CHANGE, value as boolean);
+  };
+
+  private setInactive = () => {
+    if (this.activeSession === undefined) {
+      return;
+    }
+
+    this.activeSession.removeListener(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener!);
+    this.activeSession = undefined;
+    this.activeSessionDisconnectionListener = undefined;
+
+    this.targetControlService!.getCharacteristic(Characteristic.Active)!.updateValue(false);
+    debug("Remote was set to INACTIVE");
+
+    setTimeout(() => this.emit(RemoteControllerEvents.ACTIVE_CHANGE, false), 0);
+  };
+
+  private handleActiveSessionDisconnected = (session: Session) => {
+    if (session !== this.activeSession) {
+      return;
+    }
+
+    debug("Active hap session disconnected!");
+    this.setInactive();
+  };
+
+  private sendButtonEvent = (button: ButtonType, buttonState: ButtonState) => {
+    const buttonID = this.buttons[button];
+    if (buttonID === undefined || buttonID === 0) {
+      throw new Error("Tried sending button event for unsupported button (" + button + ")");
+    }
+
+    if (this.activeIdentifier === 0) {
+      // cannot press button if no device is selected
+      throw new Error("Tried sending button event although no target was selected");
+    }
+
+    if (!this.isActive()) {
+      // cannot press button if device is not active (aka no apple tv is listening)
+      throw new Error("Tried sending button event although target was not marked as active");
+    }
+
+    if (button === ButtonType.SIRI && this.audioSupported) {
+      if (buttonState === ButtonState.DOWN) {
+        // start streaming session
+        this.handleSiriAudioStart();
+      } else if (buttonState === ButtonState.UP) {
+        // stop streaming session
+        this.handleSiriAudioStop();
+      }
+      return;
+    }
+
+    const buttonIdTlv = tlv.encode(ButtonEvent.BUTTON_ID, buttonID);
+
+    const buttonStateTlv = tlv.encode(ButtonEvent.BUTTON_STATE, buttonState);
+
+    const timestampTlv = tlv.encode(
+      ButtonEvent.TIMESTAMP,
+      tlv.writeUInt64(new Date().getTime())
+      // timestamp should be uint64. bigint though is only supported by node 10.4.0 and above
+      // thus we just interpret timestamp as a regular number
+    );
+
+    const activeIdentifierTlv = tlv.encode(ButtonEvent.ACTIVE_IDENTIFIER, tlv.writeUInt32(this.activeIdentifier));
+
+    this.lastButtonEvent = Buffer.concat([buttonIdTlv, buttonStateTlv, timestampTlv, activeIdentifierTlv]).toString(
+      "base64"
+    );
+    this.targetControlService!.getCharacteristic(Characteristic.ButtonEvent)!.updateValue(this.lastButtonEvent);
+  };
+
+  private parseTargetConfigurationTLV = (data: Buffer): TargetConfiguration => {
+    const configTLV = tlv.decode(data);
+
+    const identifier = tlv.readUInt32(configTLV[TargetConfigurationTypes.TARGET_IDENTIFIER]);
+
+    let name = undefined;
+    if (configTLV[TargetConfigurationTypes.TARGET_NAME])
+      name = configTLV[TargetConfigurationTypes.TARGET_NAME].toString();
+
+    let category = undefined;
+    if (configTLV[TargetConfigurationTypes.TARGET_CATEGORY])
+      category = tlv.readUInt16(configTLV[TargetConfigurationTypes.TARGET_CATEGORY]);
+
+    const buttonConfiguration: Record<number, ButtonConfiguration> = {};
+
+    if (configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION]) {
+      const buttonConfigurationTLV = tlv.decodeList(
+        configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION],
+        ButtonConfigurationTypes.BUTTON_ID
+      );
+      buttonConfigurationTLV.forEach(entry => {
+        const buttonId = entry[ButtonConfigurationTypes.BUTTON_ID][0];
+        const buttonType = tlv.readUInt16(entry[ButtonConfigurationTypes.BUTTON_TYPE]);
+        let buttonName;
+        if (entry[ButtonConfigurationTypes.BUTTON_NAME]) {
+          buttonName = entry[ButtonConfigurationTypes.BUTTON_NAME].toString();
+        } else {
+          buttonName = ButtonType[buttonType as ButtonType];
+        }
+
+        buttonConfiguration[buttonId] = {
+          buttonID: buttonId,
+          buttonType: buttonType,
+          buttonName: buttonName,
+        };
+      });
+    }
+
+    return {
+      targetIdentifier: identifier,
+      targetName: name,
+      targetCategory: category,
+      buttonConfiguration: buttonConfiguration,
+    };
+  };
+
+  private buildTargetConfigurationsTLV = (configurations: Record<number, TargetConfiguration>) => {
+    const bufferList = [];
+    for (const key in configurations) {
+      // noinspection JSUnfilteredForInLoop
+      const configuration = configurations[key];
+
+      const targetIdentifier = tlv.encode(
+        TargetConfigurationTypes.TARGET_IDENTIFIER,
+        tlv.writeUInt32(configuration.targetIdentifier)
+      );
+
+      const targetName = tlv.encode(TargetConfigurationTypes.TARGET_NAME, configuration.targetName!);
+
+      const targetCategory = tlv.encode(
+        TargetConfigurationTypes.TARGET_CATEGORY,
+        tlv.writeUInt16(configuration.targetCategory!)
+      );
+
+      const buttonConfigurationBuffers: Buffer[] = [];
+      Object.values(configuration.buttonConfiguration).forEach(value => {
+        let tlvBuffer = tlv.encode(
+          ButtonConfigurationTypes.BUTTON_ID,
+          value.buttonID,
+          ButtonConfigurationTypes.BUTTON_TYPE,
+          tlv.writeUInt16(value.buttonType)
+        );
+
+        if (value.buttonName) {
+          tlvBuffer = Buffer.concat([tlvBuffer, tlv.encode(ButtonConfigurationTypes.BUTTON_NAME, value.buttonName)]);
+        }
+
+        buttonConfigurationBuffers.push(tlvBuffer);
+      });
+
+      const buttonConfiguration = tlv.encode(
+        TargetConfigurationTypes.BUTTON_CONFIGURATION,
+        Buffer.concat(buttonConfigurationBuffers)
+      );
+
+      const targetConfiguration = Buffer.concat([targetIdentifier, targetName, targetCategory, buttonConfiguration]);
+
+      bufferList.push(tlv.encode(TargetControlList.TARGET_CONFIGURATION, targetConfiguration));
+    }
+
+    return Buffer.concat(bufferList).toString("base64");
+  };
+
+  private buildTargetControlSupportedConfigurationTLV = (configuration: SupportedConfiguration) => {
+    const maximumTargets = tlv.encode(TargetControlCommands.MAXIMUM_TARGETS, configuration.maximumTargets);
+
+    const ticksPerSecond = tlv.encode(
+      TargetControlCommands.TICKS_PER_SECOND,
+      tlv.writeUInt64(configuration.ticksPerSecond)
+    );
+
+    const supportedButtonConfigurationBuffers: Uint8Array[] = [];
+    configuration.supportedButtonConfiguration.forEach(value => {
+      const tlvBuffer = tlv.encode(
+        SupportedButtonConfigurationTypes.BUTTON_ID,
+        value.buttonID,
+        SupportedButtonConfigurationTypes.BUTTON_TYPE,
+        tlv.writeUInt16(value.buttonType)
+      );
+      supportedButtonConfigurationBuffers.push(tlvBuffer);
+    });
+    const supportedButtonConfiguration = tlv.encode(
+      TargetControlCommands.SUPPORTED_BUTTON_CONFIGURATION,
+      Buffer.concat(supportedButtonConfigurationBuffers)
+    );
+
+    const type = tlv.encode(TargetControlCommands.TYPE, configuration.hardwareImplemented ? 1 : 0);
+
+    return Buffer.concat([maximumTargets, ticksPerSecond, supportedButtonConfiguration, type]).toString("base64");
+  };
+
+  // --------------------------------- SIRI/DATA STREAM --------------------------------
+
+  private handleTargetControlWhoAmI = (connection: DataStreamConnection, message: Record<any, any>) => {
+    const targetIdentifier = message["identifier"];
+    this.dataStreamConnections[targetIdentifier] = connection;
+    debug("Discovered HDS connection for targetIdentifier %s", targetIdentifier);
+
+    connection.addProtocolHandler(Protocols.DATA_SEND, this);
+  };
+
+  private handleSiriAudioStart = () => {
+    if (!this.audioSupported) {
+      throw new Error("Cannot start siri stream on remote where siri is not supported");
+    }
+
+    if (!this.isActive()) {
+      debug("Tried opening Siri audio stream, however no controller is connected!");
+      return;
+    }
+
+    if (this.activeAudioSession && (!this.activeAudioSession.isClosing() || this.nextAudioSession)) {
+      // there is already a session running, which is not in closing state and/or there is even already a
+      // nextAudioSession running. ignoring start request
+      debug("Tried opening Siri audio stream, however there is already one in progress");
+      return;
+    }
+
+    const connection = this.dataStreamConnections[this.activeIdentifier]; // get connection for current target
+    if (connection === undefined) {
+      // target seems not connected, ignore it
+      debug("Tried opening Siri audio stream however target is not connected via HDS");
+      return;
+    }
+
+    const audioSession = new SiriAudioSession(
+      connection,
+      this.selectedAudioConfiguration,
+      this.audioProducerConstructor!,
+      this.audioProducerOptions
+    );
+    if (!this.activeAudioSession) {
+      this.activeAudioSession = audioSession;
+    } else {
+      // we checked above that this only happens if the activeAudioSession is in closing state,
+      // so no collision with the input device can happen
+      this.nextAudioSession = audioSession;
+    }
+
+    audioSession.on(SiriAudioSessionEvents.CLOSE, this.handleSiriAudioSessionClosed.bind(this, audioSession));
+    audioSession.start();
+  };
+
+  private handleSiriAudioStop = () => {
+    if (this.activeAudioSession) {
+      if (!this.activeAudioSession.isClosing()) {
+        this.activeAudioSession.stop();
+        return;
+      } else if (this.nextAudioSession && !this.nextAudioSession.isClosing()) {
+        this.nextAudioSession.stop();
+        return;
+      }
+    }
+
+    debug("handleSiriAudioStop called although no audio session was started");
+  };
+
+  private handleDataSendAckEvent = (message: Record<any, any>) => {
+    // transfer was successful
+    const streamId = message["streamId"];
+    const endOfStream = message["endOfStream"];
+
+    if (this.activeAudioSession && this.activeAudioSession.streamId === streamId) {
+      this.activeAudioSession.handleDataSendAckEvent(endOfStream);
+    } else if (this.nextAudioSession && this.nextAudioSession.streamId === streamId) {
+      this.nextAudioSession.handleDataSendAckEvent(endOfStream);
+    } else {
+      debug("Received dataSend acknowledgment event for unknown streamId '%s'", streamId);
+    }
+  };
+
+  private handleDataSendCloseEvent = (message: Record<any, any>) => {
+    // controller indicates he can't handle audio request currently
+    const streamId = message["streamId"];
+    const reason = message["reason"] as DataSendCloseReason;
+
+    if (this.activeAudioSession && this.activeAudioSession.streamId === streamId) {
+      this.activeAudioSession.handleDataSendCloseEvent(reason);
+    } else if (this.nextAudioSession && this.nextAudioSession.streamId === streamId) {
+      this.nextAudioSession.handleDataSendCloseEvent(reason);
+    } else {
+      debug("Received dataSend close event for unknown streamId '%s'", streamId);
+    }
+  };
+
+  private handleSiriAudioSessionClosed = (session: SiriAudioSession) => {
+    if (session === this.activeAudioSession) {
+      this.activeAudioSession = this.nextAudioSession;
+      this.nextAudioSession = undefined;
+    } else if (session === this.nextAudioSession) {
+      this.nextAudioSession = undefined;
+    }
+  };
+
+  private handleDataStreamConnectionClosed = (connection: DataStreamConnection) => {
+    for (const targetIdentifier in this.dataStreamConnections) {
+      const connection0 = this.dataStreamConnections[targetIdentifier];
+      if (connection === connection0) {
+        debug("HDS connection disconnected for targetIdentifier %s", targetIdentifier);
+        delete this.dataStreamConnections[targetIdentifier];
+        break;
+      }
+    }
+  };
+
+  // ------------------------------- AUDIO CONFIGURATION -------------------------------
+
+  private handleSelectedAudioConfigurationWrite = (value: any, callback: CharacteristicSetCallback) => {
+    const data = Buffer.from(value, "base64");
+    const objects = tlv.decode(data);
+
+    const selectedAudioStreamConfiguration = tlv.decode(
+      objects[SelectedAudioInputStreamConfigurationTypes.SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION]
+    );
+
+    const codec = selectedAudioStreamConfiguration[AudioTypes.CODEC][0];
+    const parameters = tlv.decode(selectedAudioStreamConfiguration[AudioTypes.CODEC_PARAM]);
+
+    const channels = parameters[AudioCodecParamTypes.CHANNEL][0];
+    const bitrate = parameters[AudioCodecParamTypes.BIT_RATE][0];
+    const samplerate = parameters[AudioCodecParamTypes.SAMPLE_RATE][0];
+
+    this.selectedAudioConfiguration = {
+      codecType: codec,
+      parameters: {
+        channels: channels,
+        bitrate: bitrate,
+        samplerate: samplerate,
+        rtpTime: 20,
+      },
+    };
+    this.selectedAudioConfigurationString = this.buildSelectedAudioConfigurationTLV({
+      audioCodecConfiguration: this.selectedAudioConfiguration,
+    });
+
+    callback();
+  };
+
+  private buildSupportedAudioConfigurationTLV = (configuration: SupportedAudioStreamConfiguration) => {
+    const codecConfigurationTLV = this.buildCodecConfigurationTLV(configuration.audioCodecConfiguration);
+
+    const supportedAudioStreamConfiguration = tlv.encode(
+      SupportedAudioStreamConfigurationTypes.AUDIO_CODEC_CONFIGURATION,
+      codecConfigurationTLV
+    );
+    return supportedAudioStreamConfiguration.toString("base64");
+  };
+
+  private buildSelectedAudioConfigurationTLV = (configuration: SelectedAudioStreamConfiguration) => {
+    const codecConfigurationTLV = this.buildCodecConfigurationTLV(configuration.audioCodecConfiguration);
+
+    const supportedAudioStreamConfiguration = tlv.encode(
+      SelectedAudioInputStreamConfigurationTypes.SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION,
+      codecConfigurationTLV
+    );
+    return supportedAudioStreamConfiguration.toString("base64");
+  };
+
+  private buildCodecConfigurationTLV = (codecConfiguration: AudioCodecConfiguration) => {
+    const parameters = codecConfiguration.parameters;
+
+    let parametersTLV = tlv.encode(
+      AudioCodecParamTypes.CHANNEL,
+      parameters.channels,
+      AudioCodecParamTypes.BIT_RATE,
+      parameters.bitrate,
+      AudioCodecParamTypes.SAMPLE_RATE,
+      parameters.samplerate
+    );
+    if (parameters.rtpTime) {
+      parametersTLV = Buffer.concat([parametersTLV, tlv.encode(AudioCodecParamTypes.PACKET_TIME, parameters.rtpTime)]);
+    }
+
+    return tlv.encode(AudioTypes.CODEC, codecConfiguration.codecType, AudioTypes.CODEC_PARAM, parametersTLV);
+  };
+
+  // -----------------------------------------------------------------------------------
+
+  _createServices = () => {
+    this.targetControlManagementService = new Service.TargetControlManagement("", "");
+    this.targetControlManagementService
+      .getCharacteristic(Characteristic.TargetControlSupportedConfiguration)!
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        callback(null, this.supportedConfiguration);
+      })
+      .getValue();
+    this.targetControlManagementService
+      .getCharacteristic(Characteristic.TargetControlList)!
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        callback(null, this.targetConfigurationsString);
+      })
+      .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+        this.handleTargetControlWrite(value, callback);
+      })
+      .getValue();
+
+    // you can also expose multiple TargetControl services to control multiple apple tvs simultaneously.
+    // should we extend this class to support multiple TargetControl services or should users just create a second accessory?
+    this.targetControlService = new Service.TargetControl("", "");
+    this.targetControlService
+      .getCharacteristic(Characteristic.ActiveIdentifier)!
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        callback(undefined, this.activeIdentifier);
+      })
+      .getValue();
+    this.targetControlService
+      .getCharacteristic(Characteristic.Active)!
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        callback(undefined, this.isActive());
+      })
+      .on(
+        CharacteristicEventTypes.SET,
+        (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
+          this.handleActiveWrite(value, callback, connectionID);
+        }
+      )
+      .getValue();
+    this.targetControlService
+      .getCharacteristic(Characteristic.ButtonEvent)!
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        callback(undefined, this.lastButtonEvent);
+      })
+      .getValue();
+
+    if (this.audioSupported) {
+      this.siriService = new Service.Siri("", "");
+      this.siriService
+        .getCharacteristic(Characteristic.SiriInputType)!
+        .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+          callback(undefined, SiriInputType.PUSH_BUTTON_TRIGGERED_APPLE_TV);
+        });
+
+      this.audioStreamManagementService = new Service.AudioStreamManagement("", "");
+      this.audioStreamManagementService
+        .getCharacteristic(Characteristic.SupportedAudioStreamConfiguration)!
+        .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+          callback(undefined, this.supportedAudioConfiguration);
+        })
+        .getValue();
+      this.audioStreamManagementService
+        .getCharacteristic(Characteristic.SelectedAudioStreamConfiguration)!
+        .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+          callback(null, this.selectedAudioConfigurationString);
+        })
+        .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+          this.handleSelectedAudioConfigurationWrite(value, callback);
+        })
+        .getValue();
+
+      this.dataStreamManagement = new DataStreamManagement();
+
+      this.siriService.addLinkedService(this.dataStreamManagement.getService());
+      this.siriService.addLinkedService(this.audioStreamManagementService);
+    }
+  };
 }
 
 export enum SiriAudioSessionEvents {
-    CLOSE = "close",
+  CLOSE = "close",
 }
 
 export type SiriAudioSessionEventMap = {
-    [SiriAudioSessionEvents.CLOSE]: () => void;
-}
+  [SiriAudioSessionEvents.CLOSE]: () => void;
+};
 
 /**
  * Represents an ongoing audio transmission
  */
 export class SiriAudioSession extends EventEmitter<SiriAudioSessionEventMap> {
+  readonly connection: DataStreamConnection;
+  private readonly selectedAudioConfiguration: AudioCodecConfiguration;
 
-    readonly connection: DataStreamConnection;
-    private readonly selectedAudioConfiguration: AudioCodecConfiguration;
+  private readonly producer: SiriAudioStreamProducer;
+  private producerRunning = false; // indicates if the producer is running
+  private producerTimer?: Timeout; // producer has a 3s timeout to produce the first frame, otherwise transmission will be cancelled
 
-    private readonly producer: SiriAudioStreamProducer;
-    private producerRunning = false; // indicates if the producer is running
-    private producerTimer?: Timeout; // producer has a 3s timeout to produce the first frame, otherwise transmission will be cancelled
+  state: SiriAudioSessionState = SiriAudioSessionState.STARTING;
+  streamId?: number; // present when state >= SENDING
+  endOfStream: boolean = false;
 
-    state: SiriAudioSessionState = SiriAudioSessionState.STARTING;
-    streamId?: number; // present when state >= SENDING
-    endOfStream: boolean = false;
+  private audioFrameQueue: AudioFrame[] = [];
+  private readonly maxQueueSize = 1024;
+  private sequenceNumber: number = 0;
 
-    private audioFrameQueue: AudioFrame[] = [];
-    private readonly maxQueueSize = 1024;
-    private sequenceNumber: number = 0;
+  private readonly closeListener: () => void;
 
-    private readonly closeListener: () => void;
+  constructor(
+    connection: DataStreamConnection,
+    selectedAudioConfiguration: AudioCodecConfiguration,
+    producerConstructor: SiriAudioStreamProducerConstructor,
+    producerOptions?: any
+  ) {
+    super();
+    this.connection = connection;
+    this.selectedAudioConfiguration = selectedAudioConfiguration;
 
-    constructor(connection: DataStreamConnection, selectedAudioConfiguration: AudioCodecConfiguration, producerConstructor: SiriAudioStreamProducerConstructor, producerOptions?: any) {
-        super();
-        this.connection = connection;
-        this.selectedAudioConfiguration = selectedAudioConfiguration;
+    this.producer = new producerConstructor(
+      this.handleSiriAudioFrame.bind(this),
+      this.handleProducerError.bind(this),
+      producerOptions
+    );
 
-        this.producer = new producerConstructor(this.handleSiriAudioFrame.bind(this), this.handleProducerError.bind(this), producerOptions);
+    this.connection.on(
+      DataStreamConnectionEvents.CLOSED,
+      (this.closeListener = this.handleDataStreamConnectionClosed.bind(this))
+    );
+  }
 
-        this.connection.on(DataStreamConnectionEvents.CLOSED, this.closeListener = this.handleDataStreamConnectionClosed.bind(this));
+  /**
+   * Called when siri button is pressed
+   */
+  start() {
+    debug("Sending request to start siri audio stream");
+
+    // opening dataSend
+    this.connection.sendRequest(
+      Protocols.DATA_SEND,
+      Topics.OPEN,
+      {
+        target: "controller",
+        type: "audio.siri",
+      },
+      (error, status, message) => {
+        if (this.state === SiriAudioSessionState.CLOSED) {
+          debug("Ignoring dataSend open response as the session is already closed");
+          return;
+        }
+
+        assert.strictEqual(this.state, SiriAudioSessionState.STARTING);
+        this.state = SiriAudioSessionState.SENDING;
+
+        if (error || status) {
+          if (error) {
+            // errors get produced by hap-nodejs
+            debug("Error occurred trying to start siri audio stream: %s", error.message);
+          } else if (status) {
+            // status codes are those returned by the hds response
+            debug("Controller responded with non-zero status code: %s", HDSStatus[status]);
+          }
+          this.closed();
+        } else {
+          this.streamId = message["streamId"];
+
+          if (!this.producerRunning) {
+            // audio producer errored in the meantime
+            this.sendDataSendCloseEvent(DataSendCloseReason.CANCELLED);
+          } else {
+            debug("Successfully setup siri audio stream with streamId %d", this.streamId);
+          }
+        }
+      }
+    );
+
+    this.startAudioProducer(); // start audio producer and queue frames in the meantime
+  }
+
+  /**
+   * @returns if the audio session is closing
+   */
+  isClosing() {
+    return this.state >= SiriAudioSessionState.CLOSING;
+  }
+
+  /**
+   * Called when siri button is released (or active identifier is changed to another device)
+   */
+  stop() {
+    assert(this.state <= SiriAudioSessionState.SENDING, "state was higher than SENDING");
+
+    debug("Stopping siri audio stream with streamId %d", this.streamId);
+
+    this.endOfStream = true; // mark as endOfStream
+    this.stopAudioProducer();
+
+    if (this.state === SiriAudioSessionState.SENDING) {
+      this.handleSiriAudioFrame(undefined); // send out last few audio frames with endOfStream property set
+
+      this.state = SiriAudioSessionState.CLOSING; // we are waiting for an acknowledgment (triggered by endOfStream property)
+    } else {
+      // if state is not SENDING (aka state is STARTING) the callback for DATA_SEND OPEN did not yet return (or never will)
+      this.closed();
+    }
+  }
+
+  private startAudioProducer() {
+    this.producer.startAudioProduction(this.selectedAudioConfiguration);
+    this.producerRunning = true;
+
+    this.producerTimer = setTimeout(() => {
+      // producer has 3s to start producing audio frames
+      debug(
+        "Didn't receive any frames from audio producer for stream with streamId %s. Canceling the stream now.",
+        this.streamId
+      );
+      this.producerTimer = undefined;
+      this.handleProducerError(DataSendCloseReason.CANCELLED);
+    }, 3000);
+  }
+
+  private stopAudioProducer() {
+    this.producer.stopAudioProduction();
+    this.producerRunning = false;
+
+    if (this.producerTimer) {
+      clearTimeout(this.producerTimer);
+      this.producerTimer = undefined;
+    }
+  }
+
+  private handleSiriAudioFrame = (frame?: AudioFrame) => {
+    // called from audio producer
+    if (this.state >= SiriAudioSessionState.CLOSING) {
+      return;
     }
 
-    /**
-     * Called when siri button is pressed
-     */
-    start() {
-        debug("Sending request to start siri audio stream");
-
-        // opening dataSend
-        this.connection.sendRequest(Protocols.DATA_SEND, Topics.OPEN, {
-            target: "controller",
-            type: "audio.siri"
-        }, (error, status, message) => {
-            if (this.state === SiriAudioSessionState.CLOSED) {
-                debug("Ignoring dataSend open response as the session is already closed");
-                return;
-            }
-
-            assert.strictEqual(this.state, SiriAudioSessionState.STARTING);
-            this.state = SiriAudioSessionState.SENDING;
-
-            if (error || status) {
-                if (error) { // errors get produced by hap-nodejs
-                    debug("Error occurred trying to start siri audio stream: %s", error.message);
-                } else if (status) { // status codes are those returned by the hds response
-                    debug("Controller responded with non-zero status code: %s", HDSStatus[status]);
-                }
-                this.closed();
-            } else {
-                this.streamId = message["streamId"];
-
-                if (!this.producerRunning) { // audio producer errored in the meantime
-                    this.sendDataSendCloseEvent(DataSendCloseReason.CANCELLED);
-                } else {
-                    debug("Successfully setup siri audio stream with streamId %d", this.streamId);
-                }
-            }
-        });
-
-        this.startAudioProducer(); // start audio producer and queue frames in the meantime
+    if (this.producerTimer) {
+      // if producerTimer is defined, then this is the first frame we are receiving
+      clearTimeout(this.producerTimer);
+      this.producerTimer = undefined;
     }
 
-    /**
-     * @returns if the audio session is closing
-     */
-    isClosing() {
-        return this.state >= SiriAudioSessionState.CLOSING;
+    if (frame && this.audioFrameQueue.length < this.maxQueueSize) {
+      // add frame to queue whilst it is not full
+      this.audioFrameQueue.push(frame);
     }
 
-    /**
-     * Called when siri button is released (or active identifier is changed to another device)
-     */
-    stop() {
-        assert(this.state <= SiriAudioSessionState.SENDING, "state was higher than SENDING");
+    if (this.state !== SiriAudioSessionState.SENDING) {
+      // dataSend isn't open yet
+      return;
+    }
 
-        debug("Stopping siri audio stream with streamId %d", this.streamId);
+    let queued;
+    while ((queued = this.popSome()) !== null) {
+      // send packets
+      const packets: AudioFramePacket[] = [];
+      queued.forEach(frame => {
+        const packetData: AudioFramePacket = {
+          data: frame.data,
+          metadata: {
+            rms: new Float32(frame.rms),
+            sequenceNumber: new Int64(this.sequenceNumber++),
+          },
+        };
+        packets.push(packetData);
+      });
 
-        this.endOfStream = true; // mark as endOfStream
+      const message: DataSendMessageData = {
+        packets: packets,
+        streamId: new Int64(this.streamId!),
+        endOfStream: this.endOfStream,
+      };
+
+      try {
+        this.connection.sendEvent(Protocols.DATA_SEND, Topics.DATA, message);
+      } catch (error) {
+        debug("Error occurred when trying to send audio frame of hds connection: %s", error.message);
+
         this.stopAudioProducer();
-
-        if (this.state === SiriAudioSessionState.SENDING) {
-            this.handleSiriAudioFrame(undefined); // send out last few audio frames with endOfStream property set
-
-            this.state = SiriAudioSessionState.CLOSING; // we are waiting for an acknowledgment (triggered by endOfStream property)
-        } else { // if state is not SENDING (aka state is STARTING) the callback for DATA_SEND OPEN did not yet return (or never will)
-            this.closed();
-        }
-    }
-
-    private startAudioProducer() {
-        this.producer.startAudioProduction(this.selectedAudioConfiguration);
-        this.producerRunning = true;
-
-        this.producerTimer = setTimeout(() => { // producer has 3s to start producing audio frames
-            debug("Didn't receive any frames from audio producer for stream with streamId %s. Canceling the stream now.", this.streamId);
-            this.producerTimer = undefined;
-            this.handleProducerError(DataSendCloseReason.CANCELLED);
-        }, 3000);
-    }
-
-    private stopAudioProducer() {
-        this.producer.stopAudioProduction();
-        this.producerRunning = false;
-
-        if (this.producerTimer) {
-            clearTimeout(this.producerTimer);
-            this.producerTimer = undefined;
-        }
-    }
-
-    private handleSiriAudioFrame = (frame?: AudioFrame) => { // called from audio producer
-        if (this.state >= SiriAudioSessionState.CLOSING) {
-            return;
-        }
-
-        if (this.producerTimer) { // if producerTimer is defined, then this is the first frame we are receiving
-            clearTimeout(this.producerTimer);
-            this.producerTimer = undefined;
-        }
-
-        if (frame && this.audioFrameQueue.length < this.maxQueueSize) { // add frame to queue whilst it is not full
-            this.audioFrameQueue.push(frame);
-        }
-
-        if (this.state !== SiriAudioSessionState.SENDING) { // dataSend isn't open yet
-            return;
-        }
-
-        let queued;
-        while ((queued = this.popSome()) !== null) { // send packets
-            const packets: AudioFramePacket[] = [];
-            queued.forEach(frame => {
-                const packetData: AudioFramePacket = {
-                    data: frame.data,
-                    metadata: {
-                        rms: new Float32(frame.rms),
-                        sequenceNumber: new Int64(this.sequenceNumber++),
-                    }
-                };
-                packets.push(packetData);
-            });
-
-            const message: DataSendMessageData = {
-                packets: packets,
-                streamId: new Int64(this.streamId!),
-                endOfStream: this.endOfStream,
-            };
-
-            try {
-                this.connection.sendEvent(Protocols.DATA_SEND, Topics.DATA, message);
-            } catch (error) {
-                debug("Error occurred when trying to send audio frame of hds connection: %s", error.message);
-
-                this.stopAudioProducer();
-                this.closed();
-            }
-
-            if (this.endOfStream) {
-                break; // popSome() returns empty list if endOfStream=true
-            }
-        }
-    };
-
-    private handleProducerError = (error: DataSendCloseReason) => { // called from audio producer
-        if (this.state >= SiriAudioSessionState.CLOSING) {
-            return;
-        }
-
-        this.stopAudioProducer(); // ensure backend is closed
-        if (this.state === SiriAudioSessionState.SENDING) { // if state is less than sending dataSend isn't open (yet)
-            this.sendDataSendCloseEvent(error); // cancel submission
-        }
-    };
-
-    handleDataSendAckEvent = (endOfStream: boolean) => { // transfer was successful
-        assert.strictEqual(endOfStream, true);
-
-        debug("Received acknowledgment for siri audio stream with streamId %s, closing it now", this.streamId);
-
-        this.sendDataSendCloseEvent(DataSendCloseReason.NORMAL);
-    };
-
-    handleDataSendCloseEvent = (reason: DataSendCloseReason) => { // controller indicates he can't handle audio request currently
-        debug("Received close event from controller with reason %s for stream with streamId %s", DataSendCloseReason[reason], this.streamId);
-        if (this.state <= SiriAudioSessionState.SENDING) {
-            this.stopAudioProducer();
-        }
-
         this.closed();
-    };
+      }
 
-    private sendDataSendCloseEvent = (reason: DataSendCloseReason) => {
-        assert(this.state >= SiriAudioSessionState.SENDING, "state was less than SENDING");
-        assert(this.state <= SiriAudioSessionState.CLOSING, "state was higher than CLOSING");
+      if (this.endOfStream) {
+        break; // popSome() returns empty list if endOfStream=true
+      }
+    }
+  };
 
-        this.connection.sendEvent(Protocols.DATA_SEND, Topics.CLOSE, {
-            streamId: new Int64(this.streamId!),
-            reason: new Int64(reason),
-        });
-
-        this.closed();
-    };
-
-    private handleDataStreamConnectionClosed = () => {
-        debug("Closing audio session with streamId %d", this.streamId);
-
-        if (this.state <= SiriAudioSessionState.SENDING) {
-            this.stopAudioProducer();
-        }
-
-        this.closed();
-    };
-
-    private closed = () => {
-        const lastState = this.state;
-        this.state = SiriAudioSessionState.CLOSED;
-
-        if (lastState !== SiriAudioSessionState.CLOSED) {
-            this.emit(SiriAudioSessionEvents.CLOSE);
-            this.connection.removeListener(DataStreamConnectionEvents.CLOSED, this.closeListener);
-        }
-    };
-
-    private popSome() { // tries to return 5 elements from the queue, if endOfStream=true also less than 5
-        if (this.audioFrameQueue.length < 5 && !this.endOfStream) {
-            return null;
-        }
-
-        const size = Math.min(this.audioFrameQueue.length, 5); // 5 frames per hap packet seems fine
-        const result = [];
-        for (let i = 0; i < size; i++) {
-            const element = this.audioFrameQueue.shift()!; // removes first element
-            result.push(element);
-        }
-
-        return result;
+  private handleProducerError = (error: DataSendCloseReason) => {
+    // called from audio producer
+    if (this.state >= SiriAudioSessionState.CLOSING) {
+      return;
     }
 
+    this.stopAudioProducer(); // ensure backend is closed
+    if (this.state === SiriAudioSessionState.SENDING) {
+      // if state is less than sending dataSend isn't open (yet)
+      this.sendDataSendCloseEvent(error); // cancel submission
+    }
+  };
+
+  handleDataSendAckEvent = (endOfStream: boolean) => {
+    // transfer was successful
+    assert.strictEqual(endOfStream, true);
+
+    debug("Received acknowledgment for siri audio stream with streamId %s, closing it now", this.streamId);
+
+    this.sendDataSendCloseEvent(DataSendCloseReason.NORMAL);
+  };
+
+  handleDataSendCloseEvent = (reason: DataSendCloseReason) => {
+    // controller indicates he can't handle audio request currently
+    debug(
+      "Received close event from controller with reason %s for stream with streamId %s",
+      DataSendCloseReason[reason],
+      this.streamId
+    );
+    if (this.state <= SiriAudioSessionState.SENDING) {
+      this.stopAudioProducer();
+    }
+
+    this.closed();
+  };
+
+  private sendDataSendCloseEvent = (reason: DataSendCloseReason) => {
+    assert(this.state >= SiriAudioSessionState.SENDING, "state was less than SENDING");
+    assert(this.state <= SiriAudioSessionState.CLOSING, "state was higher than CLOSING");
+
+    this.connection.sendEvent(Protocols.DATA_SEND, Topics.CLOSE, {
+      streamId: new Int64(this.streamId!),
+      reason: new Int64(reason),
+    });
+
+    this.closed();
+  };
+
+  private handleDataStreamConnectionClosed = () => {
+    debug("Closing audio session with streamId %d", this.streamId);
+
+    if (this.state <= SiriAudioSessionState.SENDING) {
+      this.stopAudioProducer();
+    }
+
+    this.closed();
+  };
+
+  private closed = () => {
+    const lastState = this.state;
+    this.state = SiriAudioSessionState.CLOSED;
+
+    if (lastState !== SiriAudioSessionState.CLOSED) {
+      this.emit(SiriAudioSessionEvents.CLOSE);
+      this.connection.removeListener(DataStreamConnectionEvents.CLOSED, this.closeListener);
+    }
+  };
+
+  private popSome() {
+    // tries to return 5 elements from the queue, if endOfStream=true also less than 5
+    if (this.audioFrameQueue.length < 5 && !this.endOfStream) {
+      return null;
+    }
+
+    const size = Math.min(this.audioFrameQueue.length, 5); // 5 frames per hap packet seems fine
+    const result = [];
+    for (let i = 0; i < size; i++) {
+      const element = this.audioFrameQueue.shift()!; // removes first element
+      result.push(element);
+    }
+
+    return result;
+  }
 }

--- a/src/lib/Service.spec.ts
+++ b/src/lib/Service.spec.ts
@@ -1,85 +1,56 @@
-import { Service, ServiceEventTypes } from './Service';
-import { generate } from './util/uuid';
-import './gen';
-import { Characteristic } from './Characteristic';
+import { Service, ServiceEventTypes } from "./Service";
+import { generate } from "./util/uuid";
+import "./gen";
+import { Characteristic } from "./Characteristic";
 
 const createService = () => {
-  return new Service('Test', generate('Foo'), 'subtype');
-}
+  return new Service("Test", generate("Foo"), "subtype");
+};
 
-describe('Service', () => {
-
-  describe('#constructor()', () => {
-    it('should set the name characteristic to the display name', () => {
+describe("Service", () => {
+  describe("#constructor()", () => {
+    it("should set the name characteristic to the display name", () => {
       const service = createService();
-      expect(service.getCharacteristic(Characteristic.Name)!.value).toEqual('Test');
+      expect(service.getCharacteristic(Characteristic.Name)!.value).toEqual("Test");
     });
 
-    it('should fail to load with no UUID', () => {
+    it("should fail to load with no UUID", () => {
       expect(() => {
-        new Service('Test', '', 'subtype');
-      }).toThrow('valid UUID');
+        new Service("Test", "", "subtype");
+      }).toThrow("valid UUID");
     });
   });
 
-  describe('#addCharacteristic()', () => {
+  describe("#addCharacteristic()", () => {});
 
-  });
+  describe("#setHiddenService()", () => {});
 
-  describe('#setHiddenService()', () => {
+  describe("#addLinkedService()", () => {});
 
-  });
+  describe("#removeLinkedService()", () => {});
 
-  describe('#addLinkedService()', () => {
+  describe("#removeCharacteristic()", () => {});
 
-  });
+  describe("#getCharacteristic()", () => {});
 
-  describe('#removeLinkedService()', () => {
+  describe("#testCharacteristic()", () => {});
 
-  });
+  describe("#setCharacteristic()", () => {});
 
-  describe('#removeCharacteristic()', () => {
+  describe("#updateCharacteristic()", () => {});
 
-  });
+  describe("#addOptionalCharacteristic()", () => {});
 
-  describe('#getCharacteristic()', () => {
+  describe("#getCharacteristicByIID()", () => {});
 
-  });
+  describe("#toHAP()", () => {});
 
-  describe('#testCharacteristic()', () => {
+  describe(`@${ServiceEventTypes.CHARACTERISTIC_CHANGE}`, () => {});
 
-  });
+  describe(`@${ServiceEventTypes.SERVICE_CONFIGURATION_CHANGE}`, () => {});
 
-  describe('#setCharacteristic()', () => {
-
-  });
-
-  describe('#updateCharacteristic()', () => {
-
-  });
-
-  describe('#addOptionalCharacteristic()', () => {
-
-  });
-
-  describe('#getCharacteristicByIID()', () => {
-
-  });
-
-  describe('#toHAP()', () => {
-
-  });
-
-  describe(`@${ServiceEventTypes.CHARACTERISTIC_CHANGE}`, () => {
-
-  });
-
-  describe(`@${ServiceEventTypes.SERVICE_CONFIGURATION_CHANGE}`, () => {
-
-  });
-
-  describe('#serialize', () => {
-    it('should serialize service', () => {
+  describe("#serialize", () => {
+    it("should serialize service", () => {
       const service = new Service.Lightbulb("TestLight", "subTypeLight");
       service.isHiddenService = true;
       service.isPrimaryService = true;
@@ -99,15 +70,17 @@ describe('Service', () => {
     });
   });
 
-  describe('#deserialize', () => {
-    it('should deserialize legacy json from homebridge', () => {
-      const json = JSON.parse('{"displayName":"Test Light","UUID":"00000043-0000-1000-8000-0026BB765291",' +
+  describe("#deserialize", () => {
+    it("should deserialize legacy json from homebridge", () => {
+      const json = JSON.parse(
+        '{"displayName":"Test Light","UUID":"00000043-0000-1000-8000-0026BB765291",' +
           '"characteristics":[{"displayName":"Name","UUID":"00000023-0000-1000-8000-0026BB765291",' +
           '"props":{"format":"string","unit":null,"minValue":null,"maxValue":null,"minStep":null,"perms":["pr"]},' +
           '"value":"Test Light","eventOnlyCharacteristic":false},' +
           '{"displayName":"On","UUID":"00000025-0000-1000-8000-0026BB765291",' +
           '"props":{"format":"bool","unit":null,"minValue":null,"maxValue":null,"minStep":null,"perms":["pr","pw","ev"]},' +
-          '"value":false,"eventOnlyCharacteristic":false}]}');
+          '"value":false,"eventOnlyCharacteristic":false}]}'
+      );
       const service = Service.deserialize(json);
 
       expect(service.displayName).toEqual(json.displayName);
@@ -123,9 +96,10 @@ describe('Service', () => {
       expect(service.optionalCharacteristics!.length).toEqual(0); // homebridge didn't save those
     });
 
-    it('should deserialize complete json', () => {
+    it("should deserialize complete json", () => {
       // json for a light accessory
-      const json = JSON.parse('{"displayName":"TestLight","UUID":"00000043-0000-1000-8000-0026BB765291",' +
+      const json = JSON.parse(
+        '{"displayName":"TestLight","UUID":"00000043-0000-1000-8000-0026BB765291",' +
           '"subtype":"subTypeLight","hiddenService":true,"primaryService":true,' +
           '"characteristics":[{"displayName":"Name","UUID":"00000023-0000-1000-8000-0026BB765291",' +
           '"props":{"format":"string","unit":null,"minValue":null,"maxValue":null,"minStep":null,"perms":["pr"]},' +
@@ -147,7 +121,8 @@ describe('Service', () => {
           '"value":"","accessRestrictedToAdmins":[],"eventOnlyCharacteristic":false},' +
           '{"displayName":"Color Temperature","UUID":"000000CE-0000-1000-8000-0026BB765291",' +
           '"props":{"format":"uint32","unit":null,"minValue":140,"maxValue":500,"minStep":1,"perms":["pr","pw","ev"]},' +
-          '"value":140,"accessRestrictedToAdmins":[],"eventOnlyCharacteristic":false}]}');
+          '"value":140,"accessRestrictedToAdmins":[],"eventOnlyCharacteristic":false}]}'
+      );
 
       const service = Service.deserialize(json);
 

--- a/src/lib/StreamController.ts
+++ b/src/lib/StreamController.ts
@@ -1,22 +1,23 @@
-import crypto from 'crypto';
+import crypto from "crypto";
 
-import ip from 'ip';
-import createDebug from 'debug';
+import ip from "ip";
+import createDebug from "debug";
 
-import * as tlv from './util/tlv';
-import { Service } from './Service';
+import * as tlv from "./util/tlv";
+import { Service } from "./Service";
 import {
   Characteristic,
   CharacteristicEventTypes,
   CharacteristicGetCallback,
-  CharacteristicSetCallback
-} from './Characteristic';
-import RTPProxy from './camera/RTPProxy';
-import { EventEmitter } from './EventEmitter';
-import { Camera } from './Camera';
+  CharacteristicSetCallback,
+} from "./Characteristic";
+import RTPProxy from "./camera/RTPProxy";
+import { EventEmitter } from "./EventEmitter";
+import { Camera } from "./Camera";
 import {
   Address,
-  AudioInfo, CharacteristicValue,
+  AudioInfo,
+  CharacteristicValue,
   NodeCallback,
   Nullable,
   SessionIdentifier,
@@ -25,9 +26,9 @@ import {
   StreamVideoParams,
   VideoInfo,
   VoidCallback,
-} from '../types';
+} from "../types";
 
-const debug = createDebug('StreamController');
+const debug = createDebug("StreamController");
 
 export enum SetupTypes {
   SESSION_ID = 0x01,
@@ -36,58 +37,58 @@ export enum SetupTypes {
   VIDEO_SRTP_PARAM = 0x04,
   AUDIO_SRTP_PARAM = 0x05,
   VIDEO_SSRC = 0x06,
-  AUDIO_SSRC = 0x07
+  AUDIO_SSRC = 0x07,
 }
 
 export enum SetupStatus {
   SUCCESS = 0x00,
   BUSY = 0x01,
-  ERROR = 0x02
+  ERROR = 0x02,
 }
 
 export enum SetupAddressVer {
   IPV4 = 0x00,
-  IPV6 = 0x01
+  IPV6 = 0x01,
 }
 
 export enum SetupAddressInfo {
   ADDRESS_VER = 0x01,
   ADDRESS = 0x02,
   VIDEO_RTP_PORT = 0x03,
-  AUDIO_RTP_PORT = 0x04
+  AUDIO_RTP_PORT = 0x04,
 }
 
 export enum SetupSRTP_PARAM {
   CRYPTO = 0x01,
   MASTER_KEY = 0x02,
-  MASTER_SALT = 0x03
+  MASTER_SALT = 0x03,
 }
 
 export enum StreamingStatus {
   AVAILABLE = 0x00,
   STREAMING = 0x01,
-  BUSY = 0x02
+  BUSY = 0x02,
 }
 
 export enum RTPConfigTypes {
-  CRYPTO = 0x02
+  CRYPTO = 0x02,
 }
 
 export enum SRTPCryptoSuites {
   AES_CM_128_HMAC_SHA1_80 = 0x00,
   AES_CM_256_HMAC_SHA1_80 = 0x01,
-  NONE = 0x02
+  NONE = 0x02,
 }
 
 export enum VideoTypes {
   CODEC = 0x01,
   CODEC_PARAM = 0x02,
   ATTRIBUTES = 0x03,
-  RTP_PARAM = 0x04
+  RTP_PARAM = 0x04,
 }
 
 export enum VideoCodecTypes {
-  H264 = 0x00
+  H264 = 0x00,
 }
 
 export enum VideoCodecParamTypes {
@@ -95,40 +96,40 @@ export enum VideoCodecParamTypes {
   LEVEL = 0x02,
   PACKETIZATION_MODE = 0x03,
   CVO_ENABLED = 0x04,
-  CVO_ID = 0x05
+  CVO_ID = 0x05,
 }
 
 export enum VideoCodecParamCVOTypes {
   UNSUPPORTED = 0x01,
-  SUPPORTED = 0x02
+  SUPPORTED = 0x02,
 }
 
 export enum VideoCodecParamProfileIDTypes {
   BASELINE = 0x00,
   MAIN = 0x01,
-  HIGH = 0x02
+  HIGH = 0x02,
 }
 
 export enum VideoCodecParamLevelTypes {
   TYPE3_1 = 0x00,
   TYPE3_2 = 0x01,
-  TYPE4_0 = 0x02
+  TYPE4_0 = 0x02,
 }
 
 export enum VideoCodecParamPacketizationModeTypes {
-  NON_INTERLEAVED = 0x00
+  NON_INTERLEAVED = 0x00,
 }
 
 export enum VideoAttributesTypes {
   IMAGE_WIDTH = 0x01,
   IMAGE_HEIGHT = 0x02,
-  FRAME_RATE = 0x03
+  FRAME_RATE = 0x03,
 }
 
 export enum SelectedStreamConfigurationTypes {
   SESSION = 0x01,
   VIDEO = 0x02,
-  AUDIO = 0x03
+  AUDIO = 0x03,
 }
 
 export enum RTPParamTypes {
@@ -137,39 +138,39 @@ export enum RTPParamTypes {
   MAX_BIT_RATE = 0x03,
   RTCP_SEND_INTERVAL = 0x04,
   MAX_MTU = 0x05,
-  COMFORT_NOISE_PAYLOAD_TYPE = 0x06
+  COMFORT_NOISE_PAYLOAD_TYPE = 0x06,
 }
 
 export enum AudioTypes {
   CODEC = 0x01,
   CODEC_PARAM = 0x02,
   RTP_PARAM = 0x03,
-  COMFORT_NOISE = 0x04
+  COMFORT_NOISE = 0x04,
 }
 
 export enum AudioCodecTypes {
   PCMU = 0x00,
   PCMA = 0x01,
   AACELD = 0x02,
-  OPUS = 0x03
+  OPUS = 0x03,
 }
 
 export enum AudioCodecParamTypes {
   CHANNEL = 0x01,
   BIT_RATE = 0x02,
   SAMPLE_RATE = 0x03,
-  PACKET_TIME = 0x04
+  PACKET_TIME = 0x04,
 }
 
 export enum AudioCodecParamBitRateTypes {
   VARIABLE = 0x00,
-  CONSTANT = 0x01
+  CONSTANT = 0x01,
 }
 
 export enum AudioCodecParamSampleRateTypes {
   KHZ_8 = 0x00,
   KHZ_16 = 0x01,
-  KHZ_24 = 0x02
+  KHZ_24 = 0x02,
 }
 
 export type StreamControllerOptions = {
@@ -178,16 +179,16 @@ export type StreamControllerOptions = {
   srtp: boolean;
   audio: StreamAudioParams;
   video: StreamVideoParams;
-}
+};
 
 export type HandleSetupReadCallback = NodeCallback<string | undefined>;
 export type HandleSetupWriteCallback = () => any;
 export type HandleStartStreamCallback = VoidCallback;
 
 export enum StreamRequestTypes {
-  RECONFIGURE = 'reconfigure',
-  START = 'start',
-  STOP = 'stop',
+  RECONFIGURE = "reconfigure",
+  START = "start",
+  STOP = "stop",
 }
 
 export type StreamRequest = {
@@ -195,33 +196,33 @@ export type StreamRequest = {
   type: StreamRequestTypes;
   video?: VideoInfo;
   audio?: AudioInfo;
-}
+};
 
 export type StartStreamRequest = {
   sessionID: SessionIdentifier;
   type: StreamRequestTypes.START;
   audio: AudioInfo;
   video: VideoInfo;
-}
+};
 
 export type ReconfigureStreamRequest = {
   sessionID: SessionIdentifier;
   type: StreamRequestTypes.RECONFIGURE;
   audio: AudioInfo;
   video: VideoInfo;
-}
+};
 
 export type StopStreamRequest = {
   sessionID: SessionIdentifier;
   type: StreamRequestTypes.STOP;
-}
+};
 
 export type PrepareStreamRequest = {
   sessionID: SessionIdentifier;
   targetAddress: string;
   audio: Source;
   video: Source;
-}
+};
 
 export type PreparedStreamRequestCallback = (response: PreparedStreamResponse) => void;
 
@@ -231,15 +232,14 @@ export type SourceResponse = {
   proxy_server_address: string;
   proxy_server_rtp: number;
   proxy_server_rtcp: number;
-}
+};
 export type PreparedStreamResponse = {
   address: Address;
   audio: Source & Partial<SourceResponse>;
   video: Source & Partial<SourceResponse>;
-}
+};
 
 export class StreamController {
-
   static SetupTypes = SetupTypes;
   static SetupStatus = SetupStatus;
   static SetupAddressVer = SetupAddressVer;
@@ -282,21 +282,17 @@ export class StreamController {
   audioProxy: any;
   videoProxy: any;
 
-  constructor(
-    public identifier: any,
-    public options: StreamControllerOptions,
-    public cameraSource?: Camera
-  ) {
+  constructor(public identifier: any, public options: StreamControllerOptions, public cameraSource?: Camera) {
     if (identifier === undefined) {
-      throw new Error('Identifier cannot be undefined');
+      throw new Error("Identifier cannot be undefined");
     }
 
     if (!options) {
-      throw new Error('Options cannot be undefined');
+      throw new Error("Options cannot be undefined");
     }
 
     if (!cameraSource) {
-      throw new Error('CameraSource cannot be undefined');
+      throw new Error("CameraSource cannot be undefined");
     }
 
     this.identifier = identifier;
@@ -311,14 +307,14 @@ export class StreamController {
 
     let videoParams = options["video"];
     if (!videoParams) {
-      throw new Error('Video parameters cannot be undefined in options');
+      throw new Error("Video parameters cannot be undefined in options");
     }
 
     this.supportedVideoStreamConfiguration = this._supportedVideoStreamConfiguration(videoParams);
 
     let audioParams = options["audio"];
     if (!audioParams) {
-      throw new Error('Audio parameters cannot be undefined in options');
+      throw new Error("Audio parameters cannot be undefined in options");
     }
 
     this.supportedAudioStreamConfiguration = this._supportedAudioStreamConfiguration(audioParams);
@@ -334,54 +330,61 @@ export class StreamController {
   forceStop = () => {
     this.connectionID = undefined;
     this._handleStopStream(undefined, true);
-  }
+  };
 
   handleCloseConnection = (connectionID: string) => {
     if (this.connectionID && this.connectionID == connectionID) {
       this.connectionID = undefined;
       this._handleStopStream();
     }
-  }
+  };
 
-// Private
+  // Private
   _createService = () => {
-    var managementService = new Service.CameraRTPStreamManagement('', this.identifier.toString());
+    var managementService = new Service.CameraRTPStreamManagement("", this.identifier.toString());
 
     managementService
       .getCharacteristic(Characteristic.StreamingStatus)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-        var data = tlv.encode( 0x01, this.streamStatus );
-        callback(null, data.toString('base64'));
-      }).getValue();
+        var data = tlv.encode(0x01, this.streamStatus);
+        callback(null, data.toString("base64"));
+      })
+      .getValue();
 
     managementService
       .getCharacteristic(Characteristic.SupportedRTPConfiguration)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         callback(null, this.supportedRTPConfiguration);
-      }).getValue();
+      })
+      .getValue();
 
     managementService
       .getCharacteristic(Characteristic.SupportedVideoStreamConfiguration)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         callback(null, this.supportedVideoStreamConfiguration);
-      }).getValue();
+      })
+      .getValue();
 
     managementService
       .getCharacteristic(Characteristic.SupportedAudioStreamConfiguration)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         callback(null, this.supportedAudioStreamConfiguration);
-      }).getValue();
+      })
+      .getValue();
 
     managementService
       .getCharacteristic(Characteristic.SelectedRTPStreamConfiguration)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-        debug('Read SelectedStreamConfiguration');
+        debug("Read SelectedStreamConfiguration");
         callback(null, this.selectedConfiguration);
       })
-      .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
-        debug('Write SelectedStreamConfiguration');
-        this._handleSelectedStreamConfigurationWrite(value, callback, connectionID!);
-      });
+      .on(
+        CharacteristicEventTypes.SET,
+        (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
+          debug("Write SelectedStreamConfiguration");
+          this._handleSelectedStreamConfigurationWrite(value, callback, connectionID!);
+        }
+      );
 
     managementService
       .getCharacteristic(Characteristic.SetupEndpoints)!
@@ -393,17 +396,17 @@ export class StreamController {
       });
 
     this.service = managementService;
-  }
+  };
 
   _handleSelectedStreamConfigurationWrite = (value: any, callback: any, connectionID: string) => {
     this.selectedConfiguration = value;
 
-    var data = Buffer.from(value, 'base64');
+    var data = Buffer.from(value, "base64");
     var objects = tlv.decode(data);
 
     var session;
 
-    if(objects[SelectedStreamConfigurationTypes.SESSION]) {
+    if (objects[SelectedStreamConfigurationTypes.SESSION]) {
       session = tlv.decode(objects[SelectedStreamConfigurationTypes.SESSION]);
       this.sessionIdentifier = session[0x01];
 
@@ -418,7 +421,7 @@ export class StreamController {
         this._handleStartStream(objects, session, false, callback);
       } else if (requestType == 0) {
         if (this.connectionID && this.connectionID != connectionID) {
-          debug("Received stop stream request from a different connection.")
+          debug("Received stop stream request from a different connection.");
         } else {
           this.connectionID = undefined;
         }
@@ -434,19 +437,23 @@ export class StreamController {
       debug("Unexpected request for Selected Stream Configuration");
       callback();
     }
-  }
+  };
 
-  _handleStartStream = (objects: Record<number, Buffer>, session: any, reconfigure: boolean = false, callback: HandleStartStreamCallback) => {
-
+  _handleStartStream = (
+    objects: Record<number, Buffer>,
+    session: any,
+    reconfigure: boolean = false,
+    callback: HandleStartStreamCallback
+  ) => {
     var request: Partial<StartStreamRequest | ReconfigureStreamRequest> = {
       sessionID: this.sessionIdentifier!,
-      type: !reconfigure ? StreamRequestTypes.START : StreamRequestTypes.RECONFIGURE
+      type: !reconfigure ? StreamRequestTypes.START : StreamRequestTypes.RECONFIGURE,
     };
 
     let videoPT = null;
     let audioPT = null;
 
-    if(objects[SelectedStreamConfigurationTypes.VIDEO]) {
+    if (objects[SelectedStreamConfigurationTypes.VIDEO]) {
       var videoInfo: Partial<VideoInfo> = {};
 
       var video = tlv.decode(objects[SelectedStreamConfigurationTypes.VIDEO]);
@@ -494,7 +501,7 @@ export class StreamController {
       request["video"] = videoInfo as VideoInfo;
     }
 
-    if(objects[SelectedStreamConfigurationTypes.AUDIO]) {
+    if (objects[SelectedStreamConfigurationTypes.AUDIO]) {
       var audioInfo: Partial<AudioInfo> = {};
 
       var audio = tlv.decode(objects[SelectedStreamConfigurationTypes.AUDIO]);
@@ -557,13 +564,12 @@ export class StreamController {
 
     this._updateStreamStatus(StreamingStatus.STREAMING);
     callback();
-  }
+  };
 
   _handleStopStream = (callback?: VoidCallback, silent: boolean = false) => {
-
     let request: Partial<StopStreamRequest> = {
-      "sessionID": this.sessionIdentifier!,
-      "type": StreamRequestTypes.STOP,
+      sessionID: this.sessionIdentifier!,
+      type: StreamRequestTypes.STOP,
     };
 
     if (!silent) {
@@ -585,11 +591,10 @@ export class StreamController {
     if (callback) {
       callback();
     }
-  }
+  };
 
   _handleSetupWrite = (value: CharacteristicValue, callback: HandleSetupWriteCallback) => {
-
-    var data = Buffer.from(`${value}`, 'base64');
+    var data = Buffer.from(`${value}`, "base64");
     var objects = tlv.decode(data) as any;
 
     this.sessionIdentifier = objects[SetupTypes.SESSION_ID];
@@ -598,7 +603,7 @@ export class StreamController {
     var targetAddressPayload = objects[SetupTypes.ADDRESS];
     var processedAddressInfo = tlv.decode(targetAddressPayload) as any;
     var isIPv6 = processedAddressInfo[SetupAddressInfo.ADDRESS_VER][0];
-    var targetAddress = processedAddressInfo[SetupAddressInfo.ADDRESS].toString('utf8');
+    var targetAddress = processedAddressInfo[SetupAddressInfo.ADDRESS].toString("utf8");
     var targetVideoPort = processedAddressInfo[SetupAddressInfo.VIDEO_RTP_PORT].readUInt16LE(0);
     var targetAudioPort = processedAddressInfo[SetupAddressInfo.AUDIO_RTP_PORT].readUInt16LE(0);
 
@@ -617,20 +622,30 @@ export class StreamController {
     var audioMasterSalt = processedAudioInfo[SetupSRTP_PARAM.MASTER_SALT];
 
     debug(
-      '\nSession: ', this.sessionIdentifier,
-      '\nControllerAddress: ', targetAddress,
-      '\nVideoPort: ', targetVideoPort,
-      '\nAudioPort: ', targetAudioPort,
-      '\nVideo Crypto: ', videoCryptoSuite,
-      '\nVideo Master Key: ', videoMasterKey,
-      '\nVideo Master Salt: ', videoMasterSalt,
-      '\nAudio Crypto: ', audioCryptoSuite,
-      '\nAudio Master Key: ', audioMasterKey,
-      '\nAudio Master Salt: ', audioMasterSalt
+      "\nSession: ",
+      this.sessionIdentifier,
+      "\nControllerAddress: ",
+      targetAddress,
+      "\nVideoPort: ",
+      targetVideoPort,
+      "\nAudioPort: ",
+      targetAudioPort,
+      "\nVideo Crypto: ",
+      videoCryptoSuite,
+      "\nVideo Master Key: ",
+      videoMasterKey,
+      "\nVideo Master Salt: ",
+      videoMasterSalt,
+      "\nAudio Crypto: ",
+      audioCryptoSuite,
+      "\nAudio Master Key: ",
+      audioMasterKey,
+      "\nAudio Master Salt: ",
+      audioMasterSalt
     );
 
     var request: Partial<PrepareStreamRequest> = {
-      "sessionID": this.sessionIdentifier!,
+      sessionID: this.sessionIdentifier!,
     };
 
     var videoInfo: Partial<Source> = {};
@@ -654,9 +669,10 @@ export class StreamController {
       request["video"] = videoInfo as Source;
       request["audio"] = audioInfo as Source;
 
-      this.cameraSource && this.cameraSource.prepareStream(request as PrepareStreamRequest, (response: PreparedStreamResponse) => {
-        this._generateSetupResponse(this.sessionIdentifier!, response, callback);
-      });
+      this.cameraSource &&
+        this.cameraSource.prepareStream(request as PrepareStreamRequest, (response: PreparedStreamResponse) => {
+          this._generateSetupResponse(this.sessionIdentifier!, response, callback);
+        });
     } else {
       request["targetAddress"] = ip.address();
       var promises = [];
@@ -666,7 +682,7 @@ export class StreamController {
         outgoingAddress: targetAddress,
         outgoingPort: targetVideoPort,
         outgoingSSRC: videoSSRCNumber,
-        disabled: false
+        disabled: false,
       });
 
       promises.push(this.videoProxy.setup());
@@ -678,7 +694,7 @@ export class StreamController {
           outgoingAddress: targetAddress,
           outgoingPort: targetAudioPort,
           outgoingSSRC: audioSSRCNumber,
-          disabled: this.videoOnly
+          disabled: this.videoOnly,
         });
 
         promises.push(this.audioProxy.setup());
@@ -699,15 +715,19 @@ export class StreamController {
         request["video"] = videoInfo as Source;
         request["audio"] = audioInfo as Source;
 
-        this.cameraSource && this.cameraSource.prepareStream(request as PrepareStreamRequest, (response: PreparedStreamResponse) => {
-          this._generateSetupResponse(this.sessionIdentifier!, response, callback);
-        });
+        this.cameraSource &&
+          this.cameraSource.prepareStream(request as PrepareStreamRequest, (response: PreparedStreamResponse) => {
+            this._generateSetupResponse(this.sessionIdentifier!, response, callback);
+          });
       });
     }
-  }
+  };
 
-  _generateSetupResponse = (identifier: SessionIdentifier, response: PreparedStreamResponse, callback: VoidCallback) => {
-
+  _generateSetupResponse = (
+    identifier: SessionIdentifier,
+    response: PreparedStreamResponse,
+    callback: VoidCallback
+  ) => {
     let ipVer = 0;
     let ipAddress = null;
     const videoPort = Buffer.alloc(2);
@@ -767,7 +787,6 @@ export class StreamController {
         audioPort.writeUInt16LE(audioInfo["port"], 0);
         audioSSRC.writeUInt32LE(audioInfo["ssrc"]!, 0);
       }
-
     } else {
       let addressInfo = response["address"];
 
@@ -795,53 +814,70 @@ export class StreamController {
         let audioSalt = audioInfo["srtp_salt"];
 
         videoSRTP = tlv.encode(
-          SetupSRTP_PARAM.CRYPTO, SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
-          SetupSRTP_PARAM.MASTER_KEY, videoKey,
-          SetupSRTP_PARAM.MASTER_SALT, videoSalt
+          SetupSRTP_PARAM.CRYPTO,
+          SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
+          SetupSRTP_PARAM.MASTER_KEY,
+          videoKey,
+          SetupSRTP_PARAM.MASTER_SALT,
+          videoSalt
         );
 
         audioSRTP = tlv.encode(
-          SetupSRTP_PARAM.CRYPTO, SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
-          SetupSRTP_PARAM.MASTER_KEY, audioKey,
-          SetupSRTP_PARAM.MASTER_SALT, audioSalt
+          SetupSRTP_PARAM.CRYPTO,
+          SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
+          SetupSRTP_PARAM.MASTER_KEY,
+          audioKey,
+          SetupSRTP_PARAM.MASTER_SALT,
+          audioSalt
         );
       }
     }
 
     var addressTLV = tlv.encode(
-      SetupAddressInfo.ADDRESS_VER, ipVer,
-      SetupAddressInfo.ADDRESS, ipAddress,
-      SetupAddressInfo.VIDEO_RTP_PORT, videoPort,
-      SetupAddressInfo.AUDIO_RTP_PORT, audioPort
+      SetupAddressInfo.ADDRESS_VER,
+      ipVer,
+      SetupAddressInfo.ADDRESS,
+      ipAddress,
+      SetupAddressInfo.VIDEO_RTP_PORT,
+      videoPort,
+      SetupAddressInfo.AUDIO_RTP_PORT,
+      audioPort
     );
 
     var responseTLV = tlv.encode(
-      SetupTypes.SESSION_ID, identifier,
-      SetupTypes.STATUS, SetupStatus.SUCCESS,
-      SetupTypes.ADDRESS, addressTLV,
-      SetupTypes.VIDEO_SRTP_PARAM, videoSRTP,
-      SetupTypes.AUDIO_SRTP_PARAM, audioSRTP,
-      SetupTypes.VIDEO_SSRC, videoSSRC,
-      SetupTypes.AUDIO_SSRC, audioSSRC
+      SetupTypes.SESSION_ID,
+      identifier,
+      SetupTypes.STATUS,
+      SetupStatus.SUCCESS,
+      SetupTypes.ADDRESS,
+      addressTLV,
+      SetupTypes.VIDEO_SRTP_PARAM,
+      videoSRTP,
+      SetupTypes.AUDIO_SRTP_PARAM,
+      audioSRTP,
+      SetupTypes.VIDEO_SSRC,
+      videoSSRC,
+      SetupTypes.AUDIO_SSRC,
+      audioSSRC
     );
 
-    this.setupResponse = responseTLV.toString('base64');
+    this.setupResponse = responseTLV.toString("base64");
     callback();
-  }
+  };
 
   _updateStreamStatus = (status: number) => {
-
     this.streamStatus = status;
 
-    this.service && this.service
-      .getCharacteristic(Characteristic.StreamingStatus)!
-      .setValue(tlv.encode( 0x01, this.streamStatus ).toString('base64'));
-  }
+    this.service &&
+      this.service
+        .getCharacteristic(Characteristic.StreamingStatus)!
+        .setValue(tlv.encode(0x01, this.streamStatus).toString("base64"));
+  };
 
   _handleSetupRead = (callback: HandleSetupReadCallback) => {
-    debug('Setup Read');
+    debug("Setup Read");
     callback(null, this.setupResponse);
-  }
+  };
 
   _supportedRTPConfiguration = (supportSRTP: boolean) => {
     var cryptoSuite = SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80;
@@ -851,20 +887,18 @@ export class StreamController {
       debug("Client claims it doesn't support SRTP. The stream may stops working with future iOS releases.");
     }
 
-    return tlv.encode(
-      RTPConfigTypes.CRYPTO, cryptoSuite
-    ).toString('base64');
-  }
+    return tlv.encode(RTPConfigTypes.CRYPTO, cryptoSuite).toString("base64");
+  };
 
   _supportedVideoStreamConfiguration = (videoParams: StreamVideoParams) => {
-
     let codec = videoParams["codec"];
     if (!codec) {
-      throw new Error('Video codec cannot be undefined');
+      throw new Error("Video codec cannot be undefined");
     }
 
     var videoCodecParamsTLV = tlv.encode(
-      VideoCodecParamTypes.PACKETIZATION_MODE, VideoCodecParamPacketizationModeTypes.NON_INTERLEAVED
+      VideoCodecParamTypes.PACKETIZATION_MODE,
+      VideoCodecParamPacketizationModeTypes.NON_INTERLEAVED
     );
 
     let profiles = codec["profiles"];
@@ -881,13 +915,13 @@ export class StreamController {
 
     let resolutions = videoParams["resolutions"];
     if (!resolutions) {
-      throw new Error('Video resolutions cannot be undefined');
+      throw new Error("Video resolutions cannot be undefined");
     }
 
     var videoAttrsTLV = Buffer.alloc(0);
     resolutions.forEach(function(resolution) {
       if (resolution.length != 3) {
-        throw new Error('Unexpected video resolution');
+        throw new Error("Unexpected video resolution");
       }
 
       var imageWidth = Buffer.alloc(2);
@@ -898,23 +932,26 @@ export class StreamController {
       frameRate.writeUInt8(resolution[2], 0);
 
       var videoAttrTLV = tlv.encode(
-        VideoAttributesTypes.IMAGE_WIDTH, imageWidth,
-        VideoAttributesTypes.IMAGE_HEIGHT, imageHeight,
-        VideoAttributesTypes.FRAME_RATE, frameRate
+        VideoAttributesTypes.IMAGE_WIDTH,
+        imageWidth,
+        VideoAttributesTypes.IMAGE_HEIGHT,
+        imageHeight,
+        VideoAttributesTypes.FRAME_RATE,
+        frameRate
       );
       var videoAttrBuffer = tlv.encode(VideoTypes.ATTRIBUTES, videoAttrTLV);
       videoAttrsTLV = Buffer.concat([videoAttrsTLV, videoAttrBuffer]);
     });
 
     var configurationTLV = tlv.encode(
-      VideoTypes.CODEC, VideoCodecTypes.H264,
-      VideoTypes.CODEC_PARAM, videoCodecParamsTLV
+      VideoTypes.CODEC,
+      VideoCodecTypes.H264,
+      VideoTypes.CODEC_PARAM,
+      videoCodecParamsTLV
     );
 
-    return tlv.encode(
-      0x01, Buffer.concat([configurationTLV, videoAttrsTLV])
-    ).toString('base64');
-  }
+    return tlv.encode(0x01, Buffer.concat([configurationTLV, videoAttrsTLV])).toString("base64");
+  };
 
   _supportedAudioStreamConfiguration = (audioParams: StreamAudioParams) => {
     // Only AACELD and OPUS are accepted by iOS currently, and we need to give it something it will accept
@@ -928,13 +965,13 @@ export class StreamController {
 
     let codecs = audioParams["codecs"];
     if (!codecs) {
-      throw new Error('Audio codecs cannot be undefined');
+      throw new Error("Audio codecs cannot be undefined");
     }
 
     var audioConfigurationsBuffer = Buffer.alloc(0);
     var hasSupportedCodec = false;
 
-    codecs.forEach(function(codecParam){
+    codecs.forEach(function(codecParam) {
       var codec = AudioCodecTypes.OPUS;
       var bitrate = AudioCodecParamBitRateTypes.CONSTANT;
       var samplerate = AudioCodecParamSampleRateTypes.KHZ_24;
@@ -942,7 +979,7 @@ export class StreamController {
       let param_type = codecParam["type"];
       let param_samplerate = codecParam["samplerate"];
 
-      if (param_type == 'OPUS') {
+      if (param_type == "OPUS") {
         hasSupportedCodec = true;
         bitrate = AudioCodecParamBitRateTypes.VARIABLE;
       } else if (param_type == "AAC-eld") {
@@ -966,21 +1003,21 @@ export class StreamController {
       }
 
       var audioParamTLV = tlv.encode(
-        AudioCodecParamTypes.CHANNEL, 1,
-        AudioCodecParamTypes.BIT_RATE, bitrate,
-        AudioCodecParamTypes.SAMPLE_RATE, samplerate
+        AudioCodecParamTypes.CHANNEL,
+        1,
+        AudioCodecParamTypes.BIT_RATE,
+        bitrate,
+        AudioCodecParamTypes.SAMPLE_RATE,
+        samplerate
       );
 
-      var audioConfiguration = tlv.encode(
-        AudioTypes.CODEC, codec,
-        AudioTypes.CODEC_PARAM, audioParamTLV
-      );
+      var audioConfiguration = tlv.encode(AudioTypes.CODEC, codec, AudioTypes.CODEC_PARAM, audioParamTLV);
 
       audioConfigurationsBuffer = Buffer.concat([audioConfigurationsBuffer, tlv.encode(0x01, audioConfiguration)]);
     });
 
     // If we're not one of the supported codecs
-    if(!hasSupportedCodec) {
+    if (!hasSupportedCodec) {
       debug("Client doesn't support any audio codec that HomeKit supports.");
 
       var codec = AudioCodecTypes.OPUS;
@@ -988,23 +1025,21 @@ export class StreamController {
       var samplerate = AudioCodecParamSampleRateTypes.KHZ_24;
 
       var audioParamTLV = tlv.encode(
-        AudioCodecParamTypes.CHANNEL, 1,
-        AudioCodecParamTypes.BIT_RATE, bitrate,
-        AudioCodecParamTypes.SAMPLE_RATE, AudioCodecParamSampleRateTypes.KHZ_24
+        AudioCodecParamTypes.CHANNEL,
+        1,
+        AudioCodecParamTypes.BIT_RATE,
+        bitrate,
+        AudioCodecParamTypes.SAMPLE_RATE,
+        AudioCodecParamSampleRateTypes.KHZ_24
       );
 
-
-      var audioConfiguration = tlv.encode(
-        AudioTypes.CODEC, codec,
-        AudioTypes.CODEC_PARAM, audioParamTLV
-      );
+      var audioConfiguration = tlv.encode(AudioTypes.CODEC, codec, AudioTypes.CODEC_PARAM, audioParamTLV);
 
       audioConfigurationsBuffer = tlv.encode(0x01, audioConfiguration);
 
       this.videoOnly = true;
     }
 
-    return Buffer.concat([audioConfigurationsBuffer, tlv.encode(0x02, comfortNoiseValue)]).toString('base64');
-  }
+    return Buffer.concat([audioConfigurationsBuffer, tlv.encode(0x02, comfortNoiseValue)]).toString("base64");
+  };
 }
-

--- a/src/lib/datastream/DataStreamManagement.ts
+++ b/src/lib/datastream/DataStreamManagement.ts
@@ -1,229 +1,252 @@
-import * as tlv from '../util/tlv';
+import * as tlv from "../util/tlv";
 import createDebug from "debug";
-import {Service} from "../Service";
+import { Service } from "../Service";
 import {
-    Characteristic,
-    CharacteristicEventTypes,
-    CharacteristicGetCallback,
-    CharacteristicSetCallback
+  Characteristic,
+  CharacteristicEventTypes,
+  CharacteristicGetCallback,
+  CharacteristicSetCallback,
 } from "../Characteristic";
-import {CharacteristicValue} from "../../types";
-import {DataStreamTransportManagement} from "../gen/HomeKit-DataStream";
-import {DataStreamServer, DataStreamServerEventMap, GlobalEventHandler, GlobalRequestHandler} from "./DataStreamServer";
-import {Session} from "../util/eventedhttp";
-import {Event} from "../EventEmitter";
+import { CharacteristicValue } from "../../types";
+import { DataStreamTransportManagement } from "../gen/HomeKit-DataStream";
+import {
+  DataStreamServer,
+  DataStreamServerEventMap,
+  GlobalEventHandler,
+  GlobalRequestHandler,
+} from "./DataStreamServer";
+import { Session } from "../util/eventedhttp";
+import { Event } from "../EventEmitter";
 
-const debug = createDebug('DataStream:Management');
+const debug = createDebug("DataStream:Management");
 
 export enum TransferTransportConfigurationTypes {
-    TRANSFER_TRANSPORT_CONFIGURATION = 1,
+  TRANSFER_TRANSPORT_CONFIGURATION = 1,
 }
 
 export enum TransportTypeTypes {
-    TRANSPORT_TYPE = 1,
+  TRANSPORT_TYPE = 1,
 }
 
-
 export enum SetupDataStreamSessionTypes {
-    SESSION_COMMAND_TYPE = 1,
-    TRANSPORT_TYPE = 2,
-    CONTROLLER_KEY_SALT = 3,
+  SESSION_COMMAND_TYPE = 1,
+  TRANSPORT_TYPE = 2,
+  CONTROLLER_KEY_SALT = 3,
 }
 
 export enum SetupDataStreamWriteResponseTypes {
-    STATUS = 1,
-    TRANSPORT_TYPE_SESSION_PARAMETERS = 2,
-    ACCESSORY_KEY_SALT = 3,
+  STATUS = 1,
+  TRANSPORT_TYPE_SESSION_PARAMETERS = 2,
+  ACCESSORY_KEY_SALT = 3,
 }
 
 export enum TransportSessionConfiguration {
-    TCP_LISTENING_PORT = 1,
+  TCP_LISTENING_PORT = 1,
 }
 
-
 export enum TransportType {
-    HOMEKIT_DATA_STREAM = 0,
+  HOMEKIT_DATA_STREAM = 0,
 }
 
 export enum SessionCommandType {
-    START_SESSION = 0,
+  START_SESSION = 0,
 }
 
 export enum DataStreamStatus {
-    SUCCESS = 0,
-    GENERIC_ERROR = 1,
-    BUSY = 2, // maximum numbers of sessions
+  SUCCESS = 0,
+  GENERIC_ERROR = 1,
+  BUSY = 2, // maximum numbers of sessions
 }
 
-
 export class DataStreamManagement {
+  // one server per accessory is probably the best practice
+  private readonly dataStreamServer: DataStreamServer = new DataStreamServer();
 
-    // one server per accessory is probably the best practice
-    private readonly dataStreamServer: DataStreamServer = new DataStreamServer();
+  dataStreamTransportManagementService: DataStreamTransportManagement;
 
-    dataStreamTransportManagementService: DataStreamTransportManagement;
+  supportedDataStreamTransportConfiguration: string;
+  lastSetupDataStreamTransportResponse: string = ""; // stripped. excludes ACCESSORY_KEY_SALT
 
-    supportedDataStreamTransportConfiguration: string;
-    lastSetupDataStreamTransportResponse: string = ""; // stripped. excludes ACCESSORY_KEY_SALT
+  constructor() {
+    const supportedConfiguration: TransportType[] = [TransportType.HOMEKIT_DATA_STREAM];
+    this.supportedDataStreamTransportConfiguration = this.buildSupportedDataStreamTransportConfigurationTLV(
+      supportedConfiguration
+    );
 
-    constructor() {
-        const supportedConfiguration: TransportType[] = [TransportType.HOMEKIT_DATA_STREAM];
-        this.supportedDataStreamTransportConfiguration = this.buildSupportedDataStreamTransportConfigurationTLV(supportedConfiguration);
+    this.dataStreamTransportManagementService = this.setupService();
+  }
 
+  /**
+   * @returns the DataStreamTransportManagement service
+   */
+  getService(): DataStreamTransportManagement {
+    return this.dataStreamTransportManagementService;
+  }
 
-        this.dataStreamTransportManagementService = this.setupService();
+  /**
+   * Registers a new event handler to handle incoming event messages.
+   * The handler is only called for a connection if for the give protocol no ProtocolHandler
+   * was registered on the connection level.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to register the handler for
+   * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalEventHandler} - function to be called for every occurring event
+   */
+  onEventMessage(protocol: string, event: string, handler: GlobalEventHandler): this {
+    this.dataStreamServer.onEventMessage(protocol, event, handler);
+    return this;
+  }
+
+  /**
+   * Removes an registered event handler.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+   * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalEventHandler} - registered event handler
+   */
+  removeEventHandler(protocol: string, event: string, handler: GlobalEventHandler): this {
+    this.dataStreamServer.removeEventHandler(protocol, event, handler);
+    return this;
+  }
+
+  /**
+   * Registers a new request handler to handle incoming request messages.
+   * The handler is only called for a connection if for the give protocol no ProtocolHandler
+   * was registered on the connection level.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to register the handler for
+   * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalRequestHandler} - function to be called for every occurring request
+   */
+  onRequestMessage(protocol: string, request: string, handler: GlobalRequestHandler): this {
+    this.dataStreamServer.onRequestMessage(protocol, request, handler);
+    return this;
+  }
+
+  /**
+   * Removes an registered request handler.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+   * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalRequestHandler} - registered request handler
+   */
+  removeRequestHandler(protocol: string, request: string, handler: GlobalRequestHandler): this {
+    this.dataStreamServer.removeRequestHandler(protocol, request, handler);
+    return this;
+  }
+
+  /**
+   * Forwards any event listener for an DataStreamServer event to the DataStreamServer instance
+   *
+   * @param event - the event to register for
+   * @param listener - the event handler
+   */
+  onServerEvent(
+    event: Event<keyof DataStreamServerEventMap>,
+    listener: DataStreamServerEventMap[Event<keyof DataStreamServerEventMap>]
+  ): this {
+    this.dataStreamServer.on(event, listener);
+    return this;
+  }
+
+  private handleSetupDataStreamTransportWrite(value: any, callback: CharacteristicSetCallback, connectionID?: string) {
+    const data = Buffer.from(value, "base64");
+    const objects = tlv.decode(data);
+
+    const sessionCommandType = objects[SetupDataStreamSessionTypes.SESSION_COMMAND_TYPE][0];
+    const transportType = objects[SetupDataStreamSessionTypes.TRANSPORT_TYPE][0];
+    const controllerKeySalt = objects[SetupDataStreamSessionTypes.CONTROLLER_KEY_SALT];
+
+    debug(
+      "Received setup write with command %s and transport type %s",
+      SessionCommandType[sessionCommandType],
+      TransportType[transportType]
+    );
+
+    if (sessionCommandType === SessionCommandType.START_SESSION) {
+      if (transportType !== TransportType.HOMEKIT_DATA_STREAM) {
+        callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+        return;
+      }
+
+      if (!connectionID) {
+        // we need the session for the shared secret to generate the encryption keys
+        callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+        return;
+      }
+
+      const session: Session = Session.getSession(connectionID);
+      if (!session) {
+        // we need the session for the shared secret to generate the encryption keys
+        callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+        return;
+      }
+
+      this.dataStreamServer.prepareSession(session, controllerKeySalt, preparedSession => {
+        const listeningPort = tlv.encode(
+          TransportSessionConfiguration.TCP_LISTENING_PORT,
+          tlv.writeUInt16(preparedSession.port!)
+        );
+
+        let response: Buffer = Buffer.concat([
+          tlv.encode(SetupDataStreamWriteResponseTypes.STATUS, DataStreamStatus.SUCCESS),
+          tlv.encode(SetupDataStreamWriteResponseTypes.TRANSPORT_TYPE_SESSION_PARAMETERS, listeningPort),
+        ]);
+        this.lastSetupDataStreamTransportResponse = response.toString("base64"); // save last response without accessory key salt
+
+        response = Buffer.concat([
+          response,
+          tlv.encode(SetupDataStreamWriteResponseTypes.ACCESSORY_KEY_SALT, preparedSession.accessoryKeySalt),
+        ]);
+        callback(null, response.toString("base64"));
+      });
+    } else {
+      callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+      return;
     }
+  }
 
-    /**
-     * @returns the DataStreamTransportManagement service
-     */
-    getService(): DataStreamTransportManagement {
-        return this.dataStreamTransportManagementService;
-    }
+  private static buildSetupStatusResponse(status: DataStreamStatus) {
+    return tlv.encode(SetupDataStreamWriteResponseTypes.STATUS, status).toString("base64");
+  }
 
-    /**
-     * Registers a new event handler to handle incoming event messages.
-     * The handler is only called for a connection if for the give protocol no ProtocolHandler
-     * was registered on the connection level.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to register the handler for
-     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalEventHandler} - function to be called for every occurring event
-     */
-    onEventMessage(protocol: string, event: string, handler: GlobalEventHandler): this {
-        this.dataStreamServer.onEventMessage(protocol, event, handler);
-        return this;
-    }
+  private buildSupportedDataStreamTransportConfigurationTLV(supportedConfiguration: TransportType[]): string {
+    const buffers: Buffer[] = [];
+    supportedConfiguration.forEach(type => {
+      const transportType = tlv.encode(TransportTypeTypes.TRANSPORT_TYPE, type);
+      const transferTransportConfiguration = tlv.encode(
+        TransferTransportConfigurationTypes.TRANSFER_TRANSPORT_CONFIGURATION,
+        transportType
+      );
 
-    /**
-     * Removes an registered event handler.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
-     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalEventHandler} - registered event handler
-     */
-    removeEventHandler(protocol: string, event: string, handler: GlobalEventHandler): this {
-        this.dataStreamServer.removeEventHandler(protocol, event, handler);
-        return this;
-    }
+      buffers.push(transferTransportConfiguration);
+    });
 
-    /**
-     * Registers a new request handler to handle incoming request messages.
-     * The handler is only called for a connection if for the give protocol no ProtocolHandler
-     * was registered on the connection level.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to register the handler for
-     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalRequestHandler} - function to be called for every occurring request
-     */
-    onRequestMessage(protocol: string, request: string, handler: GlobalRequestHandler): this {
-        this.dataStreamServer.onRequestMessage(protocol, request, handler);
-        return this;
-    }
+    return Buffer.concat(buffers).toString("base64");
+  }
 
-    /**
-     * Removes an registered request handler.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
-     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalRequestHandler} - registered request handler
-     */
-    removeRequestHandler(protocol: string, request: string, handler: GlobalRequestHandler): this {
-        this.dataStreamServer.removeRequestHandler(protocol, request, handler);
-        return this;
-    }
-
-    /**
-     * Forwards any event listener for an DataStreamServer event to the DataStreamServer instance
-     *
-     * @param event - the event to register for
-     * @param listener - the event handler
-     */
-    onServerEvent(event: Event<keyof DataStreamServerEventMap>, listener: DataStreamServerEventMap[Event<keyof DataStreamServerEventMap>]): this {
-        this.dataStreamServer.on(event, listener);
-        return this;
-    }
-
-    private handleSetupDataStreamTransportWrite(value: any, callback: CharacteristicSetCallback, connectionID?: string) {
-        const data = Buffer.from(value, 'base64');
-        const objects = tlv.decode(data);
-
-        const sessionCommandType = objects[SetupDataStreamSessionTypes.SESSION_COMMAND_TYPE][0];
-        const transportType = objects[SetupDataStreamSessionTypes.TRANSPORT_TYPE][0];
-        const controllerKeySalt = objects[SetupDataStreamSessionTypes.CONTROLLER_KEY_SALT];
-
-        debug("Received setup write with command %s and transport type %s", SessionCommandType[sessionCommandType], TransportType[transportType]);
-
-        if (sessionCommandType === SessionCommandType.START_SESSION) {
-            if (transportType !== TransportType.HOMEKIT_DATA_STREAM) {
-                callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
-                return;
-            }
-
-            if (!connectionID) { // we need the session for the shared secret to generate the encryption keys
-                callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
-                return;
-            }
-
-            const session: Session = Session.getSession(connectionID);
-            if (!session) { // we need the session for the shared secret to generate the encryption keys
-                callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
-                return;
-            }
-
-            this.dataStreamServer.prepareSession(session, controllerKeySalt, preparedSession => {
-                const listeningPort = tlv.encode(TransportSessionConfiguration.TCP_LISTENING_PORT, tlv.writeUInt16(preparedSession.port!));
-
-                let response: Buffer = Buffer.concat([
-                    tlv.encode(SetupDataStreamWriteResponseTypes.STATUS, DataStreamStatus.SUCCESS),
-                    tlv.encode(SetupDataStreamWriteResponseTypes.TRANSPORT_TYPE_SESSION_PARAMETERS, listeningPort)
-                ]);
-                this.lastSetupDataStreamTransportResponse = response.toString('base64'); // save last response without accessory key salt
-
-                response = Buffer.concat([
-                    response,
-                    tlv.encode(SetupDataStreamWriteResponseTypes.ACCESSORY_KEY_SALT, preparedSession.accessoryKeySalt)
-                ]);
-                callback(null, response.toString('base64'));
-            });
-        } else {
-            callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
-            return;
+  private setupService(): DataStreamTransportManagement {
+    const dataStreamTransportManagement = new Service.DataStreamTransportManagement("", "");
+    dataStreamTransportManagement
+      .getCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration)!
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        callback(undefined, this.supportedDataStreamTransportConfiguration);
+      })
+      .getValue();
+    dataStreamTransportManagement
+      .getCharacteristic(Characteristic.SetupDataStreamTransport)!
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        callback(null, this.lastSetupDataStreamTransportResponse);
+      })
+      .on(
+        CharacteristicEventTypes.SET,
+        (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
+          this.handleSetupDataStreamTransportWrite(value, callback, connectionID);
         }
-    }
+      )
+      .getValue();
+    dataStreamTransportManagement.setCharacteristic(Characteristic.Version, DataStreamServer.version);
 
-    private static buildSetupStatusResponse(status: DataStreamStatus) {
-        return tlv.encode(SetupDataStreamWriteResponseTypes.STATUS, status).toString('base64');
-    }
-
-    private buildSupportedDataStreamTransportConfigurationTLV(supportedConfiguration: TransportType[]): string {
-        const buffers: Buffer[] = [];
-        supportedConfiguration.forEach(type => {
-           const transportType = tlv.encode(TransportTypeTypes.TRANSPORT_TYPE, type);
-           const transferTransportConfiguration = tlv.encode(TransferTransportConfigurationTypes.TRANSFER_TRANSPORT_CONFIGURATION, transportType);
-
-           buffers.push(transferTransportConfiguration);
-        });
-
-        return Buffer.concat(buffers).toString('base64');
-    }
-
-    private setupService(): DataStreamTransportManagement {
-        const dataStreamTransportManagement = new Service.DataStreamTransportManagement('', '');
-        dataStreamTransportManagement.getCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.supportedDataStreamTransportConfiguration);
-            }).getValue();
-        dataStreamTransportManagement.getCharacteristic(Characteristic.SetupDataStreamTransport)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(null, this.lastSetupDataStreamTransportResponse);
-            })
-            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
-                this.handleSetupDataStreamTransportWrite(value, callback, connectionID);
-            }).getValue();
-        dataStreamTransportManagement.setCharacteristic(Characteristic.Version, DataStreamServer.version);
-
-        return dataStreamTransportManagement;
-    }
-
+    return dataStreamTransportManagement;
+  }
 }

--- a/src/lib/datastream/DataStreamParser.ts
+++ b/src/lib/datastream/DataStreamParser.ts
@@ -1,7 +1,7 @@
-import * as uuid from '../util/uuid'
-import * as encryption from "../util/encryption"
-import assert from 'assert';
-import createDebug from 'debug';
+import * as uuid from "../util/uuid";
+import * as encryption from "../util/encryption";
+import assert from "assert";
+import createDebug from "debug";
 
 // welcome to hell :)
 // in this file lies madness and frustration. and its not only about HDS. also JavaScript is hell
@@ -9,21 +9,21 @@ import createDebug from 'debug';
 const debug = createDebug("DataStream:Parser");
 
 class Magics {
-    static readonly TERMINATOR = { type: "terminator" };
+  static readonly TERMINATOR = { type: "terminator" };
 }
 
-export class ValueWrapper<T> { // basically used to differentiate between different sized integers when encoding (to force certain encoding)
+export class ValueWrapper<T> {
+  // basically used to differentiate between different sized integers when encoding (to force certain encoding)
 
-    value: T;
+  value: T;
 
-    constructor(value: T) {
-        this.value = value;
-    }
+  constructor(value: T) {
+    this.value = value;
+  }
 
-    public equals(obj: ValueWrapper<T>) : boolean {
-        return this.constructor.name === obj.constructor.name && obj.value === this.value;
-    }
-
+  public equals(obj: ValueWrapper<T>): boolean {
+    return this.constructor.name === obj.constructor.name && obj.value === this.value;
+  }
 }
 
 export class Int8 extends ValueWrapper<number> {}
@@ -34,868 +34,882 @@ export class Float32 extends ValueWrapper<number> {}
 export class Float64 extends ValueWrapper<number> {}
 export class SecondsSince2001 extends ValueWrapper<number> {}
 export class UUID extends ValueWrapper<string> {
-
-    constructor(value: string) {
-        assert(uuid.isValid(value), "invalid uuid format");
-        super(value);
-    }
-
+  constructor(value: string) {
+    assert(uuid.isValid(value), "invalid uuid format");
+    super(value);
+  }
 }
 
 export enum DataFormatTags {
-    INVALID = 0x00,
+  INVALID = 0x00,
 
-    TRUE = 0x01,
-    FALSE = 0x02,
+  TRUE = 0x01,
+  FALSE = 0x02,
 
-    TERMINATOR = 0x03,
-    NULL = 0x04,
-    UUID = 0x05,
-    DATE = 0x06,
+  TERMINATOR = 0x03,
+  NULL = 0x04,
+  UUID = 0x05,
+  DATE = 0x06,
 
-    INTEGER_MINUS_ONE = 0x07,
-    INTEGER_RANGE_START_0 = 0x08,
-    INTEGER_RANGE_STOP_39 = 0x2E,
-    INT8 = 0x30,
-    INT16LE = 0x31,
-    INT32LE = 0x32,
-    INT64LE = 0x33,
+  INTEGER_MINUS_ONE = 0x07,
+  INTEGER_RANGE_START_0 = 0x08,
+  INTEGER_RANGE_STOP_39 = 0x2e,
+  INT8 = 0x30,
+  INT16LE = 0x31,
+  INT32LE = 0x32,
+  INT64LE = 0x33,
 
-    FLOAT32LE = 0x35,
-    FLOAT64LE = 0x36,
+  FLOAT32LE = 0x35,
+  FLOAT64LE = 0x36,
 
-    UTF8_LENGTH_START = 0x40,
-    UTF8_LENGTH_STOP = 0x60,
-    UTF8_LENGTH8 = 0x61,
-    UTF8_LENGTH16LE = 0x62,
-    UTF8_LENGTH32LE = 0x63,
-    UTF8_LENGTH64LE = 0x64,
-    UTF8_NULL_TERMINATED = 0x6F,
+  UTF8_LENGTH_START = 0x40,
+  UTF8_LENGTH_STOP = 0x60,
+  UTF8_LENGTH8 = 0x61,
+  UTF8_LENGTH16LE = 0x62,
+  UTF8_LENGTH32LE = 0x63,
+  UTF8_LENGTH64LE = 0x64,
+  UTF8_NULL_TERMINATED = 0x6f,
 
-    DATA_LENGTH_START = 0x70,
-    DATA_LENGTH_STOP = 0x90,
-    DATA_LENGTH8 = 0x91,
-    DATA_LENGTH16LE = 0x92,
-    DATA_LENGTH32LE = 0x93,
-    DATA_LENGTH64LE = 0x94,
-    DATA_TERMINATED = 0x9F,
+  DATA_LENGTH_START = 0x70,
+  DATA_LENGTH_STOP = 0x90,
+  DATA_LENGTH8 = 0x91,
+  DATA_LENGTH16LE = 0x92,
+  DATA_LENGTH32LE = 0x93,
+  DATA_LENGTH64LE = 0x94,
+  DATA_TERMINATED = 0x9f,
 
-    DEDUPLICATION_START = 0xA0,
-    DEDUPLICATION_STOP = 0xCF,
+  DEDUPLICATION_START = 0xa0,
+  DEDUPLICATION_STOP = 0xcf,
 
-    ARRAY_LENGTH_START = 0xD0,
-    ARRAY_LENGTH_STOP = 0xDE,
-    ARRAY_TERMINATED = 0xDF,
+  ARRAY_LENGTH_START = 0xd0,
+  ARRAY_LENGTH_STOP = 0xde,
+  ARRAY_TERMINATED = 0xdf,
 
-    DICTIONARY_LENGTH_START = 0xE0,
-    DICTIONARY_LENGTH_STOP = 0xEE,
-    DICTIONARY_TERMINATED = 0xEF,
+  DICTIONARY_LENGTH_START = 0xe0,
+  DICTIONARY_LENGTH_STOP = 0xee,
+  DICTIONARY_TERMINATED = 0xef,
 }
 
 export namespace DataStreamParser {
+  export function decode(buffer: DataStreamReader): any {
+    const tag = buffer.readTag();
 
-    export function decode(buffer: DataStreamReader): any {
-        const tag = buffer.readTag();
+    if (tag === DataFormatTags.INVALID) {
+      throw new Error("HDSDecoder: zero tag detected on index " + buffer.readerIndex);
+    } else if (tag === DataFormatTags.TRUE) {
+      return buffer.readTrue();
+    } else if (tag === DataFormatTags.FALSE) {
+      return buffer.readFalse();
+    } else if (tag === DataFormatTags.TERMINATOR) {
+      return Magics.TERMINATOR;
+    } else if (tag === DataFormatTags.NULL) {
+      return null;
+    } else if (tag === DataFormatTags.UUID) {
+      return buffer.readUUID();
+    } else if (tag === DataFormatTags.DATE) {
+      return buffer.readSecondsSince2001_01_01();
+    } else if (tag === DataFormatTags.INTEGER_MINUS_ONE) {
+      return buffer.readNegOne();
+    } else if (tag >= DataFormatTags.INTEGER_RANGE_START_0 && tag <= DataFormatTags.INTEGER_RANGE_STOP_39) {
+      return buffer.readIntRange(tag); // integer values from 0-39
+    } else if (tag === DataFormatTags.INT8) {
+      return buffer.readInt8();
+    } else if (tag === DataFormatTags.INT16LE) {
+      return buffer.readInt16LE();
+    } else if (tag === DataFormatTags.INT32LE) {
+      return buffer.readInt32LE();
+    } else if (tag === DataFormatTags.INT64LE) {
+      return buffer.readInt64LE();
+    } else if (tag === DataFormatTags.FLOAT32LE) {
+      return buffer.readFloat32LE();
+    } else if (tag === DataFormatTags.FLOAT64LE) {
+      return buffer.readFloat64LE();
+    } else if (tag >= DataFormatTags.UTF8_LENGTH_START && tag <= DataFormatTags.UTF8_LENGTH_STOP) {
+      const length = tag - DataFormatTags.UTF8_LENGTH_START;
+      return buffer.readUTF8(length);
+    } else if (tag === DataFormatTags.UTF8_LENGTH8) {
+      return buffer.readUTF8_Length8();
+    } else if (tag === DataFormatTags.UTF8_LENGTH16LE) {
+      return buffer.readUTF8_Length16LE();
+    } else if (tag === DataFormatTags.UTF8_LENGTH32LE) {
+      return buffer.readUTF8_Length32LE();
+    } else if (tag === DataFormatTags.UTF8_LENGTH64LE) {
+      return buffer.readUTF8_Length64LE();
+    } else if (tag === DataFormatTags.UTF8_NULL_TERMINATED) {
+      return buffer.readUTF8_NULL_terminated();
+    } else if (tag >= DataFormatTags.DATA_LENGTH_START && tag <= DataFormatTags.DATA_LENGTH_STOP) {
+      const length = tag - DataFormatTags.DATA_LENGTH_START;
+      buffer.readData(length);
+    } else if (tag === DataFormatTags.DATA_LENGTH8) {
+      return buffer.readData_Length8();
+    } else if (tag === DataFormatTags.DATA_LENGTH16LE) {
+      return buffer.readData_Length16LE();
+    } else if (tag === DataFormatTags.DATA_LENGTH32LE) {
+      return buffer.readData_Length32LE();
+    } else if (tag === DataFormatTags.DATA_LENGTH64LE) {
+      return buffer.readData_Length64LE();
+    } else if (tag === DataFormatTags.DATA_TERMINATED) {
+      return buffer.readData_terminated();
+    } else if (tag >= DataFormatTags.DEDUPLICATION_START && tag <= DataFormatTags.DEDUPLICATION_STOP) {
+      const index = tag - DataFormatTags.DEDUPLICATION_START;
+      return buffer.deduplicateData(index);
+    } else if (tag >= DataFormatTags.ARRAY_LENGTH_START && tag <= DataFormatTags.ARRAY_LENGTH_STOP) {
+      const length = tag - DataFormatTags.ARRAY_LENGTH_START;
+      const array = [];
 
-        if (tag === DataFormatTags.INVALID) {
-            throw new Error("HDSDecoder: zero tag detected on index " + buffer.readerIndex);
-        } else if (tag === DataFormatTags.TRUE) {
-            return buffer.readTrue();
-        } else if (tag === DataFormatTags.FALSE) {
-            return buffer.readFalse();
-        } else if (tag === DataFormatTags.TERMINATOR) {
-            return Magics.TERMINATOR;
-        } else if (tag === DataFormatTags.NULL) {
-            return null;
-        } else if (tag === DataFormatTags.UUID) {
-            return buffer.readUUID();
-        } else if (tag === DataFormatTags.DATE) {
-            return buffer.readSecondsSince2001_01_01();
-        } else if (tag === DataFormatTags.INTEGER_MINUS_ONE) {
-            return buffer.readNegOne();
-        } else if (tag >= DataFormatTags.INTEGER_RANGE_START_0 && tag <= DataFormatTags.INTEGER_RANGE_STOP_39) {
-            return buffer.readIntRange(tag); // integer values from 0-39
-        } else if (tag === DataFormatTags.INT8) {
-            return buffer.readInt8();
-        } else if (tag === DataFormatTags.INT16LE) {
-            return buffer.readInt16LE();
-        } else if (tag === DataFormatTags.INT32LE) {
-            return buffer.readInt32LE();
-        } else if (tag === DataFormatTags.INT64LE) {
-            return buffer.readInt64LE();
-        } else if (tag === DataFormatTags.FLOAT32LE) {
-            return buffer.readFloat32LE();
-        } else if (tag === DataFormatTags.FLOAT64LE) {
-            return buffer.readFloat64LE();
-        } else if (tag >= DataFormatTags.UTF8_LENGTH_START && tag <= DataFormatTags.UTF8_LENGTH_STOP) {
-            const length = tag - DataFormatTags.UTF8_LENGTH_START;
-            return buffer.readUTF8(length);
-        } else if (tag === DataFormatTags.UTF8_LENGTH8) {
-            return buffer.readUTF8_Length8();
-        } else if (tag === DataFormatTags.UTF8_LENGTH16LE) {
-            return buffer.readUTF8_Length16LE();
-        } else if (tag === DataFormatTags.UTF8_LENGTH32LE) {
-            return buffer.readUTF8_Length32LE();
-        } else if (tag === DataFormatTags.UTF8_LENGTH64LE) {
-            return buffer.readUTF8_Length64LE();
-        } else if (tag === DataFormatTags.UTF8_NULL_TERMINATED) {
-            return buffer.readUTF8_NULL_terminated();
-        } else if (tag >= DataFormatTags.DATA_LENGTH_START && tag <= DataFormatTags.DATA_LENGTH_STOP) {
-            const length = tag - DataFormatTags.DATA_LENGTH_START;
-            buffer.readData(length);
-        } else if (tag === DataFormatTags.DATA_LENGTH8) {
-            return buffer.readData_Length8();
-        } else if (tag === DataFormatTags.DATA_LENGTH16LE) {
-            return buffer.readData_Length16LE();
-        } else if (tag === DataFormatTags.DATA_LENGTH32LE) {
-            return buffer.readData_Length32LE();
-        } else if (tag === DataFormatTags.DATA_LENGTH64LE) {
-            return buffer.readData_Length64LE();
-        } else if (tag === DataFormatTags.DATA_TERMINATED) {
-            return buffer.readData_terminated();
-        } else if (tag >= DataFormatTags.DEDUPLICATION_START && tag <= DataFormatTags.DEDUPLICATION_STOP) {
-            const index = tag - DataFormatTags.DEDUPLICATION_START;
-            return buffer.deduplicateData(index);
-        } else if (tag >= DataFormatTags.ARRAY_LENGTH_START && tag <= DataFormatTags.ARRAY_LENGTH_STOP) {
-            const length = tag - DataFormatTags.ARRAY_LENGTH_START;
-            const array = [];
+      for (let i = 0; i < length; i++) {
+        array.push(decode(buffer));
+      }
 
-            for (let i = 0; i < length; i++) {
-                array.push(decode(buffer));
-            }
+      return array;
+    } else if (tag === DataFormatTags.ARRAY_TERMINATED) {
+      const array = [];
 
-            return array;
-        } else if (tag === DataFormatTags.ARRAY_TERMINATED) {
-            const array = [];
+      let element;
+      while ((element = decode(buffer)) != Magics.TERMINATOR) {
+        array.push(element);
+      }
 
-            let element;
-            while ((element = decode(buffer)) != Magics.TERMINATOR) {
-                array.push(element);
-            }
+      return array;
+    } else if (tag >= DataFormatTags.DICTIONARY_LENGTH_START && tag <= DataFormatTags.DICTIONARY_LENGTH_STOP) {
+      const length = tag - DataFormatTags.DICTIONARY_LENGTH_START;
+      const dictionary: Record<any, any> = {};
 
-            return array;
-        } else if (tag >= DataFormatTags.DICTIONARY_LENGTH_START && tag <= DataFormatTags.DICTIONARY_LENGTH_STOP) {
-            const length = tag - DataFormatTags.DICTIONARY_LENGTH_START;
-            const dictionary: Record<any, any> = {};
+      for (let i = 0; i < length; i++) {
+        const key = decode(buffer);
+        dictionary[key] = decode(buffer);
+      }
 
-            for (let i = 0; i < length; i++) {
-                const key = decode(buffer);
-                dictionary[key] = decode(buffer);
-            }
+      return dictionary;
+    } else if (tag === DataFormatTags.DICTIONARY_TERMINATED) {
+      const dictionary: Record<any, any> = {};
 
-            return dictionary;
-        } else if (tag === DataFormatTags.DICTIONARY_TERMINATED) {
-            const dictionary: Record<any, any> = {};
+      let key;
+      while ((key = decode(buffer)) != Magics.TERMINATOR) {
+        dictionary[key] = decode(buffer); // decode value
+      }
 
-            let key;
-            while ((key = decode(buffer)) != Magics.TERMINATOR) {
-                dictionary[key] = decode(buffer); // decode value
-            }
+      return dictionary;
+    } else {
+      throw new Error("HDSDecoder: encountered unknown tag on index " + buffer.readerIndex + ": " + tag.toString(16));
+    }
+  }
 
-            return dictionary;
+  export function encode(data: any, buffer: DataStreamWriter): void {
+    if (data === undefined) {
+      throw new Error("HDSEncoder: cannot encode undefined");
+    }
+
+    if (data === null) {
+      buffer.writeTag(DataFormatTags.NULL);
+      return;
+    }
+
+    switch (typeof data) {
+      case "boolean":
+        if (data) {
+          buffer.writeTrue();
         } else {
-            throw new Error("HDSDecoder: encountered unknown tag on index " + buffer.readerIndex + ": " + tag.toString(16));
+          buffer.writeFalse();
         }
+        break;
+      case "number":
+        if (Number.isInteger(data)) {
+          buffer.writeNumber(data);
+        } else {
+          buffer.writeFloat64LE(new Float64(data));
+        }
+        break;
+      case "string":
+        buffer.writeUTF8(data);
+        break;
+      case "object":
+        if (Array.isArray(data)) {
+          const length = data.length;
+
+          if (length <= 12) {
+            buffer.writeTag(DataFormatTags.ARRAY_LENGTH_START + length);
+          } else {
+            buffer.writeTag(DataFormatTags.ARRAY_TERMINATED);
+          }
+
+          data.forEach(element => {
+            encode(element, buffer);
+          });
+
+          if (length > 12) {
+            buffer.writeTag(DataFormatTags.TERMINATOR);
+          }
+        } else if (data instanceof ValueWrapper) {
+          if (data instanceof Int8) {
+            buffer.writeInt8(data);
+          } else if (data instanceof Int16) {
+            buffer.writeInt16LE(data);
+          } else if (data instanceof Int32) {
+            buffer.writeInt32LE(data);
+          } else if (data instanceof Int64) {
+            buffer.writeInt64LE(data);
+          } else if (data instanceof Float32) {
+            buffer.writeFloat32LE(data);
+          } else if (data instanceof Float64) {
+            buffer.writeFloat64LE(data);
+          } else if (data instanceof SecondsSince2001) {
+            buffer.writeSecondsSince2001_01_01(data);
+          } else if (data instanceof UUID) {
+            buffer.writeUUID(data.value);
+          } else {
+            throw new Error("Unknown wrapped object 'ValueWrapper' of class " + data.constructor.name);
+          }
+        } else if (data instanceof Buffer) {
+          buffer.writeData(data);
+        } else {
+          // object is treated as dictionary
+          const entries = Object.entries(data);
+
+          if (entries.length <= 14) {
+            buffer.writeTag(DataFormatTags.DICTIONARY_LENGTH_START + entries.length);
+          } else {
+            buffer.writeTag(DataFormatTags.DICTIONARY_TERMINATED);
+          }
+
+          entries.forEach(entry => {
+            encode(entry[0], buffer); // encode key
+            encode(entry[1], buffer); // encode value
+          });
+
+          if (entries.length > 14) {
+            buffer.writeTag(DataFormatTags.TERMINATOR);
+          }
+        }
+        break;
+      default:
+        throw new Error("HDSEncoder: no idea how to encode value of type '" + typeof data + "': " + data);
     }
-
-    export function encode(data: any, buffer: DataStreamWriter): void {
-        if (data === undefined) {
-            throw new Error("HDSEncoder: cannot encode undefined");
-        }
-
-        if (data === null) {
-            buffer.writeTag(DataFormatTags.NULL);
-            return;
-        }
-
-        switch (typeof data) {
-            case "boolean":
-                if (data) {
-                    buffer.writeTrue();
-                } else {
-                    buffer.writeFalse();
-                }
-                break;
-            case "number":
-                if (Number.isInteger(data)) {
-                    buffer.writeNumber(data);
-                } else {
-                    buffer.writeFloat64LE(new Float64(data));
-                }
-                break;
-            case "string":
-                buffer.writeUTF8(data);
-                break;
-            case "object":
-                if (Array.isArray(data)) {
-                    const length = data.length;
-
-                    if (length <= 12) {
-                        buffer.writeTag(DataFormatTags.ARRAY_LENGTH_START + length);
-                    } else {
-                        buffer.writeTag(DataFormatTags.ARRAY_TERMINATED);
-                    }
-
-                    data.forEach(element => {
-                        encode(element, buffer);
-                    });
-
-                    if (length > 12) {
-                        buffer.writeTag(DataFormatTags.TERMINATOR);
-                    }
-                } else if (data instanceof ValueWrapper) {
-                    if (data instanceof Int8) {
-                        buffer.writeInt8(data);
-                    } else if (data instanceof Int16) {
-                        buffer.writeInt16LE(data);
-                    } else if (data instanceof Int32) {
-                        buffer.writeInt32LE(data);
-                    } else if (data instanceof Int64) {
-                        buffer.writeInt64LE(data);
-                    } else if (data instanceof Float32) {
-                        buffer.writeFloat32LE(data);
-                    } else if (data instanceof Float64) {
-                        buffer.writeFloat64LE(data);
-                    } else if (data instanceof SecondsSince2001) {
-                        buffer.writeSecondsSince2001_01_01(data);
-                    } else if (data instanceof UUID) {
-                        buffer.writeUUID(data.value);
-                    } else {
-                        throw new Error("Unknown wrapped object 'ValueWrapper' of class " + data.constructor.name);
-                    }
-                } else if (data instanceof Buffer) {
-                    buffer.writeData(data);
-                } else { // object is treated as dictionary
-                    const entries = Object.entries(data);
-
-                    if (entries.length <= 14) {
-                        buffer.writeTag(DataFormatTags.DICTIONARY_LENGTH_START + entries.length);
-                    } else {
-                        buffer.writeTag(DataFormatTags.DICTIONARY_TERMINATED);
-                    }
-
-                    entries.forEach(entry => {
-                        encode(entry[0], buffer); // encode key
-                        encode(entry[1], buffer); // encode value
-                    });
-
-                    if (entries.length > 14) {
-                        buffer.writeTag(DataFormatTags.TERMINATOR);
-                    }
-                }
-                break;
-            default:
-                throw new Error("HDSEncoder: no idea how to encode value of type '" + (typeof data) +"': " + data);
-        }
-    }
-
+  }
 }
 
 export class DataStreamReader {
+  private readonly data: Buffer;
+  readerIndex: number;
 
-    private readonly data: Buffer;
-    readerIndex: number;
+  private deduplicationData: any[] = [];
 
-    private deduplicationData: any[] = [];
+  constructor(data: Buffer) {
+    this.data = data;
+    this.readerIndex = 0;
+  }
 
-    constructor(data: Buffer) {
-        this.data = data;
-        this.readerIndex = 0;
+  finished() {
+    if (this.readerIndex < this.data.length) {
+      const remainingHex = this.data.slice(this.readerIndex, this.data.length).toString("hex");
+      debug(
+        "WARNING Finished reading HDS stream, but there are still %d bytes remaining () %s",
+        this.data.length - this.readerIndex,
+        remainingHex
+      );
+    }
+  }
+
+  deduplicateData(index: number) {
+    if (index >= this.deduplicationData.length) {
+      throw new Error(
+        "HDSDecoder: Tried deduplication of data for an index out of range (index " +
+          index +
+          " and got " +
+          this.deduplicationData.length +
+          " elements)"
+      );
     }
 
-    finished() {
-        if (this.readerIndex < this.data.length) {
-            const remainingHex = this.data.slice(this.readerIndex, this.data.length).toString("hex");
-            debug("WARNING Finished reading HDS stream, but there are still %d bytes remaining () %s", this.data.length - this.readerIndex, remainingHex);
-        }
+    return this.deduplicationData[index];
+  }
+
+  private cache(data: any) {
+    this.deduplicationData.push(data);
+    return data;
+  }
+
+  private ensureLength(bytes: number) {
+    if (this.readerIndex + bytes > this.data.length) {
+      const remaining = this.data.length - this.readerIndex;
+      throw new Error(
+        "HDSDecoder: End of data stream. Tried reading " +
+          bytes +
+          " bytes however got only " +
+          remaining +
+          " remaining!"
+      );
+    }
+  }
+
+  readTag() {
+    this.ensureLength(1);
+    return this.data.readUInt8(this.readerIndex++);
+  }
+
+  readTrue() {
+    return this.cache(true); // do those tag encoded values get cached?
+  }
+
+  readFalse() {
+    return this.cache(false);
+  }
+
+  readNegOne() {
+    return this.cache(-1);
+  }
+
+  readIntRange(tag: number) {
+    return this.cache(tag - DataFormatTags.INTEGER_RANGE_START_0); // integer values from 0-39
+  }
+
+  readInt8() {
+    this.ensureLength(1);
+    return this.cache(this.data.readInt8(this.readerIndex++));
+  }
+
+  readInt16LE() {
+    this.ensureLength(2);
+    const value = this.data.readInt16LE(this.readerIndex);
+    this.readerIndex += 2;
+    return this.cache(value);
+  }
+
+  readInt32LE() {
+    this.ensureLength(4);
+    const value = this.data.readInt32LE(this.readerIndex);
+    this.readerIndex += 4;
+    return this.cache(value);
+  }
+
+  readInt64LE() {
+    this.ensureLength(8);
+
+    const low = this.data.readInt32LE(this.readerIndex);
+    let value = this.data.readInt32LE(this.readerIndex + 4) * 0x100000000 + low;
+    if (low < 0) {
+      value += 0x100000000;
     }
 
-    deduplicateData(index: number) {
-        if (index >= this.deduplicationData.length) {
-            throw new Error("HDSDecoder: Tried deduplication of data for an index out of range (index " + index + " and got " + this.deduplicationData.length + " elements)");
-        }
+    this.readerIndex += 8;
+    return this.cache(value);
+  }
 
-        return this.deduplicationData[index];
+  readFloat32LE() {
+    this.ensureLength(4);
+    const value = this.data.readFloatLE(this.readerIndex);
+    this.readerIndex += 4;
+    return this.cache(value);
+  }
+
+  readFloat64LE() {
+    this.ensureLength(8);
+    const value = this.data.readDoubleLE(this.readerIndex);
+    return this.cache(value);
+  }
+
+  private readLength8() {
+    this.ensureLength(1);
+    return this.data.readUInt8(this.readerIndex++);
+  }
+
+  private readLength16LE() {
+    this.ensureLength(2);
+    const value = this.data.readUInt16LE(this.readerIndex);
+    this.readerIndex += 2;
+    return value;
+  }
+
+  private readLength32LE() {
+    this.ensureLength(4);
+    const value = this.data.readUInt32LE(this.readerIndex);
+    this.readerIndex += 4;
+    return value;
+  }
+
+  private readLength64LE() {
+    this.ensureLength(8);
+
+    const low = this.data.readUInt32LE(this.readerIndex);
+    const value = this.data.readUInt32LE(this.readerIndex + 4) * 0x100000000 + low;
+
+    this.readerIndex += 8;
+    return value;
+  }
+
+  readUTF8(length: number) {
+    this.ensureLength(length);
+    const value = this.data.toString("utf8", this.readerIndex, this.readerIndex + length);
+    this.readerIndex += length;
+    return this.cache(value);
+  }
+
+  readUTF8_Length8() {
+    const length = this.readLength8();
+    return this.readUTF8(length);
+  }
+
+  readUTF8_Length16LE() {
+    const length = this.readLength16LE();
+    return this.readUTF8(length);
+  }
+
+  readUTF8_Length32LE() {
+    const length = this.readLength32LE();
+    return this.readUTF8(length);
+  }
+
+  readUTF8_Length64LE() {
+    const length = this.readLength64LE();
+    return this.readUTF8(length);
+  }
+
+  readUTF8_NULL_terminated() {
+    let offset = this.readerIndex;
+    let nextByte;
+
+    for (;;) {
+      nextByte = this.data[offset];
+
+      if (nextByte === undefined) {
+        throw new Error("HDSDecoder: Reached end of data stream while reading NUL terminated string!");
+      } else if (nextByte === 0) {
+        break;
+      } else {
+        offset++;
+      }
     }
 
-    private cache(data: any) {
-        this.deduplicationData.push(data);
-        return data;
+    const value = this.data.toString("utf8", this.readerIndex, offset);
+    this.readerIndex = offset + 1;
+    return this.cache(value);
+  }
+
+  readData(length: number) {
+    this.ensureLength(length);
+    const value = this.data.slice(this.readerIndex, this.readerIndex + length);
+    this.readerIndex += length;
+
+    return this.cache(value);
+  }
+
+  readData_Length8() {
+    const length = this.readLength8();
+    return this.readData(length);
+  }
+
+  readData_Length16LE() {
+    const length = this.readLength16LE();
+    return this.readData(length);
+  }
+
+  readData_Length32LE() {
+    const length = this.readLength32LE();
+    return this.readData(length);
+  }
+
+  readData_Length64LE() {
+    const length = this.readLength64LE();
+    return this.readData(length);
+  }
+
+  readData_terminated() {
+    let offset = this.readerIndex;
+    let nextByte;
+
+    for (;;) {
+      nextByte = this.data[offset];
+
+      if (nextByte === undefined) {
+        throw new Error("HDSDecoder: Reached end of data stream while reading terminated data!");
+      } else if (nextByte === DataFormatTags.TERMINATOR) {
+        break;
+      } else {
+        offset++;
+      }
     }
 
-    private ensureLength(bytes: number) {
-        if (this.readerIndex + bytes > this.data.length) {
-            const remaining = this.data.length - this.readerIndex;
-            throw new Error("HDSDecoder: End of data stream. Tried reading " + bytes + " bytes however got only " + remaining + " remaining!");
-        }
-    }
+    const value = this.data.slice(this.readerIndex, offset);
+    this.readerIndex = offset + 1;
+    return this.cache(value);
+  }
 
-    readTag() {
-        this.ensureLength(1);
-        return this.data.readUInt8(this.readerIndex++);
-    }
+  readSecondsSince2001_01_01() {
+    // second since 2001-01-01 00:00:00
+    return this.readFloat64LE();
+  }
 
-    readTrue() {
-        return this.cache(true); // do those tag encoded values get cached?
-    }
-
-    readFalse() {
-        return this.cache(false);
-    }
-
-    readNegOne() {
-        return this.cache(-1);
-    }
-
-    readIntRange(tag: number) {
-        return this.cache(tag - DataFormatTags.INTEGER_RANGE_START_0); // integer values from 0-39
-    }
-
-    readInt8() {
-        this.ensureLength(1);
-        return this.cache(this.data.readInt8(this.readerIndex++));
-    }
-
-    readInt16LE() {
-        this.ensureLength(2);
-        const value = this.data.readInt16LE(this.readerIndex);
-        this.readerIndex += 2;
-        return this.cache(value);
-    }
-
-    readInt32LE() {
-        this.ensureLength(4);
-        const value = this.data.readInt32LE(this.readerIndex);
-        this.readerIndex += 4;
-        return this.cache(value);
-    }
-
-    readInt64LE() {
-        this.ensureLength(8);
-
-        const low = this.data.readInt32LE(this.readerIndex);
-        let value = this.data.readInt32LE(this.readerIndex + 4) * 0x100000000 + low;
-        if (low < 0) {
-            value += 0x100000000;
-        }
-
-        this.readerIndex += 8;
-        return this.cache(value);
-    }
-
-    readFloat32LE() {
-        this.ensureLength(4);
-        const value = this.data.readFloatLE(this.readerIndex);
-        this.readerIndex += 4;
-        return this.cache(value);
-    }
-
-    readFloat64LE() {
-        this.ensureLength(8);
-        const value = this.data.readDoubleLE(this.readerIndex);
-        return this.cache(value);
-    }
-
-    private readLength8() {
-        this.ensureLength(1);
-        return this.data.readUInt8(this.readerIndex++);
-    }
-
-    private readLength16LE() {
-        this.ensureLength(2);
-        const value = this.data.readUInt16LE(this.readerIndex);
-        this.readerIndex += 2;
-        return value;
-    }
-
-    private readLength32LE() {
-        this.ensureLength(4);
-        const value = this.data.readUInt32LE(this.readerIndex);
-        this.readerIndex += 4;
-        return value;
-    }
-
-    private readLength64LE() {
-        this.ensureLength(8);
-
-        const low = this.data.readUInt32LE(this.readerIndex);
-        const value = this.data.readUInt32LE(this.readerIndex + 4) * 0x100000000 + low;
-
-        this.readerIndex += 8;
-        return value;
-    }
-
-    readUTF8(length: number) {
-        this.ensureLength(length);
-        const value = this.data.toString('utf8', this.readerIndex, this.readerIndex + length);
-        this.readerIndex += length;
-        return this.cache(value);
-    }
-
-    readUTF8_Length8() {
-        const length = this.readLength8();
-        return this.readUTF8(length);
-    }
-
-    readUTF8_Length16LE() {
-        const length = this.readLength16LE();
-        return this.readUTF8(length);
-    }
-
-    readUTF8_Length32LE() {
-        const length = this.readLength32LE();
-        return this.readUTF8(length);
-    }
-
-    readUTF8_Length64LE() {
-        const length = this.readLength64LE();
-        return this.readUTF8(length);
-    }
-
-    readUTF8_NULL_terminated() {
-        let offset = this.readerIndex;
-        let nextByte;
-
-        for (;;) {
-            nextByte = this.data[offset];
-
-            if (nextByte === undefined) {
-                throw new Error("HDSDecoder: Reached end of data stream while reading NUL terminated string!");
-            } else  if (nextByte === 0) {
-                break;
-            } else {
-                offset++;
-            }
-        }
-
-        const value = this.data.toString('utf8', this.readerIndex, offset);
-        this.readerIndex = offset + 1;
-        return this.cache(value);
-    }
-
-    readData(length: number) {
-        this.ensureLength(length);
-        const value = this.data.slice(this.readerIndex, this.readerIndex + length);
-        this.readerIndex += length;
-
-        return this.cache(value);
-    }
-
-    readData_Length8() {
-        const length = this.readLength8();
-        return this.readData(length);
-    }
-
-    readData_Length16LE() {
-        const length = this.readLength16LE();
-        return this.readData(length);
-    }
-
-    readData_Length32LE() {
-        const length = this.readLength32LE();
-        return this.readData(length);
-    }
-
-    readData_Length64LE() {
-        const length = this.readLength64LE();
-        return this.readData(length);
-    }
-
-    readData_terminated() {
-        let offset = this.readerIndex;
-        let nextByte;
-
-        for (;;) {
-            nextByte = this.data[offset];
-
-            if (nextByte === undefined) {
-                throw new Error("HDSDecoder: Reached end of data stream while reading terminated data!");
-            } else  if (nextByte === DataFormatTags.TERMINATOR) {
-                break;
-            } else {
-                offset++;
-            }
-        }
-
-        const value = this.data.slice(this.readerIndex, offset);
-        this.readerIndex = offset + 1;
-        return this.cache(value);
-    }
-
-    readSecondsSince2001_01_01() {
-        // second since 2001-01-01 00:00:00
-        return this.readFloat64LE();
-    }
-
-    readUUID() { // big endian
-        this.ensureLength(16);
-        const value = uuid.unparse(this.data, this.readerIndex);
-        this.readerIndex += 16;
-        return this.cache(value);
-    }
-
+  readUUID() {
+    // big endian
+    this.ensureLength(16);
+    const value = uuid.unparse(this.data, this.readerIndex);
+    this.readerIndex += 16;
+    return this.cache(value);
+  }
 }
 
-class WrittenDataList { // wrapper class since javascript doesn't really have a way to override === operator
+class WrittenDataList {
+  // wrapper class since javascript doesn't really have a way to override === operator
 
-    private writtenData: any[] = [];
+  private writtenData: any[] = [];
 
-    push(data: any) {
-        this.writtenData.push(data);
-    }
+  push(data: any) {
+    this.writtenData.push(data);
+  }
 
-    indexOf(data: any) {
-        for (let i = 0; i < this.writtenData.length; i++) {
-            const data0 = this.writtenData[i];
+  indexOf(data: any) {
+    for (let i = 0; i < this.writtenData.length; i++) {
+      const data0 = this.writtenData[i];
 
-            if (data === data0) {
-                return i;
-            }
+      if (data === data0) {
+        return i;
+      }
 
-            if (data instanceof ValueWrapper && data0 instanceof ValueWrapper) {
-                if (data.equals(data0)) {
-                    return i;
-                }
-            }
+      if (data instanceof ValueWrapper && data0 instanceof ValueWrapper) {
+        if (data.equals(data0)) {
+          return i;
         }
-
-        return -1;
+      }
     }
 
+    return -1;
+  }
 }
 
 export class DataStreamWriter {
+  private static readonly chunkSize = 128; // seems to be a good default
 
-    private static readonly chunkSize = 128; // seems to be a good default
+  private data: Buffer;
+  private writerIndex: number;
 
-    private data: Buffer;
-    private writerIndex: number;
+  private writtenData = new WrittenDataList();
 
-    private writtenData = new WrittenDataList();
+  constructor() {
+    this.data = Buffer.alloc(DataStreamWriter.chunkSize);
+    this.writerIndex = 0;
+  }
 
-    constructor() {
-        this.data = Buffer.alloc(DataStreamWriter.chunkSize);
-        this.writerIndex = 0;
+  length() {
+    return this.writerIndex; // since writerIndex points to the next FREE index it also represents the length
+  }
+
+  getData() {
+    return this.data.slice(0, this.writerIndex);
+  }
+
+  private ensureLength(bytes: number) {
+    const neededBytes = this.writerIndex + bytes - this.data.length;
+    if (neededBytes > 0) {
+      const chunks = Math.ceil(neededBytes / DataStreamWriter.chunkSize);
+
+      // don't know if it's best for performance to immediately concatenate the buffers. That way it's
+      // the easiest way to handle writing though.
+      this.data = Buffer.concat([this.data, Buffer.alloc(chunks * DataStreamWriter.chunkSize)]);
+    }
+  }
+
+  private checkDeduplication(data: any): boolean {
+    const index = this.writtenData.indexOf(data);
+    if (index < 0) {
+      // data is not present yet
+      this.writtenData.push(data);
+      return false;
+    } else if (index <= DataFormatTags.DEDUPLICATION_STOP - DataFormatTags.DEDUPLICATION_START) {
+      // data was already written and the index is in the applicable range => shorten the payload
+      this.writeTag(DataFormatTags.DEDUPLICATION_START + index);
+      return true;
     }
 
-    length() {
-        return this.writerIndex; // since writerIndex points to the next FREE index it also represents the length
+    return false;
+  }
+
+  writeTag(tag: DataFormatTags) {
+    this.ensureLength(1);
+    this.data.writeUInt8(tag, this.writerIndex++);
+  }
+
+  writeTrue() {
+    this.writeTag(DataFormatTags.TRUE);
+  }
+
+  writeFalse() {
+    this.writeTag(DataFormatTags.FALSE);
+  }
+
+  writeNumber(number: number) {
+    if (number === -1) {
+      this.writeTag(DataFormatTags.INTEGER_MINUS_ONE);
+    } else if (number >= 0 && number <= 39) {
+      this.writeTag(DataFormatTags.INTEGER_RANGE_START_0 + number);
+    } else if (number >= -128 && number <= 127) {
+      this.writeInt8(new Int8(number));
+    } else if (number >= -32768 && number <= 32767) {
+      this.writeInt16LE(new Int16(number));
+    } else if (number >= -2147483648 && number <= -2147483648) {
+      this.writeInt32LE(new Int32(number));
+    } else if (number >= Number.MIN_SAFE_INTEGER && number <= Number.MAX_SAFE_INTEGER) {
+      // use correct uin64 restriction when we convert to bigint
+      this.writeInt64LE(new Int64(number));
+    } else {
+      throw new Error("Tried writing unrepresentable number (" + number + ")");
+    }
+  }
+
+  writeInt8(int8: Int8) {
+    if (this.checkDeduplication(int8)) {
+      return;
     }
 
-    getData() {
-        return this.data.slice(0, this.writerIndex);
+    this.ensureLength(2);
+    this.writeTag(DataFormatTags.INT8);
+    this.data.writeInt8(int8.value, this.writerIndex++);
+  }
+
+  writeInt16LE(int16: Int16) {
+    if (this.checkDeduplication(int16)) {
+      return;
     }
 
-    private ensureLength(bytes: number) {
-        const neededBytes = (this.writerIndex + bytes) - this.data.length;
-        if (neededBytes > 0) {
-            const chunks = Math.ceil(neededBytes / DataStreamWriter.chunkSize);
+    this.ensureLength(3);
+    this.writeTag(DataFormatTags.INT16LE);
+    this.data.writeInt16LE(int16.value, this.writerIndex);
+    this.writerIndex += 2;
+  }
 
-            // don't know if it's best for performance to immediately concatenate the buffers. That way it's
-            // the easiest way to handle writing though.
-            this.data = Buffer.concat([this.data, Buffer.alloc(chunks * DataStreamWriter.chunkSize)]);
-        }
+  writeInt32LE(int32: Int32) {
+    if (this.checkDeduplication(int32)) {
+      return;
     }
 
-    private checkDeduplication(data: any): boolean {
-        const index = this.writtenData.indexOf(data);
-        if (index < 0) {
-            // data is not present yet
-            this.writtenData.push(data);
-            return false;
-        } else if (index <= DataFormatTags.DEDUPLICATION_STOP - DataFormatTags.DEDUPLICATION_START) {
-            // data was already written and the index is in the applicable range => shorten the payload
-            this.writeTag(DataFormatTags.DEDUPLICATION_START + index);
-            return true;
-        }
+    this.ensureLength(5);
+    this.writeTag(DataFormatTags.INT32LE);
+    this.data.writeInt32LE(int32.value, this.writerIndex);
+    this.writerIndex += 4;
+  }
 
-        return false;
+  writeInt64LE(int64: Int64) {
+    if (this.checkDeduplication(int64)) {
+      return;
     }
 
-    writeTag(tag: DataFormatTags) {
-        this.ensureLength(1);
-        this.data.writeUInt8(tag, this.writerIndex++);
+    this.ensureLength(9);
+    this.writeTag(DataFormatTags.INT64LE);
+    this.data.writeUInt32LE(int64.value, this.writerIndex); // TODO correctly implement int64; currently it's basically an int32
+    this.data.writeUInt32LE(0, this.writerIndex + 4);
+    this.writerIndex += 8;
+  }
+
+  writeFloat32LE(float32: Float32) {
+    if (this.checkDeduplication(float32)) {
+      return;
     }
 
-    writeTrue() {
-        this.writeTag(DataFormatTags.TRUE);
+    this.ensureLength(5);
+    this.writeTag(DataFormatTags.FLOAT32LE);
+    this.data.writeFloatLE(float32.value, this.writerIndex);
+    this.writerIndex += 4;
+  }
+
+  writeFloat64LE(float64: Float64) {
+    if (this.checkDeduplication(float64)) {
+      return;
     }
 
-    writeFalse() {
-        this.writeTag(DataFormatTags.FALSE);
+    this.ensureLength(9);
+    this.writeTag(DataFormatTags.FLOAT64LE);
+    this.data.writeDoubleLE(float64.value, this.writerIndex);
+    this.writerIndex += 8;
+  }
+
+  private writeLength8(length: number) {
+    this.ensureLength(1);
+    this.data.writeUInt8(length, this.writerIndex++);
+  }
+
+  private writeLength16LE(length: number) {
+    this.ensureLength(2);
+    this.data.writeUInt16LE(length, this.writerIndex);
+    this.writerIndex += 2;
+  }
+
+  private writeLength32LE(length: number) {
+    this.ensureLength(4);
+    this.data.writeUInt32LE(length, this.writerIndex);
+    this.writerIndex += 4;
+  }
+
+  private writeLength64LE(length: number) {
+    this.ensureLength(8);
+    encryption.writeUInt64LE(length, this.data, this.writerIndex);
+    this.writerIndex += 8;
+  }
+
+  writeUTF8(utf8: string) {
+    if (this.checkDeduplication(utf8)) {
+      return;
     }
 
-    writeNumber(number: number) {
-        if (number === -1) {
-            this.writeTag(DataFormatTags.INTEGER_MINUS_ONE);
-        } else if (number >= 0 && number <= 39) {
-            this.writeTag(DataFormatTags.INTEGER_RANGE_START_0 + number);
-        } else if (number >= -128 && number <= 127) {
-            this.writeInt8(new Int8(number));
-        } else if (number >= -32768 && number <= 32767) {
-            this.writeInt16LE(new Int16(number));
-        } else if (number >= -2147483648 && number <= -2147483648) {
-            this.writeInt32LE(new Int32(number));
-        } else if (number >= Number.MIN_SAFE_INTEGER && number <= Number.MAX_SAFE_INTEGER) { // use correct uin64 restriction when we convert to bigint
-            this.writeInt64LE(new Int64(number));
-        } else {
-            throw new Error("Tried writing unrepresentable number (" + number + ")");
-        }
+    const length = Buffer.byteLength(utf8);
+    if (length <= 32) {
+      this.ensureLength(1 + length);
+      this.writeTag(DataFormatTags.UTF8_LENGTH_START + utf8.length);
+      this._writeUTF8(utf8);
+    } else if (length <= 255) {
+      this.writeUTF8_Length8(utf8);
+    } else if (length <= 65535) {
+      this.writeUTF8_Length16LE(utf8);
+    } else if (length <= 4294967295) {
+      this.writeUTF8_Length32LE(utf8);
+    } else if (length <= Number.MAX_SAFE_INTEGER) {
+      // use correct uin64 restriction when we convert to bigint
+      this.writeUTF8_Length64LE(utf8);
+    } else {
+      this.writeUTF8_NULL_terminated(utf8);
+    }
+  }
+
+  private _writeUTF8(utf8: string) {
+    // utility method
+    const byteLength = Buffer.byteLength(utf8);
+    this.ensureLength(byteLength);
+
+    this.data.write(utf8, this.writerIndex, undefined, "utf8");
+    this.writerIndex += byteLength;
+  }
+
+  private writeUTF8_Length8(utf8: string) {
+    const length = Buffer.byteLength(utf8);
+    this.ensureLength(2 + length);
+
+    this.writeTag(DataFormatTags.UTF8_LENGTH8);
+    this.writeLength8(length);
+    this._writeUTF8(utf8);
+  }
+
+  private writeUTF8_Length16LE(utf8: string) {
+    const length = Buffer.byteLength(utf8);
+    this.ensureLength(3 + length);
+
+    this.writeTag(DataFormatTags.UTF8_LENGTH16LE);
+    this.writeLength16LE(length);
+    this._writeUTF8(utf8);
+  }
+
+  private writeUTF8_Length32LE(utf8: string) {
+    const length = Buffer.byteLength(utf8);
+    this.ensureLength(5 + length);
+
+    this.writeTag(DataFormatTags.UTF8_LENGTH32LE);
+    this.writeLength32LE(length);
+    this._writeUTF8(utf8);
+  }
+
+  private writeUTF8_Length64LE(utf8: string) {
+    const length = Buffer.byteLength(utf8);
+    this.ensureLength(9 + length);
+
+    this.writeTag(DataFormatTags.UTF8_LENGTH64LE);
+    this.writeLength64LE(length);
+    this._writeUTF8(utf8);
+  }
+
+  private writeUTF8_NULL_terminated(utf8: string) {
+    this.ensureLength(1 + Buffer.byteLength(utf8) + 1);
+
+    this.writeTag(DataFormatTags.UTF8_NULL_TERMINATED);
+    this._writeUTF8(utf8);
+    this.data.writeUInt8(0, this.writerIndex++);
+  }
+
+  writeData(data: Buffer) {
+    if (this.checkDeduplication(data)) {
+      return;
     }
 
-    writeInt8(int8: Int8) {
-        if (this.checkDeduplication(int8)) {
-            return;
-        }
+    if (data.length <= 32) {
+      this.writeTag(DataFormatTags.DATA_LENGTH_START + data.length);
+      this._writeData(data);
+    } else if (data.length <= 255) {
+      this.writeData_Length8(data);
+    } else if (data.length <= 65535) {
+      this.writeData_Length16LE(data);
+    } else if (data.length <= 4294967295) {
+      this.writeData_Length32LE(data);
+    } else if (data.length <= Number.MAX_SAFE_INTEGER) {
+      this.writeData_Length64LE(data);
+    } else {
+      this.writeData_terminated(data);
+    }
+  }
 
-        this.ensureLength(2);
-        this.writeTag(DataFormatTags.INT8);
-        this.data.writeInt8(int8.value, this.writerIndex++);
+  private _writeData(data: Buffer) {
+    // utility method
+    this.ensureLength(data.length);
+    for (let i = 0; i < data.length; i++) {
+      this.data[this.writerIndex++] = data[i];
+    }
+  }
+
+  private writeData_Length8(data: Buffer) {
+    this.ensureLength(2 + data.length);
+
+    this.writeTag(DataFormatTags.DATA_LENGTH8);
+    this.writeLength8(data.length);
+    this._writeData(data);
+  }
+
+  private writeData_Length16LE(data: Buffer) {
+    this.ensureLength(3 + data.length);
+
+    this.writeTag(DataFormatTags.DATA_LENGTH16LE);
+    this.writeLength16LE(data.length);
+    this._writeData(data);
+  }
+
+  private writeData_Length32LE(data: Buffer) {
+    this.ensureLength(5 + data.length);
+
+    this.writeTag(DataFormatTags.DATA_LENGTH32LE);
+    this.writeLength32LE(data.length);
+    this._writeData(data);
+  }
+
+  private writeData_Length64LE(data: Buffer) {
+    this.ensureLength(9 + data.length);
+
+    this.writeTag(DataFormatTags.DATA_LENGTH64LE);
+    this.writeLength64LE(data.length);
+    this._writeData(data);
+  }
+
+  private writeData_terminated(data: Buffer) {
+    this.ensureLength(1 + data.length + 1);
+
+    this.writeTag(DataFormatTags.DATA_TERMINATED);
+    this._writeData(data);
+    this.writeTag(DataFormatTags.TERMINATOR);
+  }
+
+  writeSecondsSince2001_01_01(seconds: SecondsSince2001) {
+    if (this.checkDeduplication(seconds)) {
+      return;
     }
 
-    writeInt16LE(int16: Int16) {
-        if (this.checkDeduplication(int16)) {
-            return;
-        }
+    this.ensureLength(9);
+    this.writeTag(DataFormatTags.DATE);
+    this.data.writeDoubleLE(seconds.value, this.writerIndex);
+    this.writerIndex += 8;
+  }
 
-        this.ensureLength(3);
-        this.writeTag(DataFormatTags.INT16LE);
-        this.data.writeInt16LE(int16.value, this.writerIndex);
-        this.writerIndex += 2;
+  writeUUID(uuid_string: string) {
+    assert(uuid.isValid(uuid_string), "supplied uuid is invalid");
+    if (this.checkDeduplication(new UUID(uuid_string))) {
+      return;
     }
 
-    writeInt32LE(int32: Int32) {
-        if (this.checkDeduplication(int32)) {
-            return;
-        }
-
-        this.ensureLength(5);
-        this.writeTag(DataFormatTags.INT32LE);
-        this.data.writeInt32LE(int32.value, this.writerIndex);
-        this.writerIndex += 4;
-    }
-
-    writeInt64LE(int64: Int64) {
-        if (this.checkDeduplication(int64)) {
-            return;
-        }
-
-        this.ensureLength(9);
-        this.writeTag(DataFormatTags.INT64LE);
-        this.data.writeUInt32LE(int64.value, this.writerIndex);// TODO correctly implement int64; currently it's basically an int32
-        this.data.writeUInt32LE(0, this.writerIndex + 4);
-        this.writerIndex += 8;
-    }
-
-    writeFloat32LE(float32: Float32) {
-        if (this.checkDeduplication(float32)) {
-            return;
-        }
-
-        this.ensureLength(5);
-        this.writeTag(DataFormatTags.FLOAT32LE);
-        this.data.writeFloatLE(float32.value, this.writerIndex);
-        this.writerIndex += 4;
-    }
-
-    writeFloat64LE(float64: Float64) {
-        if (this.checkDeduplication(float64)) {
-            return;
-        }
-
-        this.ensureLength(9);
-        this.writeTag(DataFormatTags.FLOAT64LE);
-        this.data.writeDoubleLE(float64.value, this.writerIndex);
-        this.writerIndex += 8;
-    }
-
-    private writeLength8(length: number) {
-        this.ensureLength(1);
-        this.data.writeUInt8(length, this.writerIndex++);
-    }
-
-    private writeLength16LE(length: number) {
-        this.ensureLength(2);
-        this.data.writeUInt16LE(length, this.writerIndex);
-        this.writerIndex += 2;
-    }
-
-    private writeLength32LE(length: number) {
-        this.ensureLength(4);
-        this.data.writeUInt32LE(length, this.writerIndex);
-        this.writerIndex += 4;
-    }
-
-    private writeLength64LE(length: number) {
-        this.ensureLength(8);
-        encryption.writeUInt64LE(length, this.data, this.writerIndex);
-        this.writerIndex += 8;
-    }
-
-    writeUTF8(utf8: string) {
-        if (this.checkDeduplication(utf8)) {
-            return;
-        }
-
-        const length = Buffer.byteLength(utf8);
-        if (length <= 32) {
-            this.ensureLength(1 + length);
-            this.writeTag(DataFormatTags.UTF8_LENGTH_START + utf8.length);
-            this._writeUTF8(utf8);
-        } else if (length <= 255) {
-            this.writeUTF8_Length8(utf8);
-        } else if (length <= 65535) {
-            this.writeUTF8_Length16LE(utf8);
-        } else if (length <= 4294967295) {
-            this.writeUTF8_Length32LE(utf8);
-        } else if (length <= Number.MAX_SAFE_INTEGER) { // use correct uin64 restriction when we convert to bigint
-            this.writeUTF8_Length64LE(utf8);
-        } else {
-            this.writeUTF8_NULL_terminated(utf8);
-        }
-    }
-
-    private _writeUTF8(utf8: string) { // utility method
-        const byteLength = Buffer.byteLength(utf8);
-        this.ensureLength(byteLength);
-
-        this.data.write(utf8, this.writerIndex, undefined, "utf8");
-        this.writerIndex += byteLength;
-    }
-
-    private writeUTF8_Length8(utf8: string) {
-        const length = Buffer.byteLength(utf8);
-        this.ensureLength(2 + length);
-
-        this.writeTag(DataFormatTags.UTF8_LENGTH8);
-        this.writeLength8(length);
-        this._writeUTF8(utf8);
-    }
-
-    private writeUTF8_Length16LE(utf8: string) {
-        const length = Buffer.byteLength(utf8);
-        this.ensureLength(3 + length);
-
-        this.writeTag(DataFormatTags.UTF8_LENGTH16LE);
-        this.writeLength16LE(length);
-        this._writeUTF8(utf8);
-    }
-
-    private writeUTF8_Length32LE(utf8: string) {
-        const length = Buffer.byteLength(utf8);
-        this.ensureLength(5 + length);
-
-        this.writeTag(DataFormatTags.UTF8_LENGTH32LE);
-        this.writeLength32LE(length);
-        this._writeUTF8(utf8);
-    }
-
-    private writeUTF8_Length64LE(utf8: string) {
-        const length = Buffer.byteLength(utf8);
-        this.ensureLength(9 + length);
-
-        this.writeTag(DataFormatTags.UTF8_LENGTH64LE);
-        this.writeLength64LE(length);
-        this._writeUTF8(utf8);
-    }
-
-    private writeUTF8_NULL_terminated(utf8: string) {
-        this.ensureLength(1 + Buffer.byteLength(utf8) + 1);
-
-        this.writeTag(DataFormatTags.UTF8_NULL_TERMINATED);
-        this._writeUTF8(utf8);
-        this.data.writeUInt8(0, this.writerIndex++);
-    }
-
-    writeData(data: Buffer) {
-        if (this.checkDeduplication(data)) {
-            return;
-        }
-
-        if (data.length <= 32) {
-            this.writeTag(DataFormatTags.DATA_LENGTH_START + data.length);
-            this._writeData(data);
-        } else if (data.length <= 255) {
-            this.writeData_Length8(data);
-        } else if (data.length <= 65535) {
-            this.writeData_Length16LE(data);
-        } else if (data.length <= 4294967295) {
-            this.writeData_Length32LE(data);
-        } else if (data.length <= Number.MAX_SAFE_INTEGER) {
-            this.writeData_Length64LE(data);
-        } else {
-            this.writeData_terminated(data);
-        }
-    }
-
-    private _writeData(data: Buffer) { // utility method
-        this.ensureLength(data.length);
-        for (let i = 0; i < data.length; i++) {
-            this.data[this.writerIndex++] = data[i];
-        }
-    }
-
-    private writeData_Length8(data: Buffer) {
-        this.ensureLength(2 + data.length);
-
-        this.writeTag(DataFormatTags.DATA_LENGTH8);
-        this.writeLength8(data.length);
-        this._writeData(data);
-    }
-
-    private writeData_Length16LE(data: Buffer) {
-        this.ensureLength(3 + data.length);
-
-        this.writeTag(DataFormatTags.DATA_LENGTH16LE);
-        this.writeLength16LE(data.length);
-        this._writeData(data);
-    }
-
-    private writeData_Length32LE(data: Buffer) {
-        this.ensureLength(5 + data.length);
-
-        this.writeTag(DataFormatTags.DATA_LENGTH32LE);
-        this.writeLength32LE(data.length);
-        this._writeData(data);
-    }
-
-    private writeData_Length64LE(data: Buffer) {
-        this.ensureLength(9 + data.length);
-
-        this.writeTag(DataFormatTags.DATA_LENGTH64LE);
-        this.writeLength64LE(data.length);
-        this._writeData(data);
-    }
-
-    private writeData_terminated(data: Buffer) {
-        this.ensureLength(1 + data.length + 1);
-
-        this.writeTag(DataFormatTags.DATA_TERMINATED);
-        this._writeData(data);
-        this.writeTag(DataFormatTags.TERMINATOR);
-    }
-
-    writeSecondsSince2001_01_01(seconds: SecondsSince2001) {
-        if (this.checkDeduplication(seconds)) {
-            return;
-        }
-
-        this.ensureLength(9);
-        this.writeTag(DataFormatTags.DATE);
-        this.data.writeDoubleLE(seconds.value, this.writerIndex);
-        this.writerIndex += 8;
-    }
-
-    writeUUID(uuid_string: string) {
-        assert(uuid.isValid(uuid_string), "supplied uuid is invalid");
-        if (this.checkDeduplication(new UUID(uuid_string))) {
-            return;
-        }
-
-        this.ensureLength(17);
-        this.writeTag(DataFormatTags.UUID);
-        uuid.write(uuid_string, this.data, this.writerIndex);
-        this.writerIndex += 16;
-    }
-
+    this.ensureLength(17);
+    this.writeTag(DataFormatTags.UUID);
+    uuid.write(uuid_string, this.data, this.writerIndex);
+    this.writerIndex += 16;
+  }
 }

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -1,136 +1,133 @@
-import createDebug from 'debug';
-import assert from 'assert';
+import createDebug from "debug";
+import assert from "assert";
 
-import * as encryption from '../util/encryption';
-import * as hkdf from '../util/hkdf';
-import {DataStreamParser, DataStreamReader, DataStreamWriter, Int64} from './DataStreamParser';
-import crypto from 'crypto';
-import net, {Socket} from 'net';
-import {HAPSessionEvents, Session} from "../util/eventedhttp";
-import {EventEmitter as NodeEventEmitter} from "events";
-import {EventEmitter} from "../EventEmitter";
+import * as encryption from "../util/encryption";
+import * as hkdf from "../util/hkdf";
+import { DataStreamParser, DataStreamReader, DataStreamWriter, Int64 } from "./DataStreamParser";
+import crypto from "crypto";
+import net, { Socket } from "net";
+import { HAPSessionEvents, Session } from "../util/eventedhttp";
+import { EventEmitter as NodeEventEmitter } from "events";
+import { EventEmitter } from "../EventEmitter";
 import Timeout = NodeJS.Timeout;
 
-const debug = createDebug('DataStream:Server');
+const debug = createDebug("DataStream:Server");
 
 export type PreparedDataStreamSession = {
+  session: Session; // reference to the hap session which created the request
 
-    session: Session, // reference to the hap session which created the request
+  accessoryToControllerEncryptionKey: Buffer;
+  controllerToAccessoryEncryptionKey: Buffer;
+  accessoryKeySalt: Buffer;
 
-    accessoryToControllerEncryptionKey: Buffer,
-    controllerToAccessoryEncryptionKey: Buffer,
-    accessoryKeySalt: Buffer,
+  port?: number;
 
-    port?: number,
-
-    connectTimeout?: Timeout, // 10s timer
-
-}
+  connectTimeout?: Timeout; // 10s timer
+};
 
 export type EventHandler = (message: Record<any, any>) => void;
 export type RequestHandler = (id: number, message: Record<any, any>) => void;
-export type ResponseHandler = (error: Error | undefined, status: HDSStatus | undefined, message: Record<any, any>) => void;
+export type ResponseHandler = (
+  error: Error | undefined,
+  status: HDSStatus | undefined,
+  message: Record<any, any>
+) => void;
 export type GlobalEventHandler = (connection: DataStreamConnection, message: Record<any, any>) => void;
 export type GlobalRequestHandler = (connection: DataStreamConnection, id: number, message: Record<any, any>) => void;
 
 export interface DataStreamProtocolHandler {
-
-    eventHandler?: Record<string, EventHandler>,
-    requestHandler?: Record<string, RequestHandler>,
-
+  eventHandler?: Record<string, EventHandler>;
+  requestHandler?: Record<string, RequestHandler>;
 }
 
 export enum Protocols { // a collection of currently known protocols
-    CONTROL = "control",
-    TARGET_CONTROL = "targetControl",
-    DATA_SEND = "dataSend",
+  CONTROL = "control",
+  TARGET_CONTROL = "targetControl",
+  DATA_SEND = "dataSend",
 }
 
 export enum Topics { // a collection of currently known topics grouped by their protocol
-    // control
-    HELLO = "hello",
+  // control
+  HELLO = "hello",
 
-    // targetControl
-    WHOAMI = "whoami",
+  // targetControl
+  WHOAMI = "whoami",
 
-    // dataSend
-    OPEN = "open",
-    DATA = "data",
-    ACK = "ack",
-    CLOSE = "close",
+  // dataSend
+  OPEN = "open",
+  DATA = "data",
+  ACK = "ack",
+  CLOSE = "close",
 }
 
 export enum HDSStatus {
-    SUCCESS = 0,
-    OUT_OF_MEMORY = 1,
-    TIMEOUT = 2,
-    HEADER_ERROR = 3,
-    PAYLOAD_ERROR = 4,
-    MISSING_PROTOCOL = 5,
-    PROTOCOL_SPECIFIC_ERROR = 6,
+  SUCCESS = 0,
+  OUT_OF_MEMORY = 1,
+  TIMEOUT = 2,
+  HEADER_ERROR = 3,
+  PAYLOAD_ERROR = 4,
+  MISSING_PROTOCOL = 5,
+  PROTOCOL_SPECIFIC_ERROR = 6,
 }
 
 export enum DataSendCloseReason { // close reason used in the dataSend protocol
-    NORMAL = 0,
-    NOT_ALLOWED = 1,
-    BUSY = 2,
-    CANCELLED = 3,
-    UNSUPPORTED = 4,
-    UNEXPECTED_FAILURE = 5,
-    TIMEOUT = 6,
+  NORMAL = 0,
+  NOT_ALLOWED = 1,
+  BUSY = 2,
+  CANCELLED = 3,
+  UNSUPPORTED = 4,
+  UNEXPECTED_FAILURE = 5,
+  TIMEOUT = 6,
 }
 
-
 enum ServerState {
-    UNINITIALIZED, // server socket hasn't been created
-    BINDING, // server is created and is currently trying to bind
-    LISTENING, // server is created and currently listening for new connections
-    CLOSING,
+  UNINITIALIZED, // server socket hasn't been created
+  BINDING, // server is created and is currently trying to bind
+  LISTENING, // server is created and currently listening for new connections
+  CLOSING,
 }
 
 enum ConnectionState {
-    UNIDENTIFIED,
-    EXPECTING_HELLO,
-    READY,
-    CLOSING,
-    CLOSED,
+  UNIDENTIFIED,
+  EXPECTING_HELLO,
+  READY,
+  CLOSING,
+  CLOSED,
 }
 
 type HDSFrame = {
-
-    header: Buffer,
-    cipheredPayload: Buffer,
-    plaintextPayload: Buffer,
-    authTag: Buffer,
-
-}
+  header: Buffer;
+  cipheredPayload: Buffer;
+  plaintextPayload: Buffer;
+  authTag: Buffer;
+};
 
 enum MessageType {
-    EVENT = 1,
-    REQUEST = 2,
-    RESPONSE = 3,
+  EVENT = 1,
+  REQUEST = 2,
+  RESPONSE = 3,
 }
 
 type DataStreamMessage = {
-    type: MessageType,
+  type: MessageType;
 
-    protocol: string,
-    topic: string,
-    id?: number, // for requests and responses
-    status?: HDSStatus, // for responses
+  protocol: string;
+  topic: string;
+  id?: number; // for requests and responses
+  status?: HDSStatus; // for responses
 
-    message: Record<any, any>,
-}
+  message: Record<any, any>;
+};
 
 export enum DataStreamServerEvents {
-    CONNECTION_OPENED = "connection-opened",
-    CONNECTION_CLOSED = "connection-closed",
+  CONNECTION_OPENED = "connection-opened",
+  CONNECTION_CLOSED = "connection-closed",
 }
 
 export type DataStreamServerEventMap = {
-    [DataStreamServerEvents.CONNECTION_OPENED]: (connection: DataStreamConnection) => void;
-    [DataStreamServerEvents.CONNECTION_CLOSED]: (connection: DataStreamConnection) => void;
-}
+  [DataStreamServerEvents.CONNECTION_OPENED]: (connection: DataStreamConnection) => void;
+  [DataStreamServerEvents.CONNECTION_CLOSED]: (connection: DataStreamConnection) => void;
+};
 
 /**
  * DataStreamServer which listens for incoming tcp connections and handles identification of new connections
@@ -143,266 +140,298 @@ export type DataStreamServerEventMap = {
  *        This event is emitted when the socket of a connection gets closed.
  */
 export class DataStreamServer extends EventEmitter<DataStreamServerEventMap> {
+  static readonly version = "1.0";
 
-    static readonly version = "1.0";
+  private state: ServerState = ServerState.UNINITIALIZED;
 
-    private state: ServerState = ServerState.UNINITIALIZED;
+  private static accessoryToControllerInfo = Buffer.from("HDS-Read-Encryption-Key");
+  private static controllerToAccessoryInfo = Buffer.from("HDS-Write-Encryption-Key");
 
-    private static accessoryToControllerInfo = Buffer.from("HDS-Read-Encryption-Key");
-    private static controllerToAccessoryInfo = Buffer.from("HDS-Write-Encryption-Key");
+  private tcpServer?: net.Server;
+  private tcpPort?: number;
 
-    private tcpServer?: net.Server;
-    private tcpPort?: number;
+  preparedSessions: PreparedDataStreamSession[];
+  private connections: DataStreamConnection[];
 
-    preparedSessions: PreparedDataStreamSession[];
-    private connections: DataStreamConnection[];
+  private readonly internalEventEmitter: NodeEventEmitter = new NodeEventEmitter(); // used for message event and message request handlers
 
-    private readonly internalEventEmitter: NodeEventEmitter = new NodeEventEmitter(); // used for message event and message request handlers
+  constructor() {
+    super();
+    this.preparedSessions = [];
+    this.connections = [];
+  }
 
-    constructor() {
-        super();
-        this.preparedSessions = [];
-        this.connections = [];
+  /**
+   * Registers a new event handler to handle incoming event messages.
+   * The handler is only called for a connection if for the give protocol no ProtocolHandler
+   * was registered on the connection level.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to register the handler for
+   * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalEventHandler} - function to be called for every occurring event
+   */
+  onEventMessage(protocol: string | Protocols, event: string | Topics, handler: GlobalEventHandler): this {
+    this.internalEventEmitter.on(protocol + "-e-" + event, handler);
+    return this;
+  }
+
+  /**
+   * Removes an registered event handler.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+   * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalEventHandler} - registered event handler
+   */
+  removeEventHandler(protocol: string | Protocols, event: string | Topics, handler: GlobalEventHandler): this {
+    this.internalEventEmitter.removeListener(protocol + "-e-" + event, handler);
+    return this;
+  }
+
+  /**
+   * Registers a new request handler to handle incoming request messages.
+   * The handler is only called for a connection if for the give protocol no ProtocolHandler
+   * was registered on the connection level.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to register the handler for
+   * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalRequestHandler} - function to be called for every occurring request
+   */
+  onRequestMessage(protocol: string | Protocols, request: string | Topics, handler: GlobalRequestHandler): this {
+    this.internalEventEmitter.on(protocol + "-r-" + request, handler);
+    return this;
+  }
+
+  /**
+   * Removes an registered request handler.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+   * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+   * @param handler {GlobalRequestHandler} - registered request handler
+   */
+  removeRequestHandler(protocol: string | Protocols, request: string | Topics, handler: GlobalRequestHandler): this {
+    this.internalEventEmitter.removeListener(protocol + "-r-" + request, handler);
+    return this;
+  }
+
+  prepareSession(
+    session: Session,
+    controllerKeySalt: Buffer,
+    callback: (preparedSession: PreparedDataStreamSession) => void
+  ) {
+    debug("Preparing for incoming HDS connection from session %s", session.sessionID);
+    const accessoryKeySalt = crypto.randomBytes(32);
+    const salt = Buffer.concat([controllerKeySalt, accessoryKeySalt]);
+
+    const accessoryToControllerEncryptionKey = hkdf.HKDF(
+      "sha512",
+      salt,
+      session.encryption!.sharedSec,
+      DataStreamServer.accessoryToControllerInfo,
+      32
+    );
+    const controllerToAccessoryEncryptionKey = hkdf.HKDF(
+      "sha512",
+      salt,
+      session.encryption!.sharedSec,
+      DataStreamServer.controllerToAccessoryInfo,
+      32
+    );
+
+    const preparedSession: PreparedDataStreamSession = {
+      session: session,
+      accessoryToControllerEncryptionKey: accessoryToControllerEncryptionKey,
+      controllerToAccessoryEncryptionKey: controllerToAccessoryEncryptionKey,
+      accessoryKeySalt: accessoryKeySalt,
+      connectTimeout: setTimeout(() => this.timeoutPreparedSession(preparedSession), 10000),
+    };
+    this.preparedSessions.push(preparedSession);
+
+    this.checkTCPServerEstablished(preparedSession, () => callback(preparedSession));
+  }
+
+  private timeoutPreparedSession(preparedSession: PreparedDataStreamSession) {
+    debug(
+      "Prepared HDS session timed out out since no connection was opened for 10 seconds (%s)",
+      preparedSession.session.sessionID
+    );
+    const index = this.preparedSessions.indexOf(preparedSession);
+    if (index >= 0) {
+      this.preparedSessions.splice(index, 1);
     }
 
-    /**
-     * Registers a new event handler to handle incoming event messages.
-     * The handler is only called for a connection if for the give protocol no ProtocolHandler
-     * was registered on the connection level.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to register the handler for
-     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalEventHandler} - function to be called for every occurring event
-     */
-    onEventMessage(protocol: string | Protocols, event: string | Topics, handler: GlobalEventHandler): this {
-        this.internalEventEmitter.on(protocol + "-e-" + event, handler);
-        return this;
+    this.checkCloseable();
+  }
+
+  private checkTCPServerEstablished(preparedSession: PreparedDataStreamSession, callback: () => void) {
+    switch (this.state) {
+      case ServerState.UNINITIALIZED:
+        debug("Starting up TCP server.");
+        this.tcpServer = net.createServer();
+
+        this.tcpServer.once("listening", this.listening.bind(this, preparedSession, callback));
+        this.tcpServer.on("connection", this.onConnection.bind(this));
+        this.tcpServer.on("close", this.closed.bind(this));
+
+        this.tcpServer.listen();
+        this.state = ServerState.BINDING;
+        break;
+      case ServerState.BINDING:
+        debug("TCP server already running. Waiting for it to bind.");
+        this.tcpServer!.once("listening", this.listening.bind(this, preparedSession, callback));
+        break;
+      case ServerState.LISTENING:
+        debug("Instructing client to connect to already running TCP server");
+        preparedSession.port = this.tcpPort;
+        callback();
+        break;
+      case ServerState.CLOSING:
+        debug("TCP socket is currently closing. Trying again when server is fully closed and opening a new one then.");
+        this.tcpServer!.once("close", () =>
+          setTimeout(() => this.checkTCPServerEstablished(preparedSession, callback), 10)
+        );
+        break;
+    }
+  }
+
+  private listening(preparedSession: PreparedDataStreamSession, callback: () => void) {
+    this.state = ServerState.LISTENING;
+
+    const address = this.tcpServer!.address();
+    if (address && typeof address !== "string") {
+      // address is only typeof string when listening to a pipe or unix socket
+      this.tcpPort = address.port;
+      preparedSession.port = address.port;
+
+      debug("TCP server is now listening for new data stream connections on port %s", address.port);
+      callback();
+    }
+  }
+
+  private onConnection(socket: Socket) {
+    debug("[%s] New DataStream connection was established", socket.remoteAddress);
+    const connection = new DataStreamConnection(socket);
+
+    connection.on(DataStreamConnectionEvents.IDENTIFICATION, this.handleSessionIdentification.bind(this, connection));
+    connection.on(
+      DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY,
+      this.handleMessageGlobally.bind(this, connection)
+    );
+    connection.on(DataStreamConnectionEvents.CLOSED, this.connectionClosed.bind(this, connection));
+
+    this.connections.push(connection);
+
+    this.emit(DataStreamServerEvents.CONNECTION_OPENED, connection);
+  }
+
+  private handleSessionIdentification(
+    connection: DataStreamConnection,
+    firstFrame: HDSFrame,
+    callback: IdentificationCallback
+  ) {
+    let identifiedSession: PreparedDataStreamSession | undefined = undefined;
+    for (let i = 0; i < this.preparedSessions.length; i++) {
+      const preparedSession = this.preparedSessions[i];
+
+      // if we successfully decrypt the first frame with this key we know to which session this connection belongs
+      if (connection.decryptHDSFrame(firstFrame, preparedSession.controllerToAccessoryEncryptionKey)) {
+        identifiedSession = preparedSession;
+        break;
+      }
     }
 
-    /**
-     * Removes an registered event handler.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
-     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalEventHandler} - registered event handler
-     */
-    removeEventHandler(protocol: string | Protocols, event: string | Topics, handler: GlobalEventHandler): this {
-        this.internalEventEmitter.removeListener(protocol + "-e-" + event, handler);
-        return this;
+    callback(identifiedSession);
+
+    if (identifiedSession) {
+      debug(
+        "[%s] Connection was successfully identified (linked with sessionId: %s)",
+        connection._remoteAddress,
+        identifiedSession.session.sessionID
+      );
+      const index = this.preparedSessions.indexOf(identifiedSession);
+      if (index >= 0) {
+        this.preparedSessions.splice(index, 1);
+      }
+
+      clearTimeout(identifiedSession.connectTimeout!);
+      identifiedSession.connectTimeout = undefined;
+
+      // we have currently no experience with data stream connections, maybe it would be good to index active connections
+      // by their hap sessionId in order to clear out old but still open connections when the controller opens a new one
+      // on the other han the keepAlive should handle that also :thinking:
+    } else {
+      // we looped through all session and didn't find anything
+      debug("[%s] Could not identify connection. Terminating.", connection._remoteAddress);
+      connection.close(); // disconnecting since first message was not a valid hello
+    }
+  }
+
+  private handleMessageGlobally(connection: DataStreamConnection, message: DataStreamMessage) {
+    assert.notStrictEqual(message.type, MessageType.RESPONSE); // responses can't physically get here
+
+    let separator = "";
+    let args: any[] = [];
+    if (message.type === MessageType.EVENT) {
+      separator = "-e-";
+    } else if (message.type === MessageType.REQUEST) {
+      separator = "-r-";
+      args.push(message.id!);
+    }
+    args.push(message.message);
+
+    let hadListeners;
+    try {
+      hadListeners = this.internalEventEmitter.emit(message.protocol + separator + message.topic, connection, ...args);
+    } catch (error) {
+      hadListeners = true;
+      debug("[%s] Error occurred while dispatching handler for HDS message: %o", connection._remoteAddress, message);
+      debug(error.stack);
     }
 
-    /**
-     * Registers a new request handler to handle incoming request messages.
-     * The handler is only called for a connection if for the give protocol no ProtocolHandler
-     * was registered on the connection level.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to register the handler for
-     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalRequestHandler} - function to be called for every occurring request
-     */
-    onRequestMessage(protocol: string | Protocols, request: string | Topics, handler: GlobalRequestHandler): this {
-        this.internalEventEmitter.on(protocol + "-r-" + request, handler);
-        return this;
+    if (!hadListeners) {
+      debug("[%s] WARNING no handler was found for message: %o", connection._remoteAddress, message);
     }
+  }
 
-    /**
-     * Removes an registered request handler.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
-     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
-     * @param handler {GlobalRequestHandler} - registered request handler
-     */
-    removeRequestHandler(protocol: string | Protocols, request: string | Topics, handler: GlobalRequestHandler): this {
-        this.internalEventEmitter.removeListener(protocol + "-r-" + request, handler);
-        return this;
+  private connectionClosed(connection: DataStreamConnection) {
+    debug("[%s] DataStream connection closed", connection._remoteAddress);
+
+    this.connections.splice(this.connections.indexOf(connection), 1);
+    this.emit(DataStreamServerEvents.CONNECTION_CLOSED, connection);
+
+    this.checkCloseable();
+  }
+
+  private checkCloseable() {
+    if (this.connections.length === 0 && this.preparedSessions.length === 0) {
+      debug("Last connection disconnected. Closing the server now.");
+
+      this.state = ServerState.CLOSING;
+      // noinspection JSIgnoredPromiseFromCall
+      this.tcpServer!.close();
     }
+  }
 
-    prepareSession(session: Session, controllerKeySalt: Buffer, callback: (preparedSession: PreparedDataStreamSession) => void) {
-        debug("Preparing for incoming HDS connection from session %s", session.sessionID);
-        const accessoryKeySalt = crypto.randomBytes(32);
-        const salt = Buffer.concat([controllerKeySalt, accessoryKeySalt]);
+  private closed() {
+    this.tcpServer = undefined;
+    this.tcpPort = undefined;
 
-        const accessoryToControllerEncryptionKey = hkdf.HKDF("sha512", salt, session.encryption!.sharedSec, DataStreamServer.accessoryToControllerInfo, 32);
-        const controllerToAccessoryEncryptionKey = hkdf.HKDF("sha512", salt, session.encryption!.sharedSec, DataStreamServer.controllerToAccessoryInfo, 32);
-
-        const preparedSession: PreparedDataStreamSession = {
-            session: session,
-            accessoryToControllerEncryptionKey: accessoryToControllerEncryptionKey,
-            controllerToAccessoryEncryptionKey: controllerToAccessoryEncryptionKey,
-            accessoryKeySalt: accessoryKeySalt,
-            connectTimeout: setTimeout(() => this.timeoutPreparedSession(preparedSession), 10000),
-        };
-        this.preparedSessions.push(preparedSession);
-
-        this.checkTCPServerEstablished(preparedSession, () => callback(preparedSession));
-    }
-
-    private timeoutPreparedSession(preparedSession: PreparedDataStreamSession) {
-        debug("Prepared HDS session timed out out since no connection was opened for 10 seconds (%s)", preparedSession.session.sessionID);
-        const index = this.preparedSessions.indexOf(preparedSession);
-        if (index >= 0) {
-            this.preparedSessions.splice(index, 1);
-        }
-
-        this.checkCloseable();
-    }
-
-    private checkTCPServerEstablished(preparedSession: PreparedDataStreamSession, callback: () => void) {
-        switch (this.state) {
-            case ServerState.UNINITIALIZED:
-                debug("Starting up TCP server.");
-                this.tcpServer = net.createServer();
-
-                this.tcpServer.once('listening', this.listening.bind(this, preparedSession, callback));
-                this.tcpServer.on('connection', this.onConnection.bind(this));
-                this.tcpServer.on('close', this.closed.bind(this));
-
-                this.tcpServer.listen();
-                this.state = ServerState.BINDING;
-                break;
-            case ServerState.BINDING:
-                debug("TCP server already running. Waiting for it to bind.");
-                this.tcpServer!.once('listening', this.listening.bind(this, preparedSession, callback));
-                break;
-            case ServerState.LISTENING:
-                debug("Instructing client to connect to already running TCP server");
-                preparedSession.port = this.tcpPort;
-                callback();
-                break;
-            case ServerState.CLOSING:
-                debug("TCP socket is currently closing. Trying again when server is fully closed and opening a new one then.");
-                this.tcpServer!.once('close', () => setTimeout(() => this.checkTCPServerEstablished(preparedSession, callback), 10));
-                break;
-        }
-    }
-
-    private listening(preparedSession: PreparedDataStreamSession, callback: () => void) {
-        this.state = ServerState.LISTENING;
-
-        const address = this.tcpServer!.address();
-        if (address && typeof address !== "string") { // address is only typeof string when listening to a pipe or unix socket
-            this.tcpPort = address.port;
-            preparedSession.port = address.port;
-
-            debug("TCP server is now listening for new data stream connections on port %s", address.port);
-            callback();
-        }
-    }
-
-    private onConnection(socket: Socket) {
-        debug("[%s] New DataStream connection was established", socket.remoteAddress);
-        const connection = new DataStreamConnection(socket);
-
-        connection.on(DataStreamConnectionEvents.IDENTIFICATION, this.handleSessionIdentification.bind(this, connection));
-        connection.on(DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY, this.handleMessageGlobally.bind(this, connection));
-        connection.on(DataStreamConnectionEvents.CLOSED, this.connectionClosed.bind(this, connection));
-
-        this.connections.push(connection);
-
-        this.emit(DataStreamServerEvents.CONNECTION_OPENED, connection);
-    }
-
-    private handleSessionIdentification(connection: DataStreamConnection, firstFrame: HDSFrame, callback: IdentificationCallback) {
-        let identifiedSession: PreparedDataStreamSession | undefined = undefined;
-        for (let i = 0; i < this.preparedSessions.length; i++) {
-            const preparedSession = this.preparedSessions[i];
-
-            // if we successfully decrypt the first frame with this key we know to which session this connection belongs
-            if (connection.decryptHDSFrame(firstFrame, preparedSession.controllerToAccessoryEncryptionKey)) {
-                identifiedSession = preparedSession;
-                break;
-            }
-        }
-
-        callback(identifiedSession);
-
-        if (identifiedSession) {
-            debug("[%s] Connection was successfully identified (linked with sessionId: %s)", connection._remoteAddress, identifiedSession.session.sessionID);
-            const index = this.preparedSessions.indexOf(identifiedSession);
-            if (index >= 0) {
-                this.preparedSessions.splice(index, 1);
-            }
-
-            clearTimeout(identifiedSession.connectTimeout!);
-            identifiedSession.connectTimeout = undefined;
-
-            // we have currently no experience with data stream connections, maybe it would be good to index active connections
-            // by their hap sessionId in order to clear out old but still open connections when the controller opens a new one
-            // on the other han the keepAlive should handle that also :thinking:
-        } else { // we looped through all session and didn't find anything
-            debug("[%s] Could not identify connection. Terminating.", connection._remoteAddress);
-            connection.close(); // disconnecting since first message was not a valid hello
-        }
-    }
-
-    private handleMessageGlobally(connection: DataStreamConnection, message: DataStreamMessage) {
-        assert.notStrictEqual(message.type, MessageType.RESPONSE); // responses can't physically get here
-
-        let separator = "";
-        let args: any[] = [];
-        if (message.type === MessageType.EVENT) {
-            separator = "-e-";
-        } else if (message.type === MessageType.REQUEST) {
-            separator = "-r-";
-            args.push(message.id!);
-        }
-        args.push(message.message);
-
-        let hadListeners;
-        try {
-            hadListeners = this.internalEventEmitter.emit(message.protocol + separator + message.topic, connection, ...args);
-        } catch (error) {
-            hadListeners = true;
-            debug("[%s] Error occurred while dispatching handler for HDS message: %o", connection._remoteAddress, message);
-            debug(error.stack);
-        }
-
-        if (!hadListeners) {
-            debug("[%s] WARNING no handler was found for message: %o", connection._remoteAddress, message);
-        }
-    }
-
-    private connectionClosed(connection: DataStreamConnection) {
-        debug("[%s] DataStream connection closed", connection._remoteAddress);
-
-        this.connections.splice(this.connections.indexOf(connection), 1);
-        this.emit(DataStreamServerEvents.CONNECTION_CLOSED, connection);
-
-        this.checkCloseable();
-    }
-
-    private checkCloseable() {
-        if (this.connections.length === 0 && this.preparedSessions.length === 0) {
-            debug("Last connection disconnected. Closing the server now.");
-
-            this.state = ServerState.CLOSING;
-            // noinspection JSIgnoredPromiseFromCall
-            this.tcpServer!.close();
-        }
-    }
-
-    private closed() {
-        this.tcpServer = undefined;
-        this.tcpPort = undefined;
-
-        this.state = ServerState.UNINITIALIZED;
-    }
-
+    this.state = ServerState.UNINITIALIZED;
+  }
 }
 
 export enum DataStreamConnectionEvents {
-    IDENTIFICATION = "identification",
-    HANDLE_MESSAGE_GLOBALLY = "handle-message-globally",
-    CLOSED = "closed",
+  IDENTIFICATION = "identification",
+  HANDLE_MESSAGE_GLOBALLY = "handle-message-globally",
+  CLOSED = "closed",
 }
 
 export type IdentificationCallback = (identifiedSession?: PreparedDataStreamSession) => void;
 
 export type DataStreamConnectionEventMap = {
-    [DataStreamConnectionEvents.IDENTIFICATION]: (frame: HDSFrame, callback: IdentificationCallback) => void;
-    [DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY]: (message: DataStreamMessage) => void;
-    [DataStreamConnectionEvents.CLOSED]: () => void;
-}
+  [DataStreamConnectionEvents.IDENTIFICATION]: (frame: HDSFrame, callback: IdentificationCallback) => void;
+  [DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY]: (message: DataStreamMessage) => void;
+  [DataStreamConnectionEvents.CLOSED]: () => void;
+};
 
 /**
  * DataStream connection which holds any necessary state information, encryption an decryption keys, manages
@@ -421,477 +450,548 @@ export type DataStreamConnectionEventMap = {
  *        This event is emitted when the socket of the connection was closed.
  */
 export class DataStreamConnection extends EventEmitter<DataStreamConnectionEventMap> {
+  private static readonly MAX_PAYLOAD_LENGTH = 0b11111111111111111111;
 
-    private static readonly MAX_PAYLOAD_LENGTH = 0b11111111111111111111;
-
-    private socket: Socket;
-    private session?: Session; // reference to the hap session. is present when state > UNIDENTIFIED
-    readonly _remoteAddress: string;
-    /*
+  private socket: Socket;
+  private session?: Session; // reference to the hap session. is present when state > UNIDENTIFIED
+  readonly _remoteAddress: string;
+  /*
         Since our DataStream server does only listen on one port and this port is supplied to every client
         which wants to connect, we do not really know which client is who when we receive a tcp connection.
         Thus, we find the correct PreparedDataStreamSession object by testing the encryption keys of all available
         prepared sessions. Then we can reference this connection with the correct session and mark it as identified.
      */
-    private state: ConnectionState = ConnectionState.UNIDENTIFIED;
+  private state: ConnectionState = ConnectionState.UNIDENTIFIED;
 
-    private accessoryToControllerEncryptionKey?: Buffer;
-    private controllerToAccessoryEncryptionKey?: Buffer;
+  private accessoryToControllerEncryptionKey?: Buffer;
+  private controllerToAccessoryEncryptionKey?: Buffer;
 
-    private accessoryToControllerNonce: number;
-    private readonly accessoryToControllerNonceBuffer: Buffer;
-    private controllerToAccessoryNonce: number;
-    private readonly controllerToAccessoryNonceBuffer: Buffer;
+  private accessoryToControllerNonce: number;
+  private readonly accessoryToControllerNonceBuffer: Buffer;
+  private controllerToAccessoryNonce: number;
+  private readonly controllerToAccessoryNonceBuffer: Buffer;
 
-    private frameBuffer?: Buffer; // used to store incomplete HDS frames
+  private frameBuffer?: Buffer; // used to store incomplete HDS frames
 
-    private protocolHandlers: Record<string, DataStreamProtocolHandler> = {}; // used to store protocolHandlers identified by their protocol name
+  private protocolHandlers: Record<string, DataStreamProtocolHandler> = {}; // used to store protocolHandlers identified by their protocol name
 
-    private responseHandlers: Record<number, ResponseHandler> = {}; // used to store responseHandlers indexed by their respective requestId
-    private responseTimers: Record<number, Timeout> = {}; // used to store response timeouts indexed by their respective requestId
+  private responseHandlers: Record<number, ResponseHandler> = {}; // used to store responseHandlers indexed by their respective requestId
+  private responseTimers: Record<number, Timeout> = {}; // used to store response timeouts indexed by their respective requestId
 
-    private helloTimer?: Timeout;
+  private helloTimer?: Timeout;
 
-    constructor(socket: Socket) {
-        super();
-        this.socket = socket;
-        this._remoteAddress = socket.remoteAddress!;
+  constructor(socket: Socket) {
+    super();
+    this.socket = socket;
+    this._remoteAddress = socket.remoteAddress!;
 
-        this.socket.setNoDelay(true); // disable Nagle algorithm
-        this.socket.setKeepAlive(true);
+    this.socket.setNoDelay(true); // disable Nagle algorithm
+    this.socket.setKeepAlive(true);
 
-        this.accessoryToControllerNonce = 0;
-        this.accessoryToControllerNonceBuffer = Buffer.alloc(8);
-        this.controllerToAccessoryNonce = 0;
-        this.controllerToAccessoryNonceBuffer = Buffer.alloc(8);
+    this.accessoryToControllerNonce = 0;
+    this.accessoryToControllerNonceBuffer = Buffer.alloc(8);
+    this.controllerToAccessoryNonce = 0;
+    this.controllerToAccessoryNonceBuffer = Buffer.alloc(8);
 
-        this.addProtocolHandler(Protocols.CONTROL, {
-           requestHandler: {
-               [Topics.HELLO]: this.handleHello.bind(this)
-           }
-        });
+    this.addProtocolHandler(Protocols.CONTROL, {
+      requestHandler: {
+        [Topics.HELLO]: this.handleHello.bind(this),
+      },
+    });
 
-        this.helloTimer = setTimeout(() => {
-            debug("[%s] Hello message did not arrive in time. Killing the connection", this._remoteAddress);
-            this.close();
-        }, 10000);
+    this.helloTimer = setTimeout(() => {
+      debug("[%s] Hello message did not arrive in time. Killing the connection", this._remoteAddress);
+      this.close();
+    }, 10000);
 
-        this.socket.on('data', this.onSocketData.bind(this));
-        this.socket.on('error', this.onSocketError.bind(this));
-        this.socket.on('close', this.onSocketClose.bind(this)); // we MUST register for this event, otherwise the error will bubble up to the top and crash the node process entirely.
+    this.socket.on("data", this.onSocketData.bind(this));
+    this.socket.on("error", this.onSocketError.bind(this));
+    this.socket.on("close", this.onSocketClose.bind(this)); // we MUST register for this event, otherwise the error will bubble up to the top and crash the node process entirely.
+  }
+
+  private handleHello(id: number, _message: Record<any, any>) {
+    // that hello is indeed the _first_ message received is verified in onSocketData(...)
+    debug("[%s] Received hello message from client", this._remoteAddress);
+
+    clearTimeout(this.helloTimer!);
+    this.helloTimer = undefined;
+
+    this.state = ConnectionState.READY;
+
+    this.sendResponse(Protocols.CONTROL, Topics.HELLO, id);
+  }
+
+  /**
+   * Registers a new protocol handler to handle incoming messages.
+   * The same protocol cannot be registered multiple times.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to register the handler for
+   * @param protocolHandler {DataStreamProtocolHandler} - object to be registered as protocol handler
+   */
+  addProtocolHandler(protocol: string | Protocols, protocolHandler: DataStreamProtocolHandler): boolean {
+    if (this.protocolHandlers[protocol] !== undefined) {
+      return false;
     }
 
-    private handleHello(id: number, _message: Record<any, any>) {
-        // that hello is indeed the _first_ message received is verified in onSocketData(...)
-        debug("[%s] Received hello message from client", this._remoteAddress);
+    this.protocolHandlers[protocol] = protocolHandler;
+    return true;
+  }
 
-        clearTimeout(this.helloTimer!);
-        this.helloTimer = undefined;
+  /**
+   * Removes a protocol handler if it is registered.
+   *
+   * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+   * @param protocolHandler {DataStreamProtocolHandler} - object which will be unregistered
+   */
+  removeProtocolHandler(protocol: string | Protocols, protocolHandler: DataStreamProtocolHandler) {
+    const current = this.protocolHandlers[protocol];
 
-        this.state = ConnectionState.READY;
+    if (current === protocolHandler) {
+      delete this.protocolHandlers[protocol];
+    }
+  }
 
-        this.sendResponse(Protocols.CONTROL, Topics.HELLO, id);
+  /**
+   * Sends a new event message to the connected client.
+   *
+   * @param protocol {string | Protocols} - name of the protocol
+   * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+   * @param message {Record<any, any>} - message dictionary which gets sent along the event
+   */
+  sendEvent(protocol: string | Protocols, event: string | Topics, message: Record<any, any> = {}) {
+    const header: Record<any, any> = {};
+    header["protocol"] = protocol;
+    header["event"] = event;
+
+    this.sendHDSFrame(header, message);
+  }
+
+  /**
+   * Sends a new request message to the connected client.
+   *
+   * @param protocol {string | Protocols} - name of the protocol
+   * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+   * @param message {Record<any, any>} - message dictionary which gets sent along the request
+   * @param callback {ResponseHandler} - handler which gets supplied with an error object if the response didn't
+   *                                     arrive in time or the status and the message dictionary from the response
+   */
+  sendRequest(
+    protocol: string | Protocols,
+    request: string | Topics,
+    message: Record<any, any> = {},
+    callback: ResponseHandler
+  ) {
+    let requestId: number;
+    do {
+      // generate unused requestId
+      // currently writing int64 to data stream is not really supported, so 32-bit int will be the max
+      requestId = Math.floor(Math.random() * 4294967295);
+    } while (this.responseHandlers[requestId] !== undefined);
+
+    this.responseHandlers[requestId] = callback;
+    this.responseTimers[requestId] = setTimeout(() => {
+      // we did not receive a response => close socket
+      this.close();
+
+      const handler = this.responseHandlers[requestId];
+
+      delete this.responseHandlers[requestId];
+      delete this.responseTimers[requestId];
+
+      // handler should be able to cleanup their stuff
+      handler(new Error("timeout"), undefined, {});
+    }, 10000); // 10s timer
+
+    const header: Record<any, any> = {};
+    header["protocol"] = protocol;
+    header["request"] = request;
+    header["id"] = new Int64(requestId);
+
+    this.sendHDSFrame(header, message);
+  }
+
+  /**
+   * Send a new response message to a received request message to the client.
+   *
+   * @param protocol {string | Protocols} - name of the protocol
+   * @param response {string | Topics} - name of the response (also referred to as topic. See {Topics} for some known ones)
+   * @param id {number} - id from the request, to associate the response to the request
+   * @param status {HDSStatus} - status indication if the request was successful. A status of zero indicates success.
+   * @param message {Record<any, any>} - message dictionary which gets sent along the response
+   */
+  sendResponse(
+    protocol: string | Protocols,
+    response: string | Topics,
+    id: number,
+    status: HDSStatus = HDSStatus.SUCCESS,
+    message: Record<any, any> = {}
+  ) {
+    const header: Record<any, any> = {};
+    header["protocol"] = protocol;
+    header["response"] = response;
+    header["id"] = new Int64(id);
+    header["status"] = new Int64(status);
+
+    this.sendHDSFrame(header, message);
+  }
+
+  private onSocketData(data: Buffer) {
+    if (this.state >= ConnectionState.CLOSING) {
+      return;
     }
 
-    /**
-     * Registers a new protocol handler to handle incoming messages.
-     * The same protocol cannot be registered multiple times.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to register the handler for
-     * @param protocolHandler {DataStreamProtocolHandler} - object to be registered as protocol handler
-     */
-    addProtocolHandler(protocol: string | Protocols, protocolHandler: DataStreamProtocolHandler): boolean {
-        if (this.protocolHandlers[protocol] !== undefined) {
-            return false;
+    let frameIndex = 0;
+    const frames: HDSFrame[] = this.decodeHDSFrames(data);
+    if (frames.length === 0) {
+      // not enough data
+      return;
+    }
+
+    if (this.state === ConnectionState.UNIDENTIFIED) {
+      // at the beginning we are only interested in trying to decrypt the first frame in order to test decryption keys
+      const firstFrame = frames[frameIndex++];
+      this.emit(
+        DataStreamConnectionEvents.IDENTIFICATION,
+        firstFrame,
+        (identifiedSession?: PreparedDataStreamSession) => {
+          if (identifiedSession) {
+            // horray, we found our session
+            this.session = identifiedSession.session;
+            this.accessoryToControllerEncryptionKey = identifiedSession.accessoryToControllerEncryptionKey;
+            this.controllerToAccessoryEncryptionKey = identifiedSession.controllerToAccessoryEncryptionKey;
+            this.state = ConnectionState.EXPECTING_HELLO;
+
+            this.session.on(HAPSessionEvents.CLOSED, this.onHAPSessionClosed.bind(this)); // register close listener
+          }
+        }
+      );
+
+      if (this.state === ConnectionState.UNIDENTIFIED) {
+        // did not find a prepared session, server already closed this connection; nothing to do here
+        return;
+      }
+    }
+
+    for (; frameIndex < frames.length; frameIndex++) {
+      // decrypt all remaining frames
+      if (!this.decryptHDSFrame(frames[frameIndex])) {
+        debug(
+          "[%s] HDS frame decryption or authentication failed. Connection will be terminated!",
+          this._remoteAddress
+        );
+        this.close();
+        return;
+      }
+    }
+
+    const messages: DataStreamMessage[] = this.decodePayloads(frames); // decode contents of payload
+
+    if (this.state === ConnectionState.EXPECTING_HELLO) {
+      const firstMessage = messages[0];
+
+      if (
+        firstMessage.protocol !== Protocols.CONTROL ||
+        firstMessage.type !== MessageType.REQUEST ||
+        firstMessage.topic !== Topics.HELLO
+      ) {
+        // first message is not the expected hello request
+        debug(
+          "[%s] First message received was not the expected hello message. Instead got: %o",
+          this._remoteAddress,
+          firstMessage
+        );
+        this.close();
+        return;
+      }
+    }
+
+    messages.forEach(message => {
+      if (message.type === MessageType.RESPONSE) {
+        // protocol and topic are currently not tested here; just assumed their are correct;
+        // probably they are as the requestId is unique per connection no matter what protocol is used
+        const responseHandler = this.responseHandlers[message.id!];
+        const responseTimer = this.responseTimers[message.id!];
+
+        if (responseTimer) {
+          clearTimeout(responseTimer);
+          delete this.responseTimers[message.id!];
         }
 
-        this.protocolHandlers[protocol] = protocolHandler;
-        return true;
-    }
-
-    /**
-     * Removes a protocol handler if it is registered.
-     *
-     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
-     * @param protocolHandler {DataStreamProtocolHandler} - object which will be unregistered
-     */
-    removeProtocolHandler(protocol: string | Protocols, protocolHandler: DataStreamProtocolHandler) {
-        const current = this.protocolHandlers[protocol];
-
-        if (current === protocolHandler) {
-            delete this.protocolHandlers[protocol];
+        if (!responseHandler) {
+          // we got a response to a request we did not send; we ignore it for now, since nobody will be hurt
+          debug("WARNING we received a response to a request we have not sent: %o", message);
+          return;
         }
-    }
 
-    /**
-     * Sends a new event message to the connected client.
-     *
-     * @param protocol {string | Protocols} - name of the protocol
-     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
-     * @param message {Record<any, any>} - message dictionary which gets sent along the event
-     */
-    sendEvent(protocol: string | Protocols, event: string | Topics, message: Record<any, any> = {}) {
-        const header: Record<any, any> = {};
-        header["protocol"] = protocol;
-        header["event"] = event;
+        try {
+          responseHandler(undefined, message.status!, message.message);
+        } catch (error) {
+          debug(
+            "[%s] Error occurred while dispatching response handler for HDS message: %o",
+            this._remoteAddress,
+            message
+          );
+          debug(error.stack);
+        }
+        delete this.responseHandlers[message.id!];
+      } else {
+        const handler = this.protocolHandlers[message.protocol];
+        if (handler === undefined) {
+          // send message to the server to check if there are some global handlers for it
+          this.emit(DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY, message);
+          return;
+        }
 
-        this.sendHDSFrame(header, message);
-    }
-
-    /**
-     * Sends a new request message to the connected client.
-     *
-     * @param protocol {string | Protocols} - name of the protocol
-     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
-     * @param message {Record<any, any>} - message dictionary which gets sent along the request
-     * @param callback {ResponseHandler} - handler which gets supplied with an error object if the response didn't
-     *                                     arrive in time or the status and the message dictionary from the response
-     */
-    sendRequest(protocol: string | Protocols, request: string | Topics, message: Record<any, any> = {}, callback: ResponseHandler) {
-        let requestId: number;
-        do { // generate unused requestId
-            // currently writing int64 to data stream is not really supported, so 32-bit int will be the max
-            requestId = Math.floor(Math.random() * 4294967295);
-        } while (this.responseHandlers[requestId] !== undefined);
-
-        this.responseHandlers[requestId] = callback;
-        this.responseTimers[requestId] = setTimeout(() => {
-            // we did not receive a response => close socket
-            this.close();
-
-            const handler = this.responseHandlers[requestId];
-
-            delete this.responseHandlers[requestId];
-            delete this.responseTimers[requestId];
-
-            // handler should be able to cleanup their stuff
-            handler(new Error("timeout"), undefined, {});
-        }, 10000); // 10s timer
-
-        const header: Record<any, any> = {};
-        header["protocol"] = protocol;
-        header["request"] = request;
-        header["id"] = new Int64(requestId);
-
-        this.sendHDSFrame(header, message);
-    }
-
-    /**
-     * Send a new response message to a received request message to the client.
-     *
-     * @param protocol {string | Protocols} - name of the protocol
-     * @param response {string | Topics} - name of the response (also referred to as topic. See {Topics} for some known ones)
-     * @param id {number} - id from the request, to associate the response to the request
-     * @param status {HDSStatus} - status indication if the request was successful. A status of zero indicates success.
-     * @param message {Record<any, any>} - message dictionary which gets sent along the response
-     */
-    sendResponse(protocol: string | Protocols, response: string | Topics, id: number, status: HDSStatus = HDSStatus.SUCCESS, message: Record<any, any> = {}) {
-        const header: Record<any, any> = {};
-        header["protocol"] = protocol;
-        header["response"] = response;
-        header["id"] = new Int64(id);
-        header["status"] = new Int64(status);
-
-        this.sendHDSFrame(header, message);
-    }
-
-    private onSocketData(data: Buffer) {
-        if (this.state >= ConnectionState.CLOSING) {
+        if (message.type === MessageType.EVENT) {
+          let eventHandler: EventHandler;
+          if (!handler.eventHandler || !(eventHandler = handler.eventHandler[message.topic])) {
+            debug("[%s] WARNING no event handler was found for message: %o", this._remoteAddress, message);
             return;
-        }
+          }
 
-        let frameIndex = 0;
-        const frames: HDSFrame[] = this.decodeHDSFrames(data);
-        if (frames.length === 0) { // not enough data
+          try {
+            eventHandler(message.message);
+          } catch (error) {
+            debug(
+              "[%s] Error occurred while dispatching event handler for HDS message: %o",
+              this._remoteAddress,
+              message
+            );
+            debug(error.stack);
+          }
+        } else if (message.type === MessageType.REQUEST) {
+          let requestHandler: RequestHandler;
+          if (!handler.requestHandler || !(requestHandler = handler.requestHandler[message.topic])) {
+            debug("[%s] WARNING no request handler was found for message: %o", this._remoteAddress, message);
             return;
-        }
+          }
 
-        if (this.state === ConnectionState.UNIDENTIFIED) {
-            // at the beginning we are only interested in trying to decrypt the first frame in order to test decryption keys
-            const firstFrame = frames[frameIndex++];
-            this.emit(DataStreamConnectionEvents.IDENTIFICATION, firstFrame, (identifiedSession?: PreparedDataStreamSession) => {
-               if (identifiedSession) {
-                   // horray, we found our session
-                   this.session = identifiedSession.session;
-                   this.accessoryToControllerEncryptionKey = identifiedSession.accessoryToControllerEncryptionKey;
-                   this.controllerToAccessoryEncryptionKey = identifiedSession.controllerToAccessoryEncryptionKey;
-                   this.state = ConnectionState.EXPECTING_HELLO;
-
-                   this.session.on(HAPSessionEvents.CLOSED, this.onHAPSessionClosed.bind(this)); // register close listener
-               }
-            });
-
-            if (this.state === ConnectionState.UNIDENTIFIED) {
-                // did not find a prepared session, server already closed this connection; nothing to do here
-                return;
-            }
-        }
-
-        for (; frameIndex < frames.length; frameIndex++) { // decrypt all remaining frames
-            if (!this.decryptHDSFrame(frames[frameIndex])) {
-                debug("[%s] HDS frame decryption or authentication failed. Connection will be terminated!", this._remoteAddress);
-                this.close();
-                return;
-            }
-        }
-
-        const messages: DataStreamMessage[] = this.decodePayloads(frames); // decode contents of payload
-
-        if (this.state === ConnectionState.EXPECTING_HELLO) {
-            const firstMessage = messages[0];
-
-            if (firstMessage.protocol !== Protocols.CONTROL || firstMessage.type !== MessageType.REQUEST || firstMessage.topic !== Topics.HELLO) {
-                // first message is not the expected hello request
-                debug("[%s] First message received was not the expected hello message. Instead got: %o", this._remoteAddress, firstMessage);
-                this.close();
-                return;
-            }
-        }
-
-        messages.forEach(message => {
-            if (message.type === MessageType.RESPONSE) {
-                // protocol and topic are currently not tested here; just assumed their are correct;
-                // probably they are as the requestId is unique per connection no matter what protocol is used
-                const responseHandler = this.responseHandlers[message.id!];
-                const responseTimer = this.responseTimers[message.id!];
-
-                if (responseTimer) {
-                    clearTimeout(responseTimer);
-                    delete this.responseTimers[message.id!];
-                }
-
-                if (!responseHandler) {
-                    // we got a response to a request we did not send; we ignore it for now, since nobody will be hurt
-                    debug("WARNING we received a response to a request we have not sent: %o", message);
-                    return;
-                }
-
-                try {
-                    responseHandler(undefined, message.status!, message.message);
-                } catch (error) {
-                    debug("[%s] Error occurred while dispatching response handler for HDS message: %o", this._remoteAddress, message);
-                    debug(error.stack);
-                }
-                delete this.responseHandlers[message.id!];
-            } else {
-                const handler = this.protocolHandlers[message.protocol];
-                if (handler === undefined) {
-                    // send message to the server to check if there are some global handlers for it
-                    this.emit(DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY, message);
-                    return;
-                }
-
-                if (message.type === MessageType.EVENT) {
-                    let eventHandler: EventHandler;
-                    if (!handler.eventHandler || !(eventHandler = handler.eventHandler[message.topic])) {
-                        debug("[%s] WARNING no event handler was found for message: %o", this._remoteAddress, message);
-                        return;
-                    }
-
-                    try {
-                        eventHandler(message.message);
-                    } catch (error) {
-                        debug("[%s] Error occurred while dispatching event handler for HDS message: %o", this._remoteAddress, message);
-                        debug(error.stack);
-                    }
-                } else if (message.type === MessageType.REQUEST) {
-                    let requestHandler: RequestHandler;
-                    if (!handler.requestHandler || !(requestHandler = handler.requestHandler[message.topic])) {
-                        debug("[%s] WARNING no request handler was found for message: %o", this._remoteAddress, message);
-                        return;
-                    }
-
-                    try {
-                        requestHandler(message.id!, message.message);
-                    } catch (error) {
-                        debug("[%s] Error occurred while dispatching request handler for HDS message: %o", this._remoteAddress, message);
-                        debug(error.stack);
-                    }
-                } else {
-                    debug("[%s] Encountered unknown message type with id %d", this._remoteAddress, message.type);
-                }
-            }
-        })
-    }
-
-    private decodeHDSFrames(data: Buffer) {
-        if (this.frameBuffer !== undefined) {
-            data = Buffer.concat([this.frameBuffer, data]);
-            this.frameBuffer = undefined;
-        }
-
-        const totalBufferLength = data.length;
-        const frames: HDSFrame[] = [];
-
-        for (let frameBegin = 0; frameBegin < totalBufferLength;) {
-            if (frameBegin + 4 > totalBufferLength) {
-                // we don't have enough data in the buffer for the next header
-                this.frameBuffer = data.slice(frameBegin);
-                break;
-            }
-
-            const payloadType = data.readUInt8(frameBegin); // type defining structure of payload; 8-bit; currently expected to be 1
-            const payloadLength = data.readUIntBE(frameBegin + 1, 3); // read 24-bit big-endian uint length field
-
-            if (payloadLength > DataStreamConnection.MAX_PAYLOAD_LENGTH) {
-                debug("[%s] Connection send payload with size bigger than the maximum allow for data stream", this._remoteAddress);
-                this.close();
-                return [];
-            }
-
-            const remainingBufferLength = totalBufferLength - frameBegin - 4; // subtract 4 for payloadType (1-byte) and payloadLength (3-byte)
-            // check if the data from this frame is already there (payload + 16-byte authTag)
-            if (payloadLength + 16 > remainingBufferLength) {
-                // Frame is fragmented, so we wait until we receive more
-                this.frameBuffer = data.slice(frameBegin);
-                break;
-            }
-
-            const payloadBegin = frameBegin + 4;
-            const authTagBegin = payloadBegin + payloadLength;
-
-            const header = data.slice(frameBegin, payloadBegin); // header is also authenticated using authTag
-            const cipheredPayload = data.slice(payloadBegin, authTagBegin);
-            const plaintextPayload = Buffer.alloc(payloadLength);
-            const authTag = data.slice(authTagBegin, authTagBegin + 16);
-
-            frameBegin = authTagBegin + 16; // move to next frame
-
-            if (payloadType === 1) {
-                const hdsFrame: HDSFrame = {
-                    header: header,
-                    cipheredPayload: cipheredPayload,
-                    plaintextPayload: plaintextPayload,
-                    authTag: authTag,
-                };
-                frames.push(hdsFrame);
-            } else {
-                debug("[%s] Encountered unknown payload type %d for payload: %s", this._remoteAddress, plaintextPayload.toString('hex'));
-            }
-        }
-
-        return frames;
-    }
-
-    decryptHDSFrame(frame: HDSFrame, keyOverwrite?: Buffer): boolean {
-        encryption.writeUInt64LE(this.controllerToAccessoryNonce, this.controllerToAccessoryNonceBuffer, 0); // update nonce buffer
-
-        const key = keyOverwrite || this.controllerToAccessoryEncryptionKey!;
-        if (encryption.verifyAndDecrypt(key, this.controllerToAccessoryNonceBuffer,
-            frame.cipheredPayload, frame.authTag, frame.header, frame.plaintextPayload)) {
-            this.controllerToAccessoryNonce++; // we had a successful encryption, increment the nonce
-            return true;
+          try {
+            requestHandler(message.id!, message.message);
+          } catch (error) {
+            debug(
+              "[%s] Error occurred while dispatching request handler for HDS message: %o",
+              this._remoteAddress,
+              message
+            );
+            debug(error.stack);
+          }
         } else {
-            // frame decryption or authentication failed. Could happen when our guess for a PreparedDataStreamSession is wrong
-            return false;
+          debug("[%s] Encountered unknown message type with id %d", this._remoteAddress, message.type);
         }
+      }
+    });
+  }
+
+  private decodeHDSFrames(data: Buffer) {
+    if (this.frameBuffer !== undefined) {
+      data = Buffer.concat([this.frameBuffer, data]);
+      this.frameBuffer = undefined;
     }
 
-    private decodePayloads(frames: HDSFrame[]) {
-        const messages: DataStreamMessage[] = [];
+    const totalBufferLength = data.length;
+    const frames: HDSFrame[] = [];
 
-        frames.forEach(frame => {
-            const payload = frame.plaintextPayload;
+    for (let frameBegin = 0; frameBegin < totalBufferLength; ) {
+      if (frameBegin + 4 > totalBufferLength) {
+        // we don't have enough data in the buffer for the next header
+        this.frameBuffer = data.slice(frameBegin);
+        break;
+      }
 
-            const headerLength = payload.readUInt8(0);
-            const messageLength = payload.length - headerLength - 1;
+      const payloadType = data.readUInt8(frameBegin); // type defining structure of payload; 8-bit; currently expected to be 1
+      const payloadLength = data.readUIntBE(frameBegin + 1, 3); // read 24-bit big-endian uint length field
 
-            const headerBegin = 1;
-            const messageBegin = headerBegin + headerLength;
+      if (payloadLength > DataStreamConnection.MAX_PAYLOAD_LENGTH) {
+        debug(
+          "[%s] Connection send payload with size bigger than the maximum allow for data stream",
+          this._remoteAddress
+        );
+        this.close();
+        return [];
+      }
 
-            const headerPayload = new DataStreamReader(payload.slice(headerBegin, headerBegin + headerLength));
-            const messagePayload = new DataStreamReader(payload.slice(messageBegin, messageBegin + messageLength));
+      const remainingBufferLength = totalBufferLength - frameBegin - 4; // subtract 4 for payloadType (1-byte) and payloadLength (3-byte)
+      // check if the data from this frame is already there (payload + 16-byte authTag)
+      if (payloadLength + 16 > remainingBufferLength) {
+        // Frame is fragmented, so we wait until we receive more
+        this.frameBuffer = data.slice(frameBegin);
+        break;
+      }
 
-            let headerDictionary: Record<any, any>;
-            let messageDictionary: Record<any, any>;
-            try {
-                headerDictionary = DataStreamParser.decode(headerPayload);
-                headerPayload.finished();
-            } catch (error) {
-                debug("[%s] Failed to decode header payload: %s", this._remoteAddress, error.message);
-                return;
-            }
+      const payloadBegin = frameBegin + 4;
+      const authTagBegin = payloadBegin + payloadLength;
 
-            try {
-                messageDictionary = DataStreamParser.decode(messagePayload);
-                messagePayload.finished();
-            } catch (error) {
-                debug("[%s] Failed to decode message payload: %s (header: %o)", this._remoteAddress, error.message, headerDictionary);
-                return;
-            }
+      const header = data.slice(frameBegin, payloadBegin); // header is also authenticated using authTag
+      const cipheredPayload = data.slice(payloadBegin, authTagBegin);
+      const plaintextPayload = Buffer.alloc(payloadLength);
+      const authTag = data.slice(authTagBegin, authTagBegin + 16);
 
-            let type: MessageType;
-            const protocol: string = headerDictionary["protocol"];
-            let topic: string;
-            let id: number | undefined = undefined;
-            let status: HDSStatus | undefined = undefined;
+      frameBegin = authTagBegin + 16; // move to next frame
 
-            if (headerDictionary["event"] !== undefined) {
-                type = MessageType.EVENT;
-                topic = headerDictionary["event"];
-            } else if (headerDictionary["request"] !== undefined) {
-                type = MessageType.REQUEST;
-                topic = headerDictionary["request"];
-                id = headerDictionary["id"];
-            } else if (headerDictionary["response"] !== undefined) {
-                type = MessageType.RESPONSE;
-                topic = headerDictionary["response"];
-                id = headerDictionary["id"];
-                status = headerDictionary["status"];
-            } else {
-                debug("[%s] Encountered unknown payload header format: %o (message: %o)", this._remoteAddress, headerDictionary, messageDictionary);
-                return;
-            }
-
-            const message: DataStreamMessage = {
-                type: type,
-                protocol: protocol,
-                topic: topic,
-                id: id,
-                status: status,
-                message: messageDictionary,
-            };
-            messages.push(message);
-        });
-
-        return messages;
+      if (payloadType === 1) {
+        const hdsFrame: HDSFrame = {
+          header: header,
+          cipheredPayload: cipheredPayload,
+          plaintextPayload: plaintextPayload,
+          authTag: authTag,
+        };
+        frames.push(hdsFrame);
+      } else {
+        debug(
+          "[%s] Encountered unknown payload type %d for payload: %s",
+          this._remoteAddress,
+          plaintextPayload.toString("hex")
+        );
+      }
     }
 
-    private sendHDSFrame(header: Record<any, any>, message: Record<any, any>) {
-        if (this.state >= ConnectionState.CLOSING) {
-            throw Error("Cannot send message on closing/closed socket!");
-        }
+    return frames;
+  }
 
-        const headerWriter = new DataStreamWriter();
-        const messageWriter = new DataStreamWriter();
+  decryptHDSFrame(frame: HDSFrame, keyOverwrite?: Buffer): boolean {
+    encryption.writeUInt64LE(this.controllerToAccessoryNonce, this.controllerToAccessoryNonceBuffer, 0); // update nonce buffer
 
-        DataStreamParser.encode(header, headerWriter);
-        DataStreamParser.encode(message, messageWriter);
+    const key = keyOverwrite || this.controllerToAccessoryEncryptionKey!;
+    if (
+      encryption.verifyAndDecrypt(
+        key,
+        this.controllerToAccessoryNonceBuffer,
+        frame.cipheredPayload,
+        frame.authTag,
+        frame.header,
+        frame.plaintextPayload
+      )
+    ) {
+      this.controllerToAccessoryNonce++; // we had a successful encryption, increment the nonce
+      return true;
+    } else {
+      // frame decryption or authentication failed. Could happen when our guess for a PreparedDataStreamSession is wrong
+      return false;
+    }
+  }
 
+  private decodePayloads(frames: HDSFrame[]) {
+    const messages: DataStreamMessage[] = [];
 
-        const payloadHeaderBuffer = Buffer.alloc(1);
-        payloadHeaderBuffer.writeUInt8(headerWriter.length(), 0);
-        const payloadBuffer = Buffer.concat([payloadHeaderBuffer, headerWriter.getData(), messageWriter.getData()]);
-        if (payloadBuffer.length > DataStreamConnection.MAX_PAYLOAD_LENGTH) {
-            throw new Error("Tried sending payload with length larger than the maximum allowed for data stream");
-        }
+    frames.forEach(frame => {
+      const payload = frame.plaintextPayload;
 
-        const frameTypeBuffer = Buffer.alloc(1);
-        frameTypeBuffer.writeUInt8(1, 0);
-        let frameLengthBuffer = Buffer.alloc(4);
-        frameLengthBuffer.writeUInt32BE(payloadBuffer.length, 0);
-        frameLengthBuffer = frameLengthBuffer.slice(1, 4); // a bit hacky but the only real way to write 24-bit int in node
+      const headerLength = payload.readUInt8(0);
+      const messageLength = payload.length - headerLength - 1;
 
-        const frameHeader = Buffer.concat([frameTypeBuffer, frameLengthBuffer]);
-        const authTag = Buffer.alloc(16);
-        const cipheredPayload = Buffer.alloc(payloadBuffer.length);
+      const headerBegin = 1;
+      const messageBegin = headerBegin + headerLength;
 
-        encryption.writeUInt64LE(this.accessoryToControllerNonce++, this.accessoryToControllerNonceBuffer);
-        encryption.encryptAndSeal(this.accessoryToControllerEncryptionKey!, this.accessoryToControllerNonceBuffer, payloadBuffer, frameHeader, cipheredPayload, authTag);
+      const headerPayload = new DataStreamReader(payload.slice(headerBegin, headerBegin + headerLength));
+      const messagePayload = new DataStreamReader(payload.slice(messageBegin, messageBegin + messageLength));
 
-        this.socket.write(Buffer.concat([frameHeader, cipheredPayload, authTag]));
+      let headerDictionary: Record<any, any>;
+      let messageDictionary: Record<any, any>;
+      try {
+        headerDictionary = DataStreamParser.decode(headerPayload);
+        headerPayload.finished();
+      } catch (error) {
+        debug("[%s] Failed to decode header payload: %s", this._remoteAddress, error.message);
+        return;
+      }
 
-        /* Useful for debugging outgoing packages and detecting encoding errors
+      try {
+        messageDictionary = DataStreamParser.decode(messagePayload);
+        messagePayload.finished();
+      } catch (error) {
+        debug(
+          "[%s] Failed to decode message payload: %s (header: %o)",
+          this._remoteAddress,
+          error.message,
+          headerDictionary
+        );
+        return;
+      }
+
+      let type: MessageType;
+      const protocol: string = headerDictionary["protocol"];
+      let topic: string;
+      let id: number | undefined = undefined;
+      let status: HDSStatus | undefined = undefined;
+
+      if (headerDictionary["event"] !== undefined) {
+        type = MessageType.EVENT;
+        topic = headerDictionary["event"];
+      } else if (headerDictionary["request"] !== undefined) {
+        type = MessageType.REQUEST;
+        topic = headerDictionary["request"];
+        id = headerDictionary["id"];
+      } else if (headerDictionary["response"] !== undefined) {
+        type = MessageType.RESPONSE;
+        topic = headerDictionary["response"];
+        id = headerDictionary["id"];
+        status = headerDictionary["status"];
+      } else {
+        debug(
+          "[%s] Encountered unknown payload header format: %o (message: %o)",
+          this._remoteAddress,
+          headerDictionary,
+          messageDictionary
+        );
+        return;
+      }
+
+      const message: DataStreamMessage = {
+        type: type,
+        protocol: protocol,
+        topic: topic,
+        id: id,
+        status: status,
+        message: messageDictionary,
+      };
+      messages.push(message);
+    });
+
+    return messages;
+  }
+
+  private sendHDSFrame(header: Record<any, any>, message: Record<any, any>) {
+    if (this.state >= ConnectionState.CLOSING) {
+      throw Error("Cannot send message on closing/closed socket!");
+    }
+
+    const headerWriter = new DataStreamWriter();
+    const messageWriter = new DataStreamWriter();
+
+    DataStreamParser.encode(header, headerWriter);
+    DataStreamParser.encode(message, messageWriter);
+
+    const payloadHeaderBuffer = Buffer.alloc(1);
+    payloadHeaderBuffer.writeUInt8(headerWriter.length(), 0);
+    const payloadBuffer = Buffer.concat([payloadHeaderBuffer, headerWriter.getData(), messageWriter.getData()]);
+    if (payloadBuffer.length > DataStreamConnection.MAX_PAYLOAD_LENGTH) {
+      throw new Error("Tried sending payload with length larger than the maximum allowed for data stream");
+    }
+
+    const frameTypeBuffer = Buffer.alloc(1);
+    frameTypeBuffer.writeUInt8(1, 0);
+    let frameLengthBuffer = Buffer.alloc(4);
+    frameLengthBuffer.writeUInt32BE(payloadBuffer.length, 0);
+    frameLengthBuffer = frameLengthBuffer.slice(1, 4); // a bit hacky but the only real way to write 24-bit int in node
+
+    const frameHeader = Buffer.concat([frameTypeBuffer, frameLengthBuffer]);
+    const authTag = Buffer.alloc(16);
+    const cipheredPayload = Buffer.alloc(payloadBuffer.length);
+
+    encryption.writeUInt64LE(this.accessoryToControllerNonce++, this.accessoryToControllerNonceBuffer);
+    encryption.encryptAndSeal(
+      this.accessoryToControllerEncryptionKey!,
+      this.accessoryToControllerNonceBuffer,
+      payloadBuffer,
+      frameHeader,
+      cipheredPayload,
+      authTag
+    );
+
+    this.socket.write(Buffer.concat([frameHeader, cipheredPayload, authTag]));
+
+    /* Useful for debugging outgoing packages and detecting encoding errors
         console.log("SENT DATA: " + payloadBuffer.toString("hex"));
         const frame: HDSFrame = {
             header: frameHeader,
@@ -902,31 +1002,31 @@ export class DataStreamConnection extends EventEmitter<DataStreamConnectionEvent
         const sentMessage = this.decodePayloads([frame])[0];
         console.log("Sent message: " + JSON.stringify(sentMessage, null, 4));
         //*/
+  }
+
+  close() {
+    // closing socket by sending FIN packet; incoming data will be ignored from that point on
+    if (this.state >= ConnectionState.CLOSING) {
+      return; // connection is already closing/closed
     }
 
-    close() { // closing socket by sending FIN packet; incoming data will be ignored from that point on
-        if (this.state >= ConnectionState.CLOSING) {
-            return; // connection is already closing/closed
-        }
+    this.state = ConnectionState.CLOSING;
+    this.socket.end();
+  }
 
-        this.state = ConnectionState.CLOSING;
-        this.socket.end();
-    }
+  private onHAPSessionClosed() {
+    // If the hap session is closed it is probably also a good idea to close the data stream session
+    debug("[%s] HAP session disconnected. Also closing DataStream connection now.", this._remoteAddress);
+    this.close();
+  }
 
-    private onHAPSessionClosed() {
-        // If the hap session is closed it is probably also a good idea to close the data stream session
-        debug("[%s] HAP session disconnected. Also closing DataStream connection now.", this._remoteAddress);
-        this.close();
-    }
+  private onSocketError(error: Error) {
+    debug("[%s] Encountered socket error: %s", this._remoteAddress, error.message);
+    // onSocketClose will be called next
+  }
 
-    private onSocketError(error: Error) {
-        debug("[%s] Encountered socket error: %s", this._remoteAddress, error.message);
-        // onSocketClose will be called next
-    }
-
-    private onSocketClose() {
-        this.state = ConnectionState.CLOSED;
-        this.emit(DataStreamConnectionEvents.CLOSED);
-    }
-
+  private onSocketClose() {
+    this.state = ConnectionState.CLOSED;
+    this.emit(DataStreamConnectionEvents.CLOSED);
+  }
 }

--- a/src/lib/datastream/index.ts
+++ b/src/lib/datastream/index.ts
@@ -1,3 +1,3 @@
-export * from './DataStreamManagement';
-export * from './DataStreamServer';
-export * from './DataStreamParser';
+export * from "./DataStreamManagement";
+export * from "./DataStreamServer";
+export * from "./DataStreamParser";

--- a/src/lib/gen/HomeKit-Bridge.ts
+++ b/src/lib/gen/HomeKit-Bridge.ts
@@ -1,5 +1,5 @@
-import { Characteristic, Formats, Perms } from '../Characteristic';
-import { Service } from '../Service';
+import { Characteristic, Formats, Perms } from "../Characteristic";
+import { Service } from "../Service";
 
 /**
  *
@@ -12,14 +12,13 @@ import { Service } from '../Service';
  */
 
 export class AppMatchingIdentifier extends Characteristic {
-
-  static readonly UUID: string = '000000A4-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A4-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('App Matching Identifier', AppMatchingIdentifier.UUID);
+    super("App Matching Identifier", AppMatchingIdentifier.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -32,17 +31,16 @@ Characteristic.AppMatchingIdentifier = AppMatchingIdentifier;
  */
 
 export class ProgrammableSwitchOutputState extends Characteristic {
-
-  static readonly UUID: string = '00000074-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000074-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Programmable Switch Output State', ProgrammableSwitchOutputState.UUID);
+    super("Programmable Switch Output State", ProgrammableSwitchOutputState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -55,14 +53,13 @@ Characteristic.ProgrammableSwitchOutputState = ProgrammableSwitchOutputState;
  */
 
 export class SoftwareRevision extends Characteristic {
-
-  static readonly UUID: string = '00000054-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000054-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Software Revision', SoftwareRevision.UUID);
+    super("Software Revision", SoftwareRevision.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -75,8 +72,7 @@ Characteristic.SoftwareRevision = SoftwareRevision;
  */
 
 export class CameraControl extends Service {
-
-  static readonly UUID: string = '00000111-0000-1000-8000-0026BB765291'
+  static readonly UUID: string = "00000111-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, CameraControl.UUID, subtype);
@@ -105,8 +101,7 @@ Service.CameraControl = CameraControl;
  */
 
 export class StatefulProgrammableSwitch extends Service {
-
-  static readonly UUID: string = '00000088-0000-1000-8000-0026BB765291'
+  static readonly UUID: string = "00000088-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, StatefulProgrammableSwitch.UUID, subtype);
@@ -133,14 +128,13 @@ Service.StatefulProgrammableSwitch = StatefulProgrammableSwitch;
  */
 
 export class AccessoryIdentifier extends Characteristic {
-
-  static readonly UUID: string = '00000057-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000057-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Accessory Identifier', AccessoryIdentifier.UUID);
+    super("Accessory Identifier", AccessoryIdentifier.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -153,17 +147,16 @@ Characteristic.AccessoryIdentifier = AccessoryIdentifier;
  */
 
 export class Category extends Characteristic {
-
-  static readonly UUID: string = '000000A3-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A3-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Category', Category.UUID);
+    super("Category", Category.UUID);
     this.setProps({
       format: Formats.UINT16,
       maxValue: 16,
       minValue: 1,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -176,14 +169,13 @@ Characteristic.Category = Category;
  */
 
 export class ConfigureBridgedAccessory extends Characteristic {
-
-  static readonly UUID: string = '000000A0-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A0-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Configure Bridged Accessory', ConfigureBridgedAccessory.UUID);
+    super("Configure Bridged Accessory", ConfigureBridgedAccessory.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.WRITE]
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -196,14 +188,13 @@ Characteristic.ConfigureBridgedAccessory = ConfigureBridgedAccessory;
  */
 
 export class ConfigureBridgedAccessoryStatus extends Characteristic {
-
-  static readonly UUID: string = '0000009D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000009D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Configure Bridged Accessory Status', ConfigureBridgedAccessoryStatus.UUID);
+    super("Configure Bridged Accessory Status", ConfigureBridgedAccessoryStatus.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -216,14 +207,13 @@ Characteristic.ConfigureBridgedAccessoryStatus = ConfigureBridgedAccessoryStatus
  */
 
 export class CurrentTime extends Characteristic {
-
-  static readonly UUID: string = '0000009B-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000009B-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Time', CurrentTime.UUID);
+    super("Current Time", CurrentTime.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ, Perms.WRITE]
+      perms: [Perms.READ, Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -236,17 +226,16 @@ Characteristic.CurrentTime = CurrentTime;
  */
 
 export class DayoftheWeek extends Characteristic {
-
-  static readonly UUID: string = '00000098-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000098-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Day of the Week', DayoftheWeek.UUID);
+    super("Day of the Week", DayoftheWeek.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 7,
       minValue: 1,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE]
+      perms: [Perms.READ, Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -259,18 +248,17 @@ Characteristic.DayoftheWeek = DayoftheWeek;
  */
 
 export class DiscoverBridgedAccessories extends Characteristic {
-
   // The value property of DiscoverBridgedAccessories must be one of the following:
   static readonly START_DISCOVERY = 0;
   static readonly STOP_DISCOVERY = 1;
 
-  static readonly UUID: string = '0000009E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000009E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Discover Bridged Accessories', DiscoverBridgedAccessories.UUID);
+    super("Discover Bridged Accessories", DiscoverBridgedAccessories.UUID);
     this.setProps({
       format: Formats.UINT8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -283,14 +271,13 @@ Characteristic.DiscoverBridgedAccessories = DiscoverBridgedAccessories;
  */
 
 export class DiscoveredBridgedAccessories extends Characteristic {
-
-  static readonly UUID: string = '0000009F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000009F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Discovered Bridged Accessories', DiscoveredBridgedAccessories.UUID);
+    super("Discovered Bridged Accessories", DiscoveredBridgedAccessories.UUID);
     this.setProps({
       format: Formats.UINT16,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -303,17 +290,16 @@ Characteristic.DiscoveredBridgedAccessories = DiscoveredBridgedAccessories;
  */
 
 export class LinkQuality extends Characteristic {
-
-  static readonly UUID: string = '0000009C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000009C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Link Quality', LinkQuality.UUID);
+    super("Link Quality", LinkQuality.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 4,
       minValue: 1,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -326,14 +312,13 @@ Characteristic.LinkQuality = LinkQuality;
  */
 
 export class Reachable extends Characteristic {
-
-  static readonly UUID: string = '00000063-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000063-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Reachable', Reachable.UUID);
+    super("Reachable", Reachable.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -346,14 +331,13 @@ Characteristic.Reachable = Reachable;
  */
 
 export class RelayControlPoint extends Characteristic {
-
-  static readonly UUID: string = '0000005E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000005E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Relay Control Point', RelayControlPoint.UUID);
+    super("Relay Control Point", RelayControlPoint.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -366,14 +350,13 @@ Characteristic.RelayControlPoint = RelayControlPoint;
  */
 
 export class RelayEnabled extends Characteristic {
-
-  static readonly UUID: string = '0000005B-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000005B-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Relay Enabled', RelayEnabled.UUID);
+    super("Relay Enabled", RelayEnabled.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -386,14 +369,13 @@ Characteristic.RelayEnabled = RelayEnabled;
  */
 
 export class RelayState extends Characteristic {
-
-  static readonly UUID: string = '0000005C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000005C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Relay State', RelayState.UUID);
+    super("Relay State", RelayState.UUID);
     this.setProps({
       format: Formats.UINT8,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -406,14 +388,13 @@ Characteristic.RelayState = RelayState;
  */
 
 export class TimeUpdate extends Characteristic {
-
-  static readonly UUID: string = '0000009A-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000009A-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Time Update', TimeUpdate.UUID);
+    super("Time Update", TimeUpdate.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -426,14 +407,13 @@ Characteristic.TimeUpdate = TimeUpdate;
  */
 
 export class TunnelConnectionTimeout extends Characteristic {
-
-  static readonly UUID: string = '00000061-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000061-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Tunnel Connection Timeout ', TunnelConnectionTimeout.UUID);
+    super("Tunnel Connection Timeout ", TunnelConnectionTimeout.UUID);
     this.setProps({
       format: Formats.UINT32,
-      perms: [Perms.WRITE, Perms.READ, Perms.NOTIFY]
+      perms: [Perms.WRITE, Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -446,14 +426,13 @@ Characteristic.TunnelConnectionTimeout = TunnelConnectionTimeout;
  */
 
 export class TunneledAccessoryAdvertising extends Characteristic {
-
-  static readonly UUID: string = '00000060-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000060-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Tunneled Accessory Advertising', TunneledAccessoryAdvertising.UUID);
+    super("Tunneled Accessory Advertising", TunneledAccessoryAdvertising.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.WRITE, Perms.READ, Perms.NOTIFY]
+      perms: [Perms.WRITE, Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -466,14 +445,13 @@ Characteristic.TunneledAccessoryAdvertising = TunneledAccessoryAdvertising;
  */
 
 export class TunneledAccessoryConnected extends Characteristic {
-
-  static readonly UUID: string = '00000059-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000059-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Tunneled Accessory Connected', TunneledAccessoryConnected.UUID);
+    super("Tunneled Accessory Connected", TunneledAccessoryConnected.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.WRITE, Perms.READ, Perms.NOTIFY]
+      perms: [Perms.WRITE, Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -486,14 +464,13 @@ Characteristic.TunneledAccessoryConnected = TunneledAccessoryConnected;
  */
 
 export class TunneledAccessoryStateNumber extends Characteristic {
-
-  static readonly UUID: string = '00000058-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000058-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Tunneled Accessory State Number', TunneledAccessoryStateNumber.UUID);
+    super("Tunneled Accessory State Number", TunneledAccessoryStateNumber.UUID);
     this.setProps({
       format: Formats.FLOAT,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -506,14 +483,13 @@ Characteristic.TunneledAccessoryStateNumber = TunneledAccessoryStateNumber;
  */
 
 export class Version extends Characteristic {
-
-  static readonly UUID: string = '00000037-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000037-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Version', Version.UUID);
+    super("Version", Version.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -526,8 +502,7 @@ Characteristic.Version = Version;
  */
 
 export class BridgeConfiguration extends Service {
-
-  static readonly UUID: string = '000000A1-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A1-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, BridgeConfiguration.UUID, subtype);
@@ -550,8 +525,7 @@ Service.BridgeConfiguration = BridgeConfiguration;
  */
 
 export class BridgingState extends Service {
-
-  static readonly UUID: string = '00000062-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000062-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, BridgingState.UUID, subtype);
@@ -574,8 +548,7 @@ Service.BridgingState = BridgingState;
  */
 
 export class Pairing extends Service {
-
-  static readonly UUID: string = '00000055-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000055-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Pairing.UUID, subtype);
@@ -597,8 +570,7 @@ Service.Pairing = Pairing;
  */
 
 export class ProtocolInformation extends Service {
-
-  static readonly UUID: string = '000000A2-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A2-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, ProtocolInformation.UUID, subtype);
@@ -617,8 +589,7 @@ Service.ProtocolInformation = ProtocolInformation;
  */
 
 export class Relay extends Service {
-
-  static readonly UUID: string = '0000005A-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000005A-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Relay.UUID, subtype);
@@ -639,8 +610,7 @@ Service.Relay = Relay;
  */
 
 export class TimeInformation extends Service {
-
-  static readonly UUID: string = '00000099-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000099-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, TimeInformation.UUID, subtype);
@@ -662,8 +632,7 @@ Service.TimeInformation = TimeInformation;
  */
 
 export class TunneledBTLEAccessoryService extends Service {
-
-  static readonly UUID: string = '00000056-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000056-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, TunneledBTLEAccessoryService.UUID, subtype);

--- a/src/lib/gen/HomeKit-DataStream.ts
+++ b/src/lib/gen/HomeKit-DataStream.ts
@@ -1,26 +1,23 @@
 // manually created
 
-import {Characteristic, Formats, Perms} from '../Characteristic';
-import {Service} from "../Service";
-
+import { Characteristic, Formats, Perms } from "../Characteristic";
+import { Service } from "../Service";
 
 /**
  * Characteristic "Supported Data Stream Transport Configuration"
  */
 
 export class SupportedDataStreamTransportConfiguration extends Characteristic {
+  static readonly UUID: string = "00000130-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000130-0000-1000-8000-0026BB765291';
-
-    constructor() {
-        super('Supported Data Stream Transport Configuration', SupportedDataStreamTransportConfiguration.UUID);
-        this.setProps({
-            format: Formats.TLV8,
-            perms: [Perms.PAIRED_READ]
-        });
-        this.value = this.getDefaultValue();
-    }
-
+  constructor() {
+    super("Supported Data Stream Transport Configuration", SupportedDataStreamTransportConfiguration.UUID);
+    this.setProps({
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_READ],
+    });
+    this.value = this.getDefaultValue();
+  }
 }
 
 Characteristic.SupportedDataStreamTransportConfiguration = SupportedDataStreamTransportConfiguration;
@@ -30,39 +27,35 @@ Characteristic.SupportedDataStreamTransportConfiguration = SupportedDataStreamTr
  */
 
 export class SetupDataStreamTransport extends Characteristic {
+  static readonly UUID: string = "00000131-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000131-0000-1000-8000-0026BB765291';
-
-    constructor() {
-        super('Setup Data Stream Transport', SetupDataStreamTransport.UUID);
-        this.setProps({
-            format: Formats.TLV8,
-            perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE, Perms.WRITE_RESPONSE]
-        });
-        this.value = this.getDefaultValue();
-    }
-
+  constructor() {
+    super("Setup Data Stream Transport", SetupDataStreamTransport.UUID);
+    this.setProps({
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE, Perms.WRITE_RESPONSE],
+    });
+    this.value = this.getDefaultValue();
+  }
 }
 
 Characteristic.SetupDataStreamTransport = SetupDataStreamTransport;
-
 
 /**
  * Service "Data Stream Transport Management"
  */
 
 export class DataStreamTransportManagement extends Service {
+  static readonly UUID: string = "00000129-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000129-0000-1000-8000-0026BB765291';
+  constructor(displayName: string, subtype: string) {
+    super(displayName, DataStreamTransportManagement.UUID, subtype);
 
-    constructor(displayName: string, subtype: string) {
-        super(displayName, DataStreamTransportManagement.UUID, subtype);
-
-        // Required Characteristics
-        this.addCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration);
-        this.addCharacteristic(Characteristic.SetupDataStreamTransport);
-        this.addCharacteristic(Characteristic.Version);
-    }
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration);
+    this.addCharacteristic(Characteristic.SetupDataStreamTransport);
+    this.addCharacteristic(Characteristic.Version);
+  }
 }
 
 Service.DataStreamTransportManagement = DataStreamTransportManagement;

--- a/src/lib/gen/HomeKit-Remote.ts
+++ b/src/lib/gen/HomeKit-Remote.ts
@@ -1,25 +1,23 @@
 // manually created
 
-import { Access, Characteristic, Formats, Perms } from '../Characteristic';
-import { Service } from '../Service';
-
+import { Access, Characteristic, Formats, Perms } from "../Characteristic";
+import { Service } from "../Service";
 
 /**
  * Characteristic "Target Control Supported Configuration"
  */
 
 export class TargetControlSupportedConfiguration extends Characteristic {
+  static readonly UUID: string = "00000123-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000123-0000-1000-8000-0026BB765291';
-
-    constructor() {
-        super('Target Control Supported Configuration', TargetControlSupportedConfiguration.UUID);
-        this.setProps({
-            format: Formats.TLV8,
-            perms: [Perms.PAIRED_READ]
-        });
-        this.value = this.getDefaultValue();
-    }
+  constructor() {
+    super("Target Control Supported Configuration", TargetControlSupportedConfiguration.UUID);
+    this.setProps({
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_READ],
+    });
+    this.value = this.getDefaultValue();
+  }
 }
 
 Characteristic.TargetControlSupportedConfiguration = TargetControlSupportedConfiguration;
@@ -29,19 +27,17 @@ Characteristic.TargetControlSupportedConfiguration = TargetControlSupportedConfi
  */
 
 export class TargetControlList extends Characteristic {
+  static readonly UUID: string = "00000124-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000124-0000-1000-8000-0026BB765291';
-
-    constructor() {
-        super('Target Control List', TargetControlList.UUID);
-        this.setProps({
-            format: Formats.TLV8,
-            perms: [Perms.PAIRED_WRITE, Perms.PAIRED_READ, Perms.WRITE_RESPONSE]
-        });
-        this.value = this.getDefaultValue();
-        this.accessRestrictedToAdmins = [Access.READ, Access.WRITE]
-    }
-
+  constructor() {
+    super("Target Control List", TargetControlList.UUID);
+    this.setProps({
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_WRITE, Perms.PAIRED_READ, Perms.WRITE_RESPONSE],
+    });
+    this.value = this.getDefaultValue();
+    this.accessRestrictedToAdmins = [Access.READ, Access.WRITE];
+  }
 }
 
 Characteristic.TargetControlList = TargetControlList;
@@ -51,19 +47,17 @@ Characteristic.TargetControlList = TargetControlList;
  */
 
 export class ButtonEvent extends Characteristic {
+  static readonly UUID: string = "00000126-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000126-0000-1000-8000-0026BB765291';
-
-    constructor() {
-        super('Button Event', ButtonEvent.UUID);
-        this.setProps({
-            format: Formats.TLV8,
-            perms: [Perms.PAIRED_READ, Perms.NOTIFY]
-        });
-        this.value = this.getDefaultValue();
-        this.accessRestrictedToAdmins = [Access.NOTIFY];
-    }
-
+  constructor() {
+    super("Button Event", ButtonEvent.UUID);
+    this.setProps({
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_READ, Perms.NOTIFY],
+    });
+    this.value = this.getDefaultValue();
+    this.accessRestrictedToAdmins = [Access.NOTIFY];
+  }
 }
 
 Characteristic.ButtonEvent = ButtonEvent;
@@ -73,18 +67,16 @@ Characteristic.ButtonEvent = ButtonEvent;
  */
 
 export class SelectedAudioStreamConfiguration extends Characteristic {
+  static readonly UUID: string = "00000128-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000128-0000-1000-8000-0026BB765291';
-
-    constructor() {
-        super('Selected Audio Stream Configuration', SelectedAudioStreamConfiguration.UUID);
-        this.setProps({
-            format: Formats.TLV8,
-            perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE]
-        });
-        this.value = this.getDefaultValue();
-    }
-
+  constructor() {
+    super("Selected Audio Stream Configuration", SelectedAudioStreamConfiguration.UUID);
+    this.setProps({
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
+    });
+    this.value = this.getDefaultValue();
+  }
 }
 
 Characteristic.SelectedAudioStreamConfiguration = SelectedAudioStreamConfiguration;
@@ -94,23 +86,21 @@ Characteristic.SelectedAudioStreamConfiguration = SelectedAudioStreamConfigurati
  */
 
 export class SiriInputType extends Characteristic {
+  static readonly PUSH_BUTTON_TRIGGERED_APPLE_TV = 0;
 
-    static readonly PUSH_BUTTON_TRIGGERED_APPLE_TV = 0;
+  static readonly UUID: string = "00000132-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000132-0000-1000-8000-0026BB765291';
-
-    constructor() {
-        super('Siri Input Type', SiriInputType.UUID);
-        this.setProps({
-            format: Formats.UINT8,
-            minValue: 0,
-            maxValue: 0,
-            validValues: [0],
-            perms: [Perms.PAIRED_READ]
-        });
-        this.value = this.getDefaultValue();
-    }
-
+  constructor() {
+    super("Siri Input Type", SiriInputType.UUID);
+    this.setProps({
+      format: Formats.UINT8,
+      minValue: 0,
+      maxValue: 0,
+      validValues: [0],
+      perms: [Perms.PAIRED_READ],
+    });
+    this.value = this.getDefaultValue();
+  }
 }
 
 Characteristic.SiriInputType = SiriInputType;
@@ -120,16 +110,15 @@ Characteristic.SiriInputType = SiriInputType;
  */
 
 export class TargetControlManagement extends Service {
+  static readonly UUID: string = "00000122-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000122-0000-1000-8000-0026BB765291';
+  constructor(displayName: string, subtype: string) {
+    super(displayName, TargetControlManagement.UUID, subtype);
 
-    constructor(displayName: string, subtype: string) {
-        super(displayName, TargetControlManagement.UUID, subtype);
-
-        // Required Characteristics
-        this.addCharacteristic(Characteristic.TargetControlSupportedConfiguration);
-        this.addCharacteristic(Characteristic.TargetControlList);
-    }
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.TargetControlSupportedConfiguration);
+    this.addCharacteristic(Characteristic.TargetControlList);
+  }
 }
 
 Service.TargetControlManagement = TargetControlManagement;
@@ -139,20 +128,19 @@ Service.TargetControlManagement = TargetControlManagement;
  */
 
 export class TargetControl extends Service {
+  static readonly UUID: string = "00000125-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000125-0000-1000-8000-0026BB765291';
+  constructor(displayName: string, subtype: string) {
+    super(displayName, TargetControl.UUID, subtype);
 
-    constructor(displayName: string, subtype: string) {
-        super(displayName, TargetControl.UUID, subtype);
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.ActiveIdentifier);
+    this.addCharacteristic(Characteristic.Active);
+    this.addCharacteristic(Characteristic.ButtonEvent);
 
-        // Required Characteristics
-        this.addCharacteristic(Characteristic.ActiveIdentifier);
-        this.addCharacteristic(Characteristic.Active);
-        this.addCharacteristic(Characteristic.ButtonEvent);
-
-        // Optional Characteristics
-        this.addOptionalCharacteristic(Characteristic.Name);
-    }
+    // Optional Characteristics
+    this.addOptionalCharacteristic(Characteristic.Name);
+  }
 }
 
 Service.TargetControl = TargetControl;
@@ -162,16 +150,15 @@ Service.TargetControl = TargetControl;
  */
 
 export class AudioStreamManagement extends Service {
+  static readonly UUID: string = "00000127-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000127-0000-1000-8000-0026BB765291';
+  constructor(displayName: string, subtype: string) {
+    super(displayName, AudioStreamManagement.UUID, subtype);
 
-    constructor(displayName: string, subtype: string) {
-        super(displayName, AudioStreamManagement.UUID, subtype);
-
-        // Required Characteristics
-        this.addCharacteristic(Characteristic.SupportedAudioStreamConfiguration);
-        this.addCharacteristic(Characteristic.SelectedAudioStreamConfiguration);
-    }
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.SupportedAudioStreamConfiguration);
+    this.addCharacteristic(Characteristic.SelectedAudioStreamConfiguration);
+  }
 }
 
 Service.AudioStreamManagement = AudioStreamManagement;
@@ -181,15 +168,14 @@ Service.AudioStreamManagement = AudioStreamManagement;
  */
 
 export class Siri extends Service {
+  static readonly UUID: string = "00000133-0000-1000-8000-0026BB765291";
 
-    static readonly UUID: string = '00000133-0000-1000-8000-0026BB765291';
+  constructor(displayName: string, subtype: string) {
+    super(displayName, Siri.UUID, subtype);
 
-    constructor(displayName: string, subtype: string) {
-        super(displayName, Siri.UUID, subtype);
-
-        // Required Characteristics
-        this.addCharacteristic(Characteristic.SiriInputType);
-    }
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.SiriInputType);
+  }
 }
 
 Service.Siri = Siri;

--- a/src/lib/gen/HomeKit-TV.ts
+++ b/src/lib/gen/HomeKit-TV.ts
@@ -1,21 +1,20 @@
 // Manually created from metadata in HomeKitDaemon
 
-import { Characteristic, Perms, Formats } from '../Characteristic';
-import { Service } from '../Service';
+import { Characteristic, Perms, Formats } from "../Characteristic";
+import { Service } from "../Service";
 
 /**
  * Characteristic "Active Identifier"
  */
 
 export class ActiveIdentifier extends Characteristic {
-
-  static readonly UUID: string = '000000E7-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E7-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Active Identifier', ActiveIdentifier.UUID);
+    super("Active Identifier", ActiveIdentifier.UUID);
     this.setProps({
       format: Formats.UINT32,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -28,14 +27,13 @@ Characteristic.ActiveIdentifier = ActiveIdentifier;
  */
 
 export class ConfiguredName extends Characteristic {
-
-  static readonly UUID: string = '000000E3-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E3-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Configured Name', ConfiguredName.UUID);
+    super("Configured Name", ConfiguredName.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -48,21 +46,20 @@ Characteristic.ConfiguredName = ConfiguredName;
  */
 
 export class SleepDiscoveryMode extends Characteristic {
-
-// The value property of SleepDiscoveryMode must be one of the following:
+  // The value property of SleepDiscoveryMode must be one of the following:
   static readonly NOT_DISCOVERABLE = 0;
   static readonly ALWAYS_DISCOVERABLE = 1;
 
-  static readonly UUID: string = '000000E8-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E8-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Sleep Discovery Mode', SleepDiscoveryMode.UUID);
+    super("Sleep Discovery Mode", SleepDiscoveryMode.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
-      validValues: [0,1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      validValues: [0, 1],
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -75,21 +72,20 @@ Characteristic.SleepDiscoveryMode = SleepDiscoveryMode;
  */
 
 export class ClosedCaptions extends Characteristic {
-
   // The value property of ClosedCaptions must be one of the following:
   static readonly DISABLED = 0;
   static readonly ENABLED = 1;
 
-  static readonly UUID: string = '000000DD-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000DD-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Closed Captions', ClosedCaptions.UUID);
+    super("Closed Captions", ClosedCaptions.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
-      validValues: [0,1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      validValues: [0, 1],
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -102,14 +98,13 @@ Characteristic.ClosedCaptions = ClosedCaptions;
  */
 
 export class DisplayOrder extends Characteristic {
-
-  static readonly UUID: string = '00000136-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000136-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Display Order', DisplayOrder.UUID);
+    super("Display Order", DisplayOrder.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -122,17 +117,16 @@ Characteristic.DisplayOrder = DisplayOrder;
  */
 
 export class CurrentMediaState extends Characteristic {
-
-  static readonly UUID: string = '000000E0-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E0-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Media State', CurrentMediaState.UUID);
+    super("Current Media State", CurrentMediaState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
-      validValues: [0,1,2,3],
-      perms: [Perms.READ, Perms.NOTIFY]
+      validValues: [0, 1, 2, 3],
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -145,22 +139,21 @@ Characteristic.CurrentMediaState = CurrentMediaState;
  */
 
 export class TargetMediaState extends Characteristic {
-
-// The value property of TargetMediaState must be one of the following:
+  // The value property of TargetMediaState must be one of the following:
   static readonly PLAY = 0;
   static readonly PAUSE = 1;
   static readonly STOP = 2;
 
-  static readonly UUID: string = '00000137-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000137-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Media State', TargetMediaState.UUID);
+    super("Target Media State", TargetMediaState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
-      validValues: [0,1,2,3],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      validValues: [0, 1, 2, 3],
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -173,8 +166,7 @@ Characteristic.TargetMediaState = TargetMediaState;
  */
 
 export class PictureMode extends Characteristic {
-
-// The value property of PictureMode must be one of the following:
+  // The value property of PictureMode must be one of the following:
   static readonly OTHER = 0;
   static readonly STANDARD = 1;
   static readonly CALIBRATED = 2;
@@ -184,16 +176,16 @@ export class PictureMode extends Characteristic {
   static readonly COMPUTER = 6;
   static readonly CUSTOM = 7;
 
-  static readonly UUID: string = '000000E2-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E2-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Picture Mode', PictureMode.UUID);
+    super("Picture Mode", PictureMode.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 13,
       minValue: 0,
-      validValues: [0,1,2,3,4,5,6,7,8,9,10,11,12,13],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      validValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -206,21 +198,20 @@ Characteristic.PictureMode = PictureMode;
  */
 
 export class PowerModeSelection extends Characteristic {
-
   // The value property of PowerModeSelection must be one of the following:
   static readonly SHOW = 0;
   static readonly HIDE = 1;
 
-  static readonly UUID: string = '000000DF-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000DF-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Power Mode Selection', PowerModeSelection.UUID);
+    super("Power Mode Selection", PowerModeSelection.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
-      validValues: [0,1],
-      perms: [Perms.WRITE]
+      validValues: [0, 1],
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -233,8 +224,7 @@ Characteristic.PowerModeSelection = PowerModeSelection;
  */
 
 export class RemoteKey extends Characteristic {
-
-// The value property of RemoteKey must be one of the following:
+  // The value property of RemoteKey must be one of the following:
   static readonly REWIND = 0;
   static readonly FAST_FORWARD = 1;
   static readonly NEXT_TRACK = 2;
@@ -249,16 +239,16 @@ export class RemoteKey extends Characteristic {
   static readonly PLAY_PAUSE = 11;
   static readonly INFORMATION = 15;
 
-  static readonly UUID: string = '000000E1-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E1-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Remote Key', RemoteKey.UUID);
+    super("Remote Key", RemoteKey.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 16,
       minValue: 0,
-      validValues: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],
-      perms: [Perms.WRITE]
+      validValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -271,8 +261,7 @@ Characteristic.RemoteKey = RemoteKey;
  */
 
 export class InputSourceType extends Characteristic {
-
-// The value property of InputSourceType must be one of the following:
+  // The value property of InputSourceType must be one of the following:
   static readonly OTHER = 0;
   static readonly HOME_SCREEN = 1;
   static readonly TUNER = 2;
@@ -285,16 +274,16 @@ export class InputSourceType extends Characteristic {
   static readonly USB = 9;
   static readonly APPLICATION = 10;
 
-  static readonly UUID: string = '000000DB-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000DB-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Input Source Type', InputSourceType.UUID);
+    super("Input Source Type", InputSourceType.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 10,
       minValue: 0,
-      validValues: [0,1,2,3,4,5,6,7,8,9,10],
-      perms: [Perms.READ, Perms.NOTIFY]
+      validValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -307,7 +296,6 @@ Characteristic.InputSourceType = InputSourceType;
  */
 
 export class InputDeviceType extends Characteristic {
-
   // The value property of InputDeviceType must be one of the following:
   static readonly OTHER = 0;
   static readonly TV = 1;
@@ -316,16 +304,16 @@ export class InputDeviceType extends Characteristic {
   static readonly PLAYBACK = 4;
   static readonly AUDIO_SYSTEM = 5;
 
-  static readonly UUID: string = '000000DC-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000DC-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Input Device Type', InputDeviceType.UUID);
+    super("Input Device Type", InputDeviceType.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 5,
       minValue: 0,
-      validValues: [0,1,2,3,4,5],
-      perms: [Perms.READ, Perms.NOTIFY]
+      validValues: [0, 1, 2, 3, 4, 5],
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -338,16 +326,15 @@ Characteristic.InputDeviceType = InputDeviceType;
  */
 
 export class Identifier extends Characteristic {
-
-  static readonly UUID: string = '000000E6-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E6-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Identifier', Identifier.UUID);
+    super("Identifier", Identifier.UUID);
     this.setProps({
       format: Formats.UINT32,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -360,21 +347,20 @@ Characteristic.Identifier = Identifier;
  */
 
 export class CurrentVisibilityState extends Characteristic {
-
-// The value property of CurrentVisibilityState must be one of the following:
+  // The value property of CurrentVisibilityState must be one of the following:
   static readonly SHOWN = 0;
   static readonly HIDDEN = 1;
 
-  static readonly UUID: string = '00000135-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000135-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Visibility State', CurrentVisibilityState.UUID);
+    super("Current Visibility State", CurrentVisibilityState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
-      validValues: [0,1,2,3],
-      perms: [Perms.READ, Perms.NOTIFY]
+      validValues: [0, 1, 2, 3],
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -387,21 +373,20 @@ Characteristic.CurrentVisibilityState = CurrentVisibilityState;
  */
 
 export class TargetVisibilityState extends Characteristic {
-
-// The value property of TargetVisibilityState must be one of the following:
+  // The value property of TargetVisibilityState must be one of the following:
   static readonly SHOWN = 0;
   static readonly HIDDEN = 1;
 
-  static readonly UUID: string = '00000134-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000134-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Visibility State', TargetVisibilityState.UUID);
+    super("Target Visibility State", TargetVisibilityState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
-      validValues: [0,1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      validValues: [0, 1],
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -414,23 +399,22 @@ Characteristic.TargetVisibilityState = TargetVisibilityState;
  */
 
 export class VolumeControlType extends Characteristic {
-
-// The value property of VolumeControlType must be one of the following:
+  // The value property of VolumeControlType must be one of the following:
   static readonly NONE = 0;
   static readonly RELATIVE = 1;
   static readonly RELATIVE_WITH_CURRENT = 2;
   static readonly ABSOLUTE = 3;
 
-  static readonly UUID: string = '000000E9-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000E9-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Volume Control Type', VolumeControlType.UUID);
+    super("Volume Control Type", VolumeControlType.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
-      validValues: [0,1,2,3],
-      perms: [Perms.READ, Perms.NOTIFY]
+      validValues: [0, 1, 2, 3],
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -443,21 +427,20 @@ Characteristic.VolumeControlType = VolumeControlType;
  */
 
 export class VolumeSelector extends Characteristic {
-
-// The value property of VolumeSelector must be one of the following:
+  // The value property of VolumeSelector must be one of the following:
   static readonly INCREMENT = 0;
   static readonly DECREMENT = 1;
 
-  static readonly UUID: string = '000000EA-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000EA-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Volume Selector', VolumeSelector.UUID);
+    super("Volume Selector", VolumeSelector.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
-      validValues: [0,1],
-      perms: [Perms.WRITE]
+      validValues: [0, 1],
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -465,14 +448,12 @@ export class VolumeSelector extends Characteristic {
 
 Characteristic.VolumeSelector = VolumeSelector;
 
-
 /**
  * Service "Television"
  */
 
 export class Television extends Service {
-
-  static readonly UUID: string = '000000D8-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D8-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Television.UUID, subtype);
@@ -502,8 +483,7 @@ Service.Television = Television;
  */
 
 export class InputSource extends Service {
-
-  static readonly UUID: string = '000000D9-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D9-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, InputSource.UUID, subtype);
@@ -529,8 +509,7 @@ Service.InputSource = InputSource;
  */
 
 export class TelevisionSpeaker extends Service {
-
-  static readonly UUID: string = '00000113-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000113-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, TelevisionSpeaker.UUID, subtype);

--- a/src/lib/gen/HomeKit.ts
+++ b/src/lib/gen/HomeKit.ts
@@ -1,21 +1,20 @@
 // THIS FILE IS AUTO-GENERATED - DO NOT MODIFY
 
-import { Characteristic, Formats, Perms, Units } from '../Characteristic';
-import { Service } from '../Service';
+import { Characteristic, Formats, Perms, Units } from "../Characteristic";
+import { Service } from "../Service";
 
 /**
  * Characteristic "Accessory Flags"
  */
 
 export class AccessoryFlags extends Characteristic {
-
-  static readonly UUID: string = '000000A6-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A6-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Accessory Flags', AccessoryFlags.UUID);
+    super("Accessory Flags", AccessoryFlags.UUID);
     this.setProps({
       format: Formats.UINT32,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -28,14 +27,13 @@ Characteristic.AccessoryFlags = AccessoryFlags;
  */
 
 export class ProductData extends Characteristic {
-
-  static readonly UUID: string = '00000220-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000220-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Product Data', ProductData.UUID);
+    super("Product Data", ProductData.UUID);
     this.setProps({
       format: Formats.DATA,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -48,21 +46,20 @@ Characteristic.ProductData = ProductData;
  */
 
 export class Active extends Characteristic {
-
   // The value property of Active must be one of the following:
   static readonly INACTIVE = 0;
   static readonly ACTIVE = 1;
 
-  static readonly UUID: string = '000000B0-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000B0-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Active', Active.UUID);
+    super("Active", Active.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -75,14 +72,13 @@ Characteristic.Active = Active;
  */
 
 export class AdministratorOnlyAccess extends Characteristic {
-
-  static readonly UUID: string = '00000001-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000001-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Administrator Only Access', AdministratorOnlyAccess.UUID);
+    super("Administrator Only Access", AdministratorOnlyAccess.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -95,17 +91,16 @@ Characteristic.AdministratorOnlyAccess = AdministratorOnlyAccess;
  */
 
 export class AirParticulateDensity extends Characteristic {
-
-  static readonly UUID: string = '00000064-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000064-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Air Particulate Density', AirParticulateDensity.UUID);
+    super("Air Particulate Density", AirParticulateDensity.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 1000,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -118,21 +113,20 @@ Characteristic.AirParticulateDensity = AirParticulateDensity;
  */
 
 export class AirParticulateSize extends Characteristic {
-
   // The value property of AirParticulateSize must be one of the following:
   static readonly _2_5_M = 0;
   static readonly _10_M = 1;
 
-  static readonly UUID: string = '00000065-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000065-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Air Particulate Size', AirParticulateSize.UUID);
+    super("Air Particulate Size", AirParticulateSize.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -140,13 +134,11 @@ export class AirParticulateSize extends Characteristic {
 
 Characteristic.AirParticulateSize = AirParticulateSize;
 
-
 /**
  * Characteristic "Air Quality"
  */
 
 export class AirQuality extends Characteristic {
-
   // The value property of AirQuality must be one of the following:
   static readonly UNKNOWN = 0;
   static readonly EXCELLENT = 1;
@@ -155,16 +147,16 @@ export class AirQuality extends Characteristic {
   static readonly INFERIOR = 4;
   static readonly POOR = 5;
 
-  static readonly UUID: string = '00000095-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000095-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Air Quality', AirQuality.UUID);
+    super("Air Quality", AirQuality.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 5,
       minValue: 0,
       validValues: [0, 1, 2, 3, 4, 5],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -172,20 +164,18 @@ export class AirQuality extends Characteristic {
 
 Characteristic.AirQuality = AirQuality;
 
-
 /**
  * Characteristic "Audio Feedback"
  */
 
 export class AudioFeedback extends Characteristic {
-
-  static readonly UUID: string = '00000005-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000005-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Audio Feedback', AudioFeedback.UUID);
+    super("Audio Feedback", AudioFeedback.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -198,18 +188,17 @@ Characteristic.AudioFeedback = AudioFeedback;
  */
 
 export class BatteryLevel extends Characteristic {
-
-  static readonly UUID: string = '00000068-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000068-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Battery Level', BatteryLevel.UUID);
+    super("Battery Level", BatteryLevel.UUID);
     this.setProps({
       format: Formats.UINT8,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -222,18 +211,17 @@ Characteristic.BatteryLevel = BatteryLevel;
  */
 
 export class Brightness extends Characteristic {
-
-  static readonly UUID: string = '00000008-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000008-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Brightness', Brightness.UUID);
+    super("Brightness", Brightness.UUID);
     this.setProps({
       format: Formats.INT,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -246,21 +234,20 @@ Characteristic.Brightness = Brightness;
  */
 
 export class CarbonDioxideDetected extends Characteristic {
-
   // The value property of CarbonDioxideDetected must be one of the following:
   static readonly CO2_LEVELS_NORMAL = 0;
   static readonly CO2_LEVELS_ABNORMAL = 1;
 
-  static readonly UUID: string = '00000092-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000092-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Carbon Dioxide Detected', CarbonDioxideDetected.UUID);
+    super("Carbon Dioxide Detected", CarbonDioxideDetected.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -273,16 +260,15 @@ Characteristic.CarbonDioxideDetected = CarbonDioxideDetected;
  */
 
 export class CarbonDioxideLevel extends Characteristic {
-
-  static readonly UUID: string = '00000093-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000093-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Carbon Dioxide Level', CarbonDioxideLevel.UUID);
+    super("Carbon Dioxide Level", CarbonDioxideLevel.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 100000,
       minValue: 0,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -295,16 +281,15 @@ Characteristic.CarbonDioxideLevel = CarbonDioxideLevel;
  */
 
 export class CarbonDioxidePeakLevel extends Characteristic {
-
-  static readonly UUID: string = '00000094-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000094-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Carbon Dioxide Peak Level', CarbonDioxidePeakLevel.UUID);
+    super("Carbon Dioxide Peak Level", CarbonDioxidePeakLevel.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 100000,
       minValue: 0,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -317,21 +302,20 @@ Characteristic.CarbonDioxidePeakLevel = CarbonDioxidePeakLevel;
  */
 
 export class CarbonMonoxideDetected extends Characteristic {
-
   // The value property of CarbonMonoxideDetected must be one of the following:
   static readonly CO_LEVELS_NORMAL = 0;
   static readonly CO_LEVELS_ABNORMAL = 1;
 
-  static readonly UUID: string = '00000069-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000069-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Carbon Monoxide Detected', CarbonMonoxideDetected.UUID);
+    super("Carbon Monoxide Detected", CarbonMonoxideDetected.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -344,16 +328,15 @@ Characteristic.CarbonMonoxideDetected = CarbonMonoxideDetected;
  */
 
 export class CarbonMonoxideLevel extends Characteristic {
-
-  static readonly UUID: string = '00000090-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000090-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Carbon Monoxide Level', CarbonMonoxideLevel.UUID);
+    super("Carbon Monoxide Level", CarbonMonoxideLevel.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 100,
       minValue: 0,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -366,16 +349,15 @@ Characteristic.CarbonMonoxideLevel = CarbonMonoxideLevel;
  */
 
 export class CarbonMonoxidePeakLevel extends Characteristic {
-
-  static readonly UUID: string = '00000091-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000091-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Carbon Monoxide Peak Level', CarbonMonoxidePeakLevel.UUID);
+    super("Carbon Monoxide Peak Level", CarbonMonoxidePeakLevel.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 100,
       minValue: 0,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -388,22 +370,21 @@ Characteristic.CarbonMonoxidePeakLevel = CarbonMonoxidePeakLevel;
  */
 
 export class ChargingState extends Characteristic {
-
   // The value property of ChargingState must be one of the following:
   static readonly NOT_CHARGING = 0;
   static readonly CHARGING = 1;
   static readonly NOT_CHARGEABLE = 2;
 
-  static readonly UUID: string = '0000008F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000008F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Charging State', ChargingState.UUID);
+    super("Charging State", ChargingState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -416,17 +397,16 @@ Characteristic.ChargingState = ChargingState;
  */
 
 export class ColorTemperature extends Characteristic {
-
-  static readonly UUID: string = '000000CE-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000CE-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Color Temperature', ColorTemperature.UUID);
+    super("Color Temperature", ColorTemperature.UUID);
     this.setProps({
       format: Formats.UINT32,
       maxValue: 500,
       minValue: 140,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -439,21 +419,20 @@ Characteristic.ColorTemperature = ColorTemperature;
  */
 
 export class ContactSensorState extends Characteristic {
-
   // The value property of ContactSensorState must be one of the following:
   static readonly CONTACT_DETECTED = 0;
   static readonly CONTACT_NOT_DETECTED = 1;
 
-  static readonly UUID: string = '0000006A-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000006A-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Contact Sensor State', ContactSensorState.UUID);
+    super("Contact Sensor State", ContactSensorState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -466,18 +445,17 @@ Characteristic.ContactSensorState = ContactSensorState;
  */
 
 export class CoolingThresholdTemperature extends Characteristic {
-
-  static readonly UUID: string = '0000000D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000000D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Cooling Threshold Temperature', CoolingThresholdTemperature.UUID);
+    super("Cooling Threshold Temperature", CoolingThresholdTemperature.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.CELSIUS,
       maxValue: 35,
       minValue: 10,
       minStep: 0.1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -490,22 +468,21 @@ Characteristic.CoolingThresholdTemperature = CoolingThresholdTemperature;
  */
 
 export class CurrentAirPurifierState extends Characteristic {
-
   // The value property of CurrentAirPurifierState must be one of the following:
   static readonly INACTIVE = 0;
   static readonly IDLE = 1;
   static readonly PURIFYING_AIR = 2;
 
-  static readonly UUID: string = '000000A9-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A9-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Air Purifier State', CurrentAirPurifierState.UUID);
+    super("Current Air Purifier State", CurrentAirPurifierState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -513,23 +490,21 @@ export class CurrentAirPurifierState extends Characteristic {
 
 Characteristic.CurrentAirPurifierState = CurrentAirPurifierState;
 
-
 /**
  * Characteristic "Current Ambient Light Level"
  */
 
 export class CurrentAmbientLightLevel extends Characteristic {
-
-  static readonly UUID: string = '0000006B-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000006B-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Ambient Light Level', CurrentAmbientLightLevel.UUID);
+    super("Current Ambient Light Level", CurrentAmbientLightLevel.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.LUX,
       maxValue: 100000,
       minValue: 0.0001,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -542,7 +517,6 @@ Characteristic.CurrentAmbientLightLevel = CurrentAmbientLightLevel;
  */
 
 export class CurrentDoorState extends Characteristic {
-
   // The value property of CurrentDoorState must be one of the following:
   static readonly OPEN = 0;
   static readonly CLOSED = 1;
@@ -550,16 +524,16 @@ export class CurrentDoorState extends Characteristic {
   static readonly CLOSING = 3;
   static readonly STOPPED = 4;
 
-  static readonly UUID: string = '0000000E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000000E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Door State', CurrentDoorState.UUID);
+    super("Current Door State", CurrentDoorState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 4,
       minValue: 0,
       validValues: [0, 1, 2, 3, 4],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -572,22 +546,21 @@ Characteristic.CurrentDoorState = CurrentDoorState;
  */
 
 export class CurrentFanState extends Characteristic {
-
   // The value property of CurrentFanState must be one of the following:
   static readonly INACTIVE = 0;
   static readonly IDLE = 1;
   static readonly BLOWING_AIR = 2;
 
-  static readonly UUID: string = '000000AF-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000AF-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Fan State', CurrentFanState.UUID);
+    super("Current Fan State", CurrentFanState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -600,23 +573,22 @@ Characteristic.CurrentFanState = CurrentFanState;
  */
 
 export class CurrentHeaterCoolerState extends Characteristic {
-
   // The value property of CurrentHeaterCoolerState must be one of the following:
   static readonly INACTIVE = 0;
   static readonly IDLE = 1;
   static readonly HEATING = 2;
   static readonly COOLING = 3;
 
-  static readonly UUID: string = '000000B1-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000B1-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Heater Cooler State', CurrentHeaterCoolerState.UUID);
+    super("Current Heater Cooler State", CurrentHeaterCoolerState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
       validValues: [0, 1, 2, 3],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -629,22 +601,21 @@ Characteristic.CurrentHeaterCoolerState = CurrentHeaterCoolerState;
  */
 
 export class CurrentHeatingCoolingState extends Characteristic {
-
   // The value property of CurrentHeatingCoolingState must be one of the following:
   static readonly OFF = 0;
   static readonly HEAT = 1;
   static readonly COOL = 2;
 
-  static readonly UUID: string = '0000000F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000000F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Heating Cooling State', CurrentHeatingCoolingState.UUID);
+    super("Current Heating Cooling State", CurrentHeatingCoolingState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -657,18 +628,17 @@ Characteristic.CurrentHeatingCoolingState = CurrentHeatingCoolingState;
  */
 
 export class CurrentHorizontalTiltAngle extends Characteristic {
-
-  static readonly UUID: string = '0000006C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000006C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Horizontal Tilt Angle', CurrentHorizontalTiltAngle.UUID);
+    super("Current Horizontal Tilt Angle", CurrentHorizontalTiltAngle.UUID);
     this.setProps({
       format: Formats.INT,
       unit: Units.ARC_DEGREE,
       maxValue: 90,
       minValue: -90,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -681,23 +651,22 @@ Characteristic.CurrentHorizontalTiltAngle = CurrentHorizontalTiltAngle;
  */
 
 export class CurrentHumidifierDehumidifierState extends Characteristic {
-
   // The value property of CurrentHumidifierDehumidifierState must be one of the following:
   static readonly INACTIVE = 0;
   static readonly IDLE = 1;
   static readonly HUMIDIFYING = 2;
   static readonly DEHUMIDIFYING = 3;
 
-  static readonly UUID: string = '000000B3-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000B3-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Humidifier Dehumidifier State', CurrentHumidifierDehumidifierState.UUID);
+    super("Current Humidifier Dehumidifier State", CurrentHumidifierDehumidifierState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
       validValues: [0, 1, 2, 3],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -710,18 +679,17 @@ Characteristic.CurrentHumidifierDehumidifierState = CurrentHumidifierDehumidifie
  */
 
 export class CurrentPosition extends Characteristic {
-
-  static readonly UUID: string = '0000006D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000006D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Position', CurrentPosition.UUID);
+    super("Current Position", CurrentPosition.UUID);
     this.setProps({
       format: Formats.UINT8,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -734,18 +702,17 @@ Characteristic.CurrentPosition = CurrentPosition;
  */
 
 export class CurrentRelativeHumidity extends Characteristic {
-
-  static readonly UUID: string = '00000010-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000010-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Relative Humidity', CurrentRelativeHumidity.UUID);
+    super("Current Relative Humidity", CurrentRelativeHumidity.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -758,22 +725,21 @@ Characteristic.CurrentRelativeHumidity = CurrentRelativeHumidity;
  */
 
 export class CurrentSlatState extends Characteristic {
-
   // The value property of CurrentSlatState must be one of the following:
   static readonly FIXED = 0;
   static readonly JAMMED = 1;
   static readonly SWINGING = 2;
 
-  static readonly UUID: string = '000000AA-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000AA-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Slat State', CurrentSlatState.UUID);
+    super("Current Slat State", CurrentSlatState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -786,18 +752,17 @@ Characteristic.CurrentSlatState = CurrentSlatState;
  */
 
 export class CurrentTemperature extends Characteristic {
-
-  static readonly UUID: string = '00000011-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000011-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Temperature', CurrentTemperature.UUID);
+    super("Current Temperature", CurrentTemperature.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.CELSIUS,
       maxValue: 100,
       minValue: 0,
       minStep: 0.1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -810,18 +775,17 @@ Characteristic.CurrentTemperature = CurrentTemperature;
  */
 
 export class CurrentTiltAngle extends Characteristic {
-
-  static readonly UUID: string = '000000C1-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C1-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Tilt Angle', CurrentTiltAngle.UUID);
+    super("Current Tilt Angle", CurrentTiltAngle.UUID);
     this.setProps({
       format: Formats.INT,
       unit: Units.ARC_DEGREE,
       maxValue: 90,
       minValue: -90,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -834,18 +798,17 @@ Characteristic.CurrentTiltAngle = CurrentTiltAngle;
  */
 
 export class CurrentVerticalTiltAngle extends Characteristic {
-
-  static readonly UUID: string = '0000006E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000006E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Current Vertical Tilt Angle', CurrentVerticalTiltAngle.UUID);
+    super("Current Vertical Tilt Angle", CurrentVerticalTiltAngle.UUID);
     this.setProps({
       format: Formats.INT,
       unit: Units.ARC_DEGREE,
       maxValue: 90,
       minValue: -90,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -858,14 +821,13 @@ Characteristic.CurrentVerticalTiltAngle = CurrentVerticalTiltAngle;
  */
 
 export class DigitalZoom extends Characteristic {
-
-  static readonly UUID: string = '0000011D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000011D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Digital Zoom', DigitalZoom.UUID);
+    super("Digital Zoom", DigitalZoom.UUID);
     this.setProps({
       format: Formats.FLOAT,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -878,21 +840,20 @@ Characteristic.DigitalZoom = DigitalZoom;
  */
 
 export class FilterChangeIndication extends Characteristic {
-
   // The value property of FilterChangeIndication must be one of the following:
   static readonly FILTER_OK = 0;
   static readonly CHANGE_FILTER = 1;
 
-  static readonly UUID: string = '000000AC-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000AC-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Filter Change Indication', FilterChangeIndication.UUID);
+    super("Filter Change Indication", FilterChangeIndication.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -905,16 +866,15 @@ Characteristic.FilterChangeIndication = FilterChangeIndication;
  */
 
 export class FilterLifeLevel extends Characteristic {
-
-  static readonly UUID: string = '000000AB-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000AB-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Filter Life Level', FilterLifeLevel.UUID);
+    super("Filter Life Level", FilterLifeLevel.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 100,
       minValue: 0,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -927,14 +887,13 @@ Characteristic.FilterLifeLevel = FilterLifeLevel;
  */
 
 export class FirmwareRevision extends Characteristic {
-
-  static readonly UUID: string = '00000052-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000052-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Firmware Revision', FirmwareRevision.UUID);
+    super("Firmware Revision", FirmwareRevision.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -947,14 +906,13 @@ Characteristic.FirmwareRevision = FirmwareRevision;
  */
 
 export class HardwareRevision extends Characteristic {
-
-  static readonly UUID: string = '00000053-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000053-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Hardware Revision', HardwareRevision.UUID);
+    super("Hardware Revision", HardwareRevision.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -967,18 +925,17 @@ Characteristic.HardwareRevision = HardwareRevision;
  */
 
 export class HeatingThresholdTemperature extends Characteristic {
-
-  static readonly UUID: string = '00000012-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000012-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Heating Threshold Temperature', HeatingThresholdTemperature.UUID);
+    super("Heating Threshold Temperature", HeatingThresholdTemperature.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.CELSIUS,
       maxValue: 25,
       minValue: 0,
       minStep: 0.1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -991,14 +948,13 @@ Characteristic.HeatingThresholdTemperature = HeatingThresholdTemperature;
  */
 
 export class HoldPosition extends Characteristic {
-
-  static readonly UUID: string = '0000006F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000006F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Hold Position', HoldPosition.UUID);
+    super("Hold Position", HoldPosition.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.WRITE]
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -1011,18 +967,17 @@ Characteristic.HoldPosition = HoldPosition;
  */
 
 export class Hue extends Characteristic {
-
-  static readonly UUID: string = '00000013-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000013-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Hue', Hue.UUID);
+    super("Hue", Hue.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.ARC_DEGREE,
       maxValue: 360,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1035,14 +990,13 @@ Characteristic.Hue = Hue;
  */
 
 export class Identify extends Characteristic {
-
-  static readonly UUID: string = '00000014-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000014-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Identify', Identify.UUID);
+    super("Identify", Identify.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.WRITE]
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -1055,14 +1009,13 @@ Characteristic.Identify = Identify;
  */
 
 export class ImageMirroring extends Characteristic {
-
-  static readonly UUID: string = '0000011F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000011F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Image Mirroring', ImageMirroring.UUID);
+    super("Image Mirroring", ImageMirroring.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1075,18 +1028,17 @@ Characteristic.ImageMirroring = ImageMirroring;
  */
 
 export class ImageRotation extends Characteristic {
-
-  static readonly UUID: string = '0000011E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000011E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Image Rotation', ImageRotation.UUID);
+    super("Image Rotation", ImageRotation.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.ARC_DEGREE,
       maxValue: 270,
       minValue: 0,
       minStep: 90,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1099,21 +1051,20 @@ Characteristic.ImageRotation = ImageRotation;
  */
 
 export class InUse extends Characteristic {
-
   // The value property of InUse must be one of the following:
   static readonly NOT_IN_USE = 0;
   static readonly IN_USE = 1;
 
-  static readonly UUID: string = '000000D2-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D2-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('In Use', InUse.UUID);
+    super("In Use", InUse.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1126,21 +1077,20 @@ Characteristic.InUse = InUse;
  */
 
 export class IsConfigured extends Characteristic {
-
   // The value property of IsConfigured must be one of the following:
   static readonly NOT_CONFIGURED = 0;
   static readonly CONFIGURED = 1;
 
-  static readonly UUID: string = '000000D6-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D6-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Is Configured', IsConfigured.UUID);
+    super("Is Configured", IsConfigured.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1153,21 +1103,20 @@ Characteristic.IsConfigured = IsConfigured;
  */
 
 export class LeakDetected extends Characteristic {
-
   // The value property of LeakDetected must be one of the following:
   static readonly LEAK_NOT_DETECTED = 0;
   static readonly LEAK_DETECTED = 1;
 
-  static readonly UUID: string = '00000070-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000070-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Leak Detected', LeakDetected.UUID);
+    super("Leak Detected", LeakDetected.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1180,14 +1129,13 @@ Characteristic.LeakDetected = LeakDetected;
  */
 
 export class LockControlPoint extends Characteristic {
-
-  static readonly UUID: string = '00000019-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000019-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Lock Control Point', LockControlPoint.UUID);
+    super("Lock Control Point", LockControlPoint.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.WRITE]
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -1200,23 +1148,22 @@ Characteristic.LockControlPoint = LockControlPoint;
  */
 
 export class LockCurrentState extends Characteristic {
-
   // The value property of LockCurrentState must be one of the following:
   static readonly UNSECURED = 0;
   static readonly SECURED = 1;
   static readonly JAMMED = 2;
   static readonly UNKNOWN = 3;
 
-  static readonly UUID: string = '0000001D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000001D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Lock Current State', LockCurrentState.UUID);
+    super("Lock Current State", LockCurrentState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
       validValues: [0, 1, 2, 3],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1229,7 +1176,6 @@ Characteristic.LockCurrentState = LockCurrentState;
  */
 
 export class LockLastKnownAction extends Characteristic {
-
   // The value property of LockLastKnownAction must be one of the following:
   static readonly SECURED_PHYSICALLY_INTERIOR = 0;
   static readonly UNSECURED_PHYSICALLY_INTERIOR = 1;
@@ -1241,16 +1187,16 @@ export class LockLastKnownAction extends Characteristic {
   static readonly UNSECURED_REMOTELY = 7;
   static readonly SECURED_BY_AUTO_SECURE_TIMEOUT = 8;
 
-  static readonly UUID: string = '0000001C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000001C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Lock Last Known Action', LockLastKnownAction.UUID);
+    super("Lock Last Known Action", LockLastKnownAction.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 8,
       minValue: 0,
       validValues: [0, 1, 2, 3, 4, 5, 6, 7, 8],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1263,15 +1209,14 @@ Characteristic.LockLastKnownAction = LockLastKnownAction;
  */
 
 export class LockManagementAutoSecurityTimeout extends Characteristic {
-
-  static readonly UUID: string = '0000001A-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000001A-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Lock Management Auto Security Timeout', LockManagementAutoSecurityTimeout.UUID);
+    super("Lock Management Auto Security Timeout", LockManagementAutoSecurityTimeout.UUID);
     this.setProps({
       format: Formats.UINT32,
       unit: Units.SECONDS,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1284,21 +1229,20 @@ Characteristic.LockManagementAutoSecurityTimeout = LockManagementAutoSecurityTim
  */
 
 export class LockPhysicalControls extends Characteristic {
-
   // The value property of LockPhysicalControls must be one of the following:
   static readonly CONTROL_LOCK_DISABLED = 0;
   static readonly CONTROL_LOCK_ENABLED = 1;
 
-  static readonly UUID: string = '000000A7-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A7-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Lock Physical Controls', LockPhysicalControls.UUID);
+    super("Lock Physical Controls", LockPhysicalControls.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1311,21 +1255,20 @@ Characteristic.LockPhysicalControls = LockPhysicalControls;
  */
 
 export class LockTargetState extends Characteristic {
-
   // The value property of LockTargetState must be one of the following:
   static readonly UNSECURED = 0;
   static readonly SECURED = 1;
 
-  static readonly UUID: string = '0000001E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000001E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Lock Target State', LockTargetState.UUID);
+    super("Lock Target State", LockTargetState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1338,14 +1281,13 @@ Characteristic.LockTargetState = LockTargetState;
  */
 
 export class Logs extends Characteristic {
-
-  static readonly UUID: string = '0000001F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000001F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Logs', Logs.UUID);
+    super("Logs", Logs.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1358,14 +1300,13 @@ Characteristic.Logs = Logs;
  */
 
 export class Manufacturer extends Characteristic {
-
-  static readonly UUID: string = '00000020-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000020-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Manufacturer', Manufacturer.UUID);
+    super("Manufacturer", Manufacturer.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -1378,14 +1319,13 @@ Characteristic.Manufacturer = Manufacturer;
  */
 
 export class Model extends Characteristic {
-
-  static readonly UUID: string = '00000021-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000021-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Model', Model.UUID);
+    super("Model", Model.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -1398,14 +1338,13 @@ Characteristic.Model = Model;
  */
 
 export class MotionDetected extends Characteristic {
-
-  static readonly UUID: string = '00000022-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000022-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Motion Detected', MotionDetected.UUID);
+    super("Motion Detected", MotionDetected.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1418,14 +1357,13 @@ Characteristic.MotionDetected = MotionDetected;
  */
 
 export class Mute extends Characteristic {
-
-  static readonly UUID: string = '0000011A-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000011A-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Mute', Mute.UUID);
+    super("Mute", Mute.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1438,14 +1376,13 @@ Characteristic.Mute = Mute;
  */
 
 export class Name extends Characteristic {
-
-  static readonly UUID: string = '00000023-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000023-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Name', Name.UUID);
+    super("Name", Name.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -1458,14 +1395,13 @@ Characteristic.Name = Name;
  */
 
 export class NightVision extends Characteristic {
-
-  static readonly UUID: string = '0000011B-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000011B-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Night Vision', NightVision.UUID);
+    super("Night Vision", NightVision.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1478,17 +1414,16 @@ Characteristic.NightVision = NightVision;
  */
 
 export class NitrogenDioxideDensity extends Characteristic {
-
-  static readonly UUID: string = '000000C4-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C4-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Nitrogen Dioxide Density', NitrogenDioxideDensity.UUID);
+    super("Nitrogen Dioxide Density", NitrogenDioxideDensity.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 1000,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1501,14 +1436,13 @@ Characteristic.NitrogenDioxideDensity = NitrogenDioxideDensity;
  */
 
 export class ObstructionDetected extends Characteristic {
-
-  static readonly UUID: string = '00000024-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000024-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Obstruction Detected', ObstructionDetected.UUID);
+    super("Obstruction Detected", ObstructionDetected.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1521,21 +1455,20 @@ Characteristic.ObstructionDetected = ObstructionDetected;
  */
 
 export class OccupancyDetected extends Characteristic {
-
   // The value property of OccupancyDetected must be one of the following:
   static readonly OCCUPANCY_NOT_DETECTED = 0;
   static readonly OCCUPANCY_DETECTED = 1;
 
-  static readonly UUID: string = '00000071-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000071-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Occupancy Detected', OccupancyDetected.UUID);
+    super("Occupancy Detected", OccupancyDetected.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1548,14 +1481,13 @@ Characteristic.OccupancyDetected = OccupancyDetected;
  */
 
 export class On extends Characteristic {
-
-  static readonly UUID: string = '00000025-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000025-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('On', On.UUID);
+    super("On", On.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1568,14 +1500,13 @@ Characteristic.On = On;
  */
 
 export class OpticalZoom extends Characteristic {
-
-  static readonly UUID: string = '0000011C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000011C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Optical Zoom', OpticalZoom.UUID);
+    super("Optical Zoom", OpticalZoom.UUID);
     this.setProps({
       format: Formats.FLOAT,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1588,14 +1519,13 @@ Characteristic.OpticalZoom = OpticalZoom;
  */
 
 export class OutletInUse extends Characteristic {
-
-  static readonly UUID: string = '00000026-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000026-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Outlet In Use', OutletInUse.UUID);
+    super("Outlet In Use", OutletInUse.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1608,17 +1538,16 @@ Characteristic.OutletInUse = OutletInUse;
  */
 
 export class OzoneDensity extends Characteristic {
-
-  static readonly UUID: string = '000000C3-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C3-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Ozone Density', OzoneDensity.UUID);
+    super("Ozone Density", OzoneDensity.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 1000,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1631,14 +1560,13 @@ Characteristic.OzoneDensity = OzoneDensity;
  */
 
 export class PairSetup extends Characteristic {
-
-  static readonly UUID: string = '0000004C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000004C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Pair Setup', PairSetup.UUID);
+    super("Pair Setup", PairSetup.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE]
+      perms: [Perms.READ, Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -1651,14 +1579,13 @@ Characteristic.PairSetup = PairSetup;
  */
 
 export class PairVerify extends Characteristic {
-
-  static readonly UUID: string = '0000004E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000004E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Pair Verify', PairVerify.UUID);
+    super("Pair Verify", PairVerify.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE]
+      perms: [Perms.READ, Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -1671,14 +1598,13 @@ Characteristic.PairVerify = PairVerify;
  */
 
 export class PairingFeatures extends Characteristic {
-
-  static readonly UUID: string = '0000004F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000004F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Pairing Features', PairingFeatures.UUID);
+    super("Pairing Features", PairingFeatures.UUID);
     this.setProps({
       format: Formats.UINT8,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -1691,14 +1617,13 @@ Characteristic.PairingFeatures = PairingFeatures;
  */
 
 export class PairingPairings extends Characteristic {
-
-  static readonly UUID: string = '00000050-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000050-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Pairing Pairings', PairingPairings.UUID);
+    super("Pairing Pairings", PairingPairings.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE]
+      perms: [Perms.READ, Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -1711,17 +1636,16 @@ Characteristic.PairingPairings = PairingPairings;
  */
 
 export class PM10Density extends Characteristic {
-
-  static readonly UUID: string = '000000C7-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C7-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('PM10 Density', PM10Density.UUID);
+    super("PM10 Density", PM10Density.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 1000,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1734,17 +1658,16 @@ Characteristic.PM10Density = PM10Density;
  */
 
 export class PM2_5Density extends Characteristic {
-
-  static readonly UUID: string = '000000C6-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C6-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('PM2.5 Density', PM2_5Density.UUID);
+    super("PM2.5 Density", PM2_5Density.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 1000,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1757,22 +1680,21 @@ Characteristic.PM2_5Density = PM2_5Density;
  */
 
 export class PositionState extends Characteristic {
-
   // The value property of PositionState must be one of the following:
   static readonly DECREASING = 0;
   static readonly INCREASING = 1;
   static readonly STOPPED = 2;
 
-  static readonly UUID: string = '00000072-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000072-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Position State', PositionState.UUID);
+    super("Position State", PositionState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1785,22 +1707,21 @@ Characteristic.PositionState = PositionState;
  */
 
 export class ProgramMode extends Characteristic {
-
   // The value property of ProgramMode must be one of the following:
   static readonly NO_PROGRAM_SCHEDULED = 0;
   static readonly PROGRAM_SCHEDULED = 1;
   static readonly PROGRAM_SCHEDULED_MANUAL_MODE_ = 2;
 
-  static readonly UUID: string = '000000D1-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D1-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Program Mode', ProgramMode.UUID);
+    super("Program Mode", ProgramMode.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1813,22 +1734,21 @@ Characteristic.ProgramMode = ProgramMode;
  */
 
 export class ProgrammableSwitchEvent extends Characteristic {
-
   // The value property of ProgrammableSwitchEvent must be one of the following:
   static readonly SINGLE_PRESS = 0;
   static readonly DOUBLE_PRESS = 1;
   static readonly LONG_PRESS = 2;
 
-  static readonly UUID: string = '00000073-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000073-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Programmable Switch Event', ProgrammableSwitchEvent.UUID);
+    super("Programmable Switch Event", ProgrammableSwitchEvent.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.eventOnlyCharacteristic = true; //Manual addition.
     this.value = this.getDefaultValue();
@@ -1842,17 +1762,16 @@ Characteristic.ProgrammableSwitchEvent = ProgrammableSwitchEvent;
  */
 
 export class RelativeHumidityDehumidifierThreshold extends Characteristic {
-
-  static readonly UUID: string = '000000C9-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C9-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Relative Humidity Dehumidifier Threshold', RelativeHumidityDehumidifierThreshold.UUID);
+    super("Relative Humidity Dehumidifier Threshold", RelativeHumidityDehumidifierThreshold.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1865,18 +1784,17 @@ Characteristic.RelativeHumidityDehumidifierThreshold = RelativeHumidityDehumidif
  */
 
 export class RelativeHumidityHumidifierThreshold extends Characteristic {
-
-  static readonly UUID: string = '000000CA-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000CA-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Relative Humidity Humidifier Threshold', RelativeHumidityHumidifierThreshold.UUID);
+    super("Relative Humidity Humidifier Threshold", RelativeHumidityHumidifierThreshold.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1889,17 +1807,16 @@ Characteristic.RelativeHumidityHumidifierThreshold = RelativeHumidityHumidifierT
  */
 
 export class RemainingDuration extends Characteristic {
-
-  static readonly UUID: string = '000000D4-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D4-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Remaining Duration', RemainingDuration.UUID);
+    super("Remaining Duration", RemainingDuration.UUID);
     this.setProps({
       format: Formats.UINT32,
       maxValue: 3600,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1912,17 +1829,16 @@ Characteristic.RemainingDuration = RemainingDuration;
  */
 
 export class ResetFilterIndication extends Characteristic {
-
-  static readonly UUID: string = '000000AD-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000AD-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Reset Filter Indication', ResetFilterIndication.UUID);
+    super("Reset Filter Indication", ResetFilterIndication.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 1,
       minStep: 1,
-      perms: [Perms.WRITE]
+      perms: [Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -1935,21 +1851,20 @@ Characteristic.ResetFilterIndication = ResetFilterIndication;
  */
 
 export class RotationDirection extends Characteristic {
-
   // The value property of RotationDirection must be one of the following:
   static readonly CLOCKWISE = 0;
   static readonly COUNTER_CLOCKWISE = 1;
 
-  static readonly UUID: string = '00000028-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000028-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Rotation Direction', RotationDirection.UUID);
+    super("Rotation Direction", RotationDirection.UUID);
     this.setProps({
       format: Formats.INT,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1962,18 +1877,17 @@ Characteristic.RotationDirection = RotationDirection;
  */
 
 export class RotationSpeed extends Characteristic {
-
-  static readonly UUID: string = '00000029-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000029-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Rotation Speed', RotationSpeed.UUID);
+    super("Rotation Speed", RotationSpeed.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -1986,18 +1900,17 @@ Characteristic.RotationSpeed = RotationSpeed;
  */
 
 export class Saturation extends Characteristic {
-
-  static readonly UUID: string = '0000002F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000002F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Saturation', Saturation.UUID);
+    super("Saturation", Saturation.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2010,17 +1923,16 @@ Characteristic.Saturation = Saturation;
  */
 
 export class SecuritySystemAlarmType extends Characteristic {
-
-  static readonly UUID: string = '0000008E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000008E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Security System Alarm Type', SecuritySystemAlarmType.UUID);
+    super("Security System Alarm Type", SecuritySystemAlarmType.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2033,7 +1945,6 @@ Characteristic.SecuritySystemAlarmType = SecuritySystemAlarmType;
  */
 
 export class SecuritySystemCurrentState extends Characteristic {
-
   // The value property of SecuritySystemCurrentState must be one of the following:
   static readonly STAY_ARM = 0;
   static readonly AWAY_ARM = 1;
@@ -2041,16 +1952,16 @@ export class SecuritySystemCurrentState extends Characteristic {
   static readonly DISARMED = 3;
   static readonly ALARM_TRIGGERED = 4;
 
-  static readonly UUID: string = '00000066-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000066-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Security System Current State', SecuritySystemCurrentState.UUID);
+    super("Security System Current State", SecuritySystemCurrentState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 4,
       minValue: 0,
       validValues: [0, 1, 2, 3, 4],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2063,23 +1974,22 @@ Characteristic.SecuritySystemCurrentState = SecuritySystemCurrentState;
  */
 
 export class SecuritySystemTargetState extends Characteristic {
-
   // The value property of SecuritySystemTargetState must be one of the following:
   static readonly STAY_ARM = 0;
   static readonly AWAY_ARM = 1;
   static readonly NIGHT_ARM = 2;
   static readonly DISARM = 3;
 
-  static readonly UUID: string = '00000067-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000067-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Security System Target State', SecuritySystemTargetState.UUID);
+    super("Security System Target State", SecuritySystemTargetState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
       validValues: [0, 1, 2, 3],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2092,14 +2002,13 @@ Characteristic.SecuritySystemTargetState = SecuritySystemTargetState;
  */
 
 export class SelectedRTPStreamConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000117-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000117-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Selected RTP Stream Configuration', SelectedRTPStreamConfiguration.UUID);
+    super("Selected RTP Stream Configuration", SelectedRTPStreamConfiguration.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE]
+      perms: [Perms.READ, Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -2112,14 +2021,13 @@ Characteristic.SelectedRTPStreamConfiguration = SelectedRTPStreamConfiguration;
  */
 
 export class SerialNumber extends Characteristic {
-
-  static readonly UUID: string = '00000030-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000030-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Serial Number', SerialNumber.UUID);
+    super("Serial Number", SerialNumber.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -2132,17 +2040,16 @@ Characteristic.SerialNumber = SerialNumber;
  */
 
 export class ServiceLabelIndex extends Characteristic {
-
-  static readonly UUID: string = '000000CB-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000CB-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Service Label Index', ServiceLabelIndex.UUID);
+    super("Service Label Index", ServiceLabelIndex.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 255,
       minValue: 1,
       minStep: 1,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -2155,21 +2062,20 @@ Characteristic.ServiceLabelIndex = ServiceLabelIndex;
  */
 
 export class ServiceLabelNamespace extends Characteristic {
-
   // The value property of ServiceLabelNamespace must be one of the following:
   static readonly DOTS = 0;
   static readonly ARABIC_NUMERALS = 1;
 
-  static readonly UUID: string = '000000CD-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000CD-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Service Label Namespace', ServiceLabelNamespace.UUID);
+    super("Service Label Namespace", ServiceLabelNamespace.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -2182,17 +2088,16 @@ Characteristic.ServiceLabelNamespace = ServiceLabelNamespace;
  */
 
 export class SetDuration extends Characteristic {
-
-  static readonly UUID: string = '000000D3-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D3-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Set Duration', SetDuration.UUID);
+    super("Set Duration", SetDuration.UUID);
     this.setProps({
       format: Formats.UINT32,
       maxValue: 3600,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2205,14 +2110,13 @@ Characteristic.SetDuration = SetDuration;
  */
 
 export class SetupEndpoints extends Characteristic {
-
-  static readonly UUID: string = '00000118-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000118-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Setup Endpoints', SetupEndpoints.UUID);
+    super("Setup Endpoints", SetupEndpoints.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE]
+      perms: [Perms.READ, Perms.WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -2225,21 +2129,20 @@ Characteristic.SetupEndpoints = SetupEndpoints;
  */
 
 export class SlatType extends Characteristic {
-
   // The value property of SlatType must be one of the following:
   static readonly HORIZONTAL = 0;
   static readonly VERTICAL = 1;
 
-  static readonly UUID: string = '000000C0-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C0-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Slat Type', SlatType.UUID);
+    super("Slat Type", SlatType.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -2252,21 +2155,20 @@ Characteristic.SlatType = SlatType;
  */
 
 export class SmokeDetected extends Characteristic {
-
   // The value property of SmokeDetected must be one of the following:
   static readonly SMOKE_NOT_DETECTED = 0;
   static readonly SMOKE_DETECTED = 1;
 
-  static readonly UUID: string = '00000076-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000076-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Smoke Detected', SmokeDetected.UUID);
+    super("Smoke Detected", SmokeDetected.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2279,14 +2181,13 @@ Characteristic.SmokeDetected = SmokeDetected;
  */
 
 export class StatusActive extends Characteristic {
-
-  static readonly UUID: string = '00000075-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000075-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Status Active', StatusActive.UUID);
+    super("Status Active", StatusActive.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2299,21 +2200,20 @@ Characteristic.StatusActive = StatusActive;
  */
 
 export class StatusFault extends Characteristic {
-
   // The value property of StatusFault must be one of the following:
   static readonly NO_FAULT = 0;
   static readonly GENERAL_FAULT = 1;
 
-  static readonly UUID: string = '00000077-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000077-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Status Fault', StatusFault.UUID);
+    super("Status Fault", StatusFault.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2326,21 +2226,20 @@ Characteristic.StatusFault = StatusFault;
  */
 
 export class StatusJammed extends Characteristic {
-
   // The value property of StatusJammed must be one of the following:
   static readonly NOT_JAMMED = 0;
   static readonly JAMMED = 1;
 
-  static readonly UUID: string = '00000078-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000078-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Status Jammed', StatusJammed.UUID);
+    super("Status Jammed", StatusJammed.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2353,21 +2252,20 @@ Characteristic.StatusJammed = StatusJammed;
  */
 
 export class StatusLowBattery extends Characteristic {
-
   // The value property of StatusLowBattery must be one of the following:
   static readonly BATTERY_LEVEL_NORMAL = 0;
   static readonly BATTERY_LEVEL_LOW = 1;
 
-  static readonly UUID: string = '00000079-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000079-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Status Low Battery', StatusLowBattery.UUID);
+    super("Status Low Battery", StatusLowBattery.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2375,27 +2273,25 @@ export class StatusLowBattery extends Characteristic {
 
 Characteristic.StatusLowBattery = StatusLowBattery;
 
-
 /**
  * Characteristic "Status Tampered"
  */
 
 export class StatusTampered extends Characteristic {
-
   // The value property of StatusTampered must be one of the following:
   static readonly NOT_TAMPERED = 0;
   static readonly TAMPERED = 1;
 
-  static readonly UUID: string = '0000007A-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000007A-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Status Tampered', StatusTampered.UUID);
+    super("Status Tampered", StatusTampered.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2408,14 +2304,13 @@ Characteristic.StatusTampered = StatusTampered;
  */
 
 export class StreamingStatus extends Characteristic {
-
-  static readonly UUID: string = '00000120-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000120-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Streaming Status', StreamingStatus.UUID);
+    super("Streaming Status", StreamingStatus.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2428,17 +2323,16 @@ Characteristic.StreamingStatus = StreamingStatus;
  */
 
 export class SulphurDioxideDensity extends Characteristic {
-
-  static readonly UUID: string = '000000C5-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C5-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Sulphur Dioxide Density', SulphurDioxideDensity.UUID);
+    super("Sulphur Dioxide Density", SulphurDioxideDensity.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 1000,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2451,14 +2345,13 @@ Characteristic.SulphurDioxideDensity = SulphurDioxideDensity;
  */
 
 export class SupportedAudioStreamConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000115-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000115-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Supported Audio Stream Configuration', SupportedAudioStreamConfiguration.UUID);
+    super("Supported Audio Stream Configuration", SupportedAudioStreamConfiguration.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -2471,14 +2364,13 @@ Characteristic.SupportedAudioStreamConfiguration = SupportedAudioStreamConfigura
  */
 
 export class SupportedRTPConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000116-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000116-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Supported RTP Configuration', SupportedRTPConfiguration.UUID);
+    super("Supported RTP Configuration", SupportedRTPConfiguration.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -2491,14 +2383,13 @@ Characteristic.SupportedRTPConfiguration = SupportedRTPConfiguration;
  */
 
 export class SupportedVideoStreamConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000114-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000114-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Supported Video Stream Configuration', SupportedVideoStreamConfiguration.UUID);
+    super("Supported Video Stream Configuration", SupportedVideoStreamConfiguration.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -2511,21 +2402,20 @@ Characteristic.SupportedVideoStreamConfiguration = SupportedVideoStreamConfigura
  */
 
 export class SwingMode extends Characteristic {
-
   // The value property of SwingMode must be one of the following:
   static readonly SWING_DISABLED = 0;
   static readonly SWING_ENABLED = 1;
 
-  static readonly UUID: string = '000000B6-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000B6-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Swing Mode', SwingMode.UUID);
+    super("Swing Mode", SwingMode.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2538,21 +2428,20 @@ Characteristic.SwingMode = SwingMode;
  */
 
 export class TargetAirPurifierState extends Characteristic {
-
   // The value property of TargetAirPurifierState must be one of the following:
   static readonly MANUAL = 0;
   static readonly AUTO = 1;
 
-  static readonly UUID: string = '000000A8-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000A8-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Air Purifier State', TargetAirPurifierState.UUID);
+    super("Target Air Purifier State", TargetAirPurifierState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2565,22 +2454,21 @@ Characteristic.TargetAirPurifierState = TargetAirPurifierState;
  */
 
 export class TargetAirQuality extends Characteristic {
-
   // The value property of TargetAirQuality must be one of the following:
   static readonly EXCELLENT = 0;
   static readonly GOOD = 1;
   static readonly FAIR = 2;
 
-  static readonly UUID: string = '000000AE-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000AE-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Air Quality', TargetAirQuality.UUID);
+    super("Target Air Quality", TargetAirQuality.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2593,21 +2481,20 @@ Characteristic.TargetAirQuality = TargetAirQuality;
  */
 
 export class TargetDoorState extends Characteristic {
-
   // The value property of TargetDoorState must be one of the following:
   static readonly OPEN = 0;
   static readonly CLOSED = 1;
 
-  static readonly UUID: string = '00000032-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000032-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Door State', TargetDoorState.UUID);
+    super("Target Door State", TargetDoorState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2620,21 +2507,20 @@ Characteristic.TargetDoorState = TargetDoorState;
  */
 
 export class TargetFanState extends Characteristic {
-
   // The value property of TargetFanState must be one of the following:
   static readonly MANUAL = 0;
   static readonly AUTO = 1;
 
-  static readonly UUID: string = '000000BF-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000BF-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Fan State', TargetFanState.UUID);
+    super("Target Fan State", TargetFanState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2647,22 +2533,21 @@ Characteristic.TargetFanState = TargetFanState;
  */
 
 export class TargetHeaterCoolerState extends Characteristic {
-
   // The value property of TargetHeaterCoolerState must be one of the following:
   static readonly AUTO = 0;
   static readonly HEAT = 1;
   static readonly COOL = 2;
 
-  static readonly UUID: string = '000000B2-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000B2-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Heater Cooler State', TargetHeaterCoolerState.UUID);
+    super("Target Heater Cooler State", TargetHeaterCoolerState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2675,23 +2560,22 @@ Characteristic.TargetHeaterCoolerState = TargetHeaterCoolerState;
  */
 
 export class TargetHeatingCoolingState extends Characteristic {
-
   // The value property of TargetHeatingCoolingState must be one of the following:
   static readonly OFF = 0;
   static readonly HEAT = 1;
   static readonly COOL = 2;
   static readonly AUTO = 3;
 
-  static readonly UUID: string = '00000033-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000033-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Heating Cooling State', TargetHeatingCoolingState.UUID);
+    super("Target Heating Cooling State", TargetHeatingCoolingState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
       validValues: [0, 1, 2, 3],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2704,18 +2588,17 @@ Characteristic.TargetHeatingCoolingState = TargetHeatingCoolingState;
  */
 
 export class TargetHorizontalTiltAngle extends Characteristic {
-
-  static readonly UUID: string = '0000007B-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000007B-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Horizontal Tilt Angle', TargetHorizontalTiltAngle.UUID);
+    super("Target Horizontal Tilt Angle", TargetHorizontalTiltAngle.UUID);
     this.setProps({
       format: Formats.INT,
       unit: Units.ARC_DEGREE,
       maxValue: 90,
       minValue: -90,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2728,7 +2611,6 @@ Characteristic.TargetHorizontalTiltAngle = TargetHorizontalTiltAngle;
  */
 
 export class TargetHumidifierDehumidifierState extends Characteristic {
-
   /**
    * @deprecated Removed in iOS 11. Use HUMIDIFIER_OR_DEHUMIDIFIER instead.
    */
@@ -2739,16 +2621,16 @@ export class TargetHumidifierDehumidifierState extends Characteristic {
   static readonly HUMIDIFIER = 1;
   static readonly DEHUMIDIFIER = 2;
 
-  static readonly UUID: string = '000000B4-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000B4-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Humidifier Dehumidifier State', TargetHumidifierDehumidifierState.UUID);
+    super("Target Humidifier Dehumidifier State", TargetHumidifierDehumidifierState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
       validValues: [0, 1, 2],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2761,18 +2643,17 @@ Characteristic.TargetHumidifierDehumidifierState = TargetHumidifierDehumidifierS
  */
 
 export class TargetPosition extends Characteristic {
-
-  static readonly UUID: string = '0000007C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000007C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Position', TargetPosition.UUID);
+    super("Target Position", TargetPosition.UUID);
     this.setProps({
       format: Formats.UINT8,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2785,18 +2666,17 @@ Characteristic.TargetPosition = TargetPosition;
  */
 
 export class TargetRelativeHumidity extends Characteristic {
-
-  static readonly UUID: string = '00000034-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000034-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Relative Humidity', TargetRelativeHumidity.UUID);
+    super("Target Relative Humidity", TargetRelativeHumidity.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2809,21 +2689,20 @@ Characteristic.TargetRelativeHumidity = TargetRelativeHumidity;
  */
 
 export class TargetSlatState extends Characteristic {
-
   // The value property of TargetSlatState must be one of the following:
   static readonly MANUAL = 0;
   static readonly AUTO = 1;
 
-  static readonly UUID: string = '000000BE-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000BE-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Slat State', TargetSlatState.UUID);
+    super("Target Slat State", TargetSlatState.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2836,18 +2715,17 @@ Characteristic.TargetSlatState = TargetSlatState;
  */
 
 export class TargetTemperature extends Characteristic {
-
-  static readonly UUID: string = '00000035-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000035-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Temperature', TargetTemperature.UUID);
+    super("Target Temperature", TargetTemperature.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.CELSIUS,
       maxValue: 38,
       minValue: 10,
       minStep: 0.1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2860,18 +2738,17 @@ Characteristic.TargetTemperature = TargetTemperature;
  */
 
 export class TargetTiltAngle extends Characteristic {
-
-  static readonly UUID: string = '000000C2-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C2-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Tilt Angle', TargetTiltAngle.UUID);
+    super("Target Tilt Angle", TargetTiltAngle.UUID);
     this.setProps({
       format: Formats.INT,
       unit: Units.ARC_DEGREE,
       maxValue: 90,
       minValue: -90,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2884,18 +2761,17 @@ Characteristic.TargetTiltAngle = TargetTiltAngle;
  */
 
 export class TargetVerticalTiltAngle extends Characteristic {
-
-  static readonly UUID: string = '0000007D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000007D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Target Vertical Tilt Angle', TargetVerticalTiltAngle.UUID);
+    super("Target Vertical Tilt Angle", TargetVerticalTiltAngle.UUID);
     this.setProps({
       format: Formats.INT,
       unit: Units.ARC_DEGREE,
       maxValue: 90,
       minValue: -90,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2908,21 +2784,20 @@ Characteristic.TargetVerticalTiltAngle = TargetVerticalTiltAngle;
  */
 
 export class TemperatureDisplayUnits extends Characteristic {
-
   // The value property of TemperatureDisplayUnits must be one of the following:
   static readonly CELSIUS = 0;
   static readonly FAHRENHEIT = 1;
 
-  static readonly UUID: string = '00000036-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000036-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Temperature Display Units', TemperatureDisplayUnits.UUID);
+    super("Temperature Display Units", TemperatureDisplayUnits.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
       validValues: [0, 1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2935,23 +2810,22 @@ Characteristic.TemperatureDisplayUnits = TemperatureDisplayUnits;
  */
 
 export class ValveType extends Characteristic {
-
   // The value property of ValveType must be one of the following:
   static readonly GENERIC_VALVE = 0;
   static readonly IRRIGATION = 1;
   static readonly SHOWER_HEAD = 2;
   static readonly WATER_FAUCET = 3;
 
-  static readonly UUID: string = '000000D5-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000D5-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Valve Type', ValveType.UUID);
+    super("Valve Type", ValveType.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 3,
       minValue: 0,
       validValues: [0, 1, 2, 3],
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2964,14 +2838,13 @@ Characteristic.ValveType = ValveType;
  */
 
 export class Version extends Characteristic {
-
-  static readonly UUID: string = '00000037-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000037-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Version', Version.UUID);
+    super("Version", Version.UUID);
     this.setProps({
       format: Formats.STRING,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -2984,17 +2857,16 @@ Characteristic.Version = Version;
  */
 
 export class VOCDensity extends Characteristic {
-
-  static readonly UUID: string = '000000C8-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000C8-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('VOC Density', VOCDensity.UUID);
+    super("VOC Density", VOCDensity.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 1000,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3007,18 +2879,17 @@ Characteristic.VOCDensity = VOCDensity;
  */
 
 export class Volume extends Characteristic {
-
-  static readonly UUID: string = '00000119-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000119-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Volume', Volume.UUID);
+    super("Volume", Volume.UUID);
     this.setProps({
       format: Formats.UINT8,
       unit: Units.PERCENTAGE,
       maxValue: 100,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3031,16 +2902,15 @@ Characteristic.Volume = Volume;
  */
 
 export class WaterLevel extends Characteristic {
-
-  static readonly UUID: string = '000000B5-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "000000B5-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Water Level', WaterLevel.UUID);
+    super("Water Level", WaterLevel.UUID);
     this.setProps({
       format: Formats.FLOAT,
       maxValue: 100,
       minValue: 0,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3053,17 +2923,16 @@ Characteristic.WaterLevel = WaterLevel;
  */
 
 export class RecordingAudioActive extends Characteristic {
-
   static readonly DISABLE = 0;
   static readonly ENABLE = 1;
 
-  static readonly UUID: string = '00000226-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000226-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Recording Audio Active', RecordingAudioActive.UUID);
+    super("Recording Audio Active", RecordingAudioActive.UUID);
     this.setProps({
-        format: Formats.UINT8,
-        perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      format: Formats.UINT8,
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3076,14 +2945,13 @@ Characteristic.RecordingAudioActive = RecordingAudioActive;
  */
 
 export class SupportedCameraRecordingConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000205-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000205-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Supported Camera Recording Configuration', SupportedCameraRecordingConfiguration.UUID);
+    super("Supported Camera Recording Configuration", SupportedCameraRecordingConfiguration.UUID);
     this.setProps({
-        format: Formats.TLV8,
-        perms: [Perms.READ, Perms.NOTIFY]
+      format: Formats.TLV8,
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3096,14 +2964,13 @@ Characteristic.SupportedCameraRecordingConfiguration = SupportedCameraRecordingC
  */
 
 export class SupportedVideoRecordingConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000206-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000206-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Supported Video Recording Configuration', SupportedVideoRecordingConfiguration.UUID);
+    super("Supported Video Recording Configuration", SupportedVideoRecordingConfiguration.UUID);
     this.setProps({
-        format: Formats.TLV8,
-        perms: [Perms.READ, Perms.NOTIFY]
+      format: Formats.TLV8,
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3116,14 +2983,13 @@ Characteristic.SupportedVideoRecordingConfiguration = SupportedVideoRecordingCon
  */
 
 export class SupportedAudioRecordingConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000207-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000207-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Supported Audio Recording Configuration', SupportedAudioRecordingConfiguration.UUID);
+    super("Supported Audio Recording Configuration", SupportedAudioRecordingConfiguration.UUID);
     this.setProps({
-        format: Formats.TLV8,
-        perms: [Perms.READ, Perms.NOTIFY]
+      format: Formats.TLV8,
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3136,14 +3002,13 @@ Characteristic.SupportedAudioRecordingConfiguration = SupportedAudioRecordingCon
  */
 
 export class SelectedCameraRecordingConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000209-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000209-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Selected Camera Recording Configuration', SelectedCameraRecordingConfiguration.UUID);
+    super("Selected Camera Recording Configuration", SelectedCameraRecordingConfiguration.UUID);
     this.setProps({
-        format: Formats.TLV8,
-        perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      format: Formats.TLV8,
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3156,17 +3021,16 @@ Characteristic.SelectedCameraRecordingConfiguration = SelectedCameraRecordingCon
  */
 
 export class CameraOperatingModeIndicator extends Characteristic {
-
   static readonly DISABLE = 0;
   static readonly ENABLE = 1;
 
-  static readonly UUID: string = '0000021D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000021D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Camera Operating Mode Indicator', CameraOperatingModeIndicator.UUID);
+    super("Camera Operating Mode Indicator", CameraOperatingModeIndicator.UUID);
     this.setProps({
-        format: Formats.UINT8,
-        perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE]
+      format: Formats.UINT8,
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -3179,17 +3043,16 @@ Characteristic.CameraOperatingModeIndicator = CameraOperatingModeIndicator;
  */
 
 export class EventSnapshotsActive extends Characteristic {
-
   static readonly DISABLE = 0;
   static readonly ENABLE = 1;
 
-  static readonly UUID: string = '00000223-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000223-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Event Snapshots Active', EventSnapshotsActive.UUID);
+    super("Event Snapshots Active", EventSnapshotsActive.UUID);
     this.setProps({
       format: Formats.UINT8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3202,18 +3065,17 @@ Characteristic.EventSnapshotsActive = EventSnapshotsActive;
  */
 
 export class DiagonalFieldOfView extends Characteristic {
-
-  static readonly UUID: string = '00000224-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000224-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Diagonal Field Of View', DiagonalFieldOfView.UUID);
+    super("Diagonal Field Of View", DiagonalFieldOfView.UUID);
     this.setProps({
       format: Formats.FLOAT,
       unit: Units.ARC_DEGREE,
       maxValue: 360,
       minValue: 0,
       minStep: 1,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3226,17 +3088,16 @@ Characteristic.DiagonalFieldOfView = DiagonalFieldOfView;
  */
 
 export class HomeKitCameraActive extends Characteristic {
-
   static readonly OFF = 0;
   static readonly ON = 1;
 
-  static readonly UUID: string = '0000021B-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000021B-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('HomeKit Camera Active', HomeKitCameraActive.UUID);
+    super("HomeKit Camera Active", HomeKitCameraActive.UUID);
     this.setProps({
       format: Formats.UINT8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -3249,17 +3110,16 @@ Characteristic.HomeKitCameraActive = HomeKitCameraActive;
  */
 
 export class ManuallyDisabled extends Characteristic {
-
   static readonly ENABLED = 0;
   static readonly DISABLED = 1;
 
-  static readonly UUID: string = '00000227-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000227-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Manually disabled', ManuallyDisabled.UUID);
+    super("Manually disabled", ManuallyDisabled.UUID);
     this.setProps({
       format: Formats.BOOL,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3272,17 +3132,16 @@ Characteristic.ManuallyDisabled = ManuallyDisabled;
  */
 
 export class ThirdPartyCameraActive extends Characteristic {
-
   static readonly OFF = 0;
   static readonly ON = 1;
 
-  static readonly UUID: string = '0000021C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000021C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Third Party Camera Active', ThirdPartyCameraActive.UUID);
+    super("Third Party Camera Active", ThirdPartyCameraActive.UUID);
     this.setProps({
       format: Formats.UINT8,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3295,17 +3154,16 @@ Characteristic.ThirdPartyCameraActive = ThirdPartyCameraActive;
  */
 
 export class PeriodicSnapshotsActive extends Characteristic {
-
   static readonly DISABLE = 0;
   static readonly ENABLE = 1;
 
-  static readonly UUID: string = '00000225-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000225-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Periodic Snapshots Active', PeriodicSnapshotsActive.UUID);
+    super("Periodic Snapshots Active", PeriodicSnapshotsActive.UUID);
     this.setProps({
       format: Formats.UINT8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3318,14 +3176,13 @@ Characteristic.PeriodicSnapshotsActive = PeriodicSnapshotsActive;
  */
 
 export class NetworkClientProfileControl extends Characteristic {
-
-  static readonly UUID: string = '0000020C-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000020C-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Network Client Profile Control', NetworkClientProfileControl.UUID);
+    super("Network Client Profile Control", NetworkClientProfileControl.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE, Perms.WRITE_RESPONSE]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE, Perms.WRITE_RESPONSE],
     });
     this.value = this.getDefaultValue();
   }
@@ -3338,14 +3195,13 @@ Characteristic.NetworkClientProfileControl = NetworkClientProfileControl;
  */
 
 export class NetworkClientStatusControl extends Characteristic {
-
-  static readonly UUID: string = '0000020D-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000020D-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Network Client Status Control', NetworkClientStatusControl.UUID);
+    super("Network Client Status Control", NetworkClientStatusControl.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE, Perms.WRITE_RESPONSE]
+      perms: [Perms.READ, Perms.WRITE, Perms.WRITE_RESPONSE],
     });
     this.value = this.getDefaultValue();
   }
@@ -3358,20 +3214,19 @@ Characteristic.NetworkClientStatusControl = NetworkClientStatusControl;
  */
 
 export class RouterStatus extends Characteristic {
-
   static readonly READY = 0;
   static readonly NOT_READY = 1;
 
-  static readonly UUID: string = '0000020E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000020E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Router Status', RouterStatus.UUID);
+    super("Router Status", RouterStatus.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
-      validValues: [0,1],
-      perms: [Perms.READ, Perms.NOTIFY]
+      validValues: [0, 1],
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3384,14 +3239,13 @@ Characteristic.RouterStatus = RouterStatus;
  */
 
 export class SupportedRouterConfiguration extends Characteristic {
-
-  static readonly UUID: string = '00000210-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000210-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Supported Router Configuration', SupportedRouterConfiguration.UUID);
+    super("Supported Router Configuration", SupportedRouterConfiguration.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ]
+      perms: [Perms.READ],
     });
     this.value = this.getDefaultValue();
   }
@@ -3404,14 +3258,13 @@ Characteristic.SupportedRouterConfiguration = SupportedRouterConfiguration;
  */
 
 export class WANConfigurationList extends Characteristic {
-
-  static readonly UUID: string = '00000211-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000211-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('WAN Configuration List', WANConfigurationList.UUID);
+    super("WAN Configuration List", WANConfigurationList.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3424,14 +3277,13 @@ Characteristic.WANConfigurationList = WANConfigurationList;
  */
 
 export class WANStatusList extends Characteristic {
-
-  static readonly UUID: string = '00000212-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000212-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('WAN Status List', WANStatusList.UUID);
+    super("WAN Status List", WANStatusList.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.NOTIFY]
+      perms: [Perms.READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3448,16 +3300,16 @@ export class ManagedNetworkEnable extends Characteristic {
   static readonly ENABLED = 1;
   static readonly UNKNOWN = 2;
 
-  static readonly UUID: string = '00000215-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "00000215-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Managed Network Enable', ManagedNetworkEnable.UUID);
+    super("Managed Network Enable", ManagedNetworkEnable.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 1,
       minValue: 0,
-      validValues: [0,1],
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE]
+      validValues: [0, 1],
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE],
     });
     this.value = this.getDefaultValue();
   }
@@ -3470,14 +3322,13 @@ Characteristic.ManagedNetworkEnable = ManagedNetworkEnable;
  */
 
 export class NetworkAccessViolationControl extends Characteristic {
-
-  static readonly UUID: string = '0000021F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000021F-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Network Access Violation Control', NetworkAccessViolationControl.UUID);
+    super("Network Access Violation Control", NetworkAccessViolationControl.UUID);
     this.setProps({
       format: Formats.TLV8,
-      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE, Perms.WRITE_RESPONSE]
+      perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY, Perms.TIMED_WRITE, Perms.WRITE_RESPONSE],
     });
     this.value = this.getDefaultValue();
   }
@@ -3495,16 +3346,16 @@ export class WiFiSatelliteStatus extends Characteristic {
   static readonly CONNECTED = 1;
   static readonly NOT_CONNECTED = 2;
 
-  static readonly UUID: string = '0000021E-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000021E-0000-1000-8000-0026BB765291";
 
   constructor() {
-    super('Wi-Fi Satellite Status', WiFiSatelliteStatus.UUID);
+    super("Wi-Fi Satellite Status", WiFiSatelliteStatus.UUID);
     this.setProps({
       format: Formats.UINT8,
       maxValue: 2,
       minValue: 0,
-      validValues: [0,1,2],
-      perms: [Perms.PAIRED_READ, Perms.NOTIFY]
+      validValues: [0, 1, 2],
+      perms: [Perms.PAIRED_READ, Perms.NOTIFY],
     });
     this.value = this.getDefaultValue();
   }
@@ -3517,8 +3368,7 @@ Characteristic.WiFiSatelliteStatus = WiFiSatelliteStatus;
  */
 
 export class AccessoryInformation extends Service {
-
-  static UUID: string = '0000003E-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000003E-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, AccessoryInformation.UUID, subtype);
@@ -3545,8 +3395,7 @@ Service.AccessoryInformation = AccessoryInformation;
  */
 
 export class AirPurifier extends Service {
-
-  static UUID: string = '000000BB-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000BB-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, AirPurifier.UUID, subtype);
@@ -3571,8 +3420,7 @@ Service.AirPurifier = AirPurifier;
  */
 
 export class AirQualitySensor extends Service {
-
-  static UUID: string = '0000008D-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000008D-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, AirQualitySensor.UUID, subtype);
@@ -3602,8 +3450,7 @@ Service.AirQualitySensor = AirQualitySensor;
  */
 
 export class BatteryService extends Service {
-
-  static UUID: string = '00000096-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000096-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, BatteryService.UUID, subtype);
@@ -3625,8 +3472,7 @@ Service.BatteryService = BatteryService;
  */
 
 export class CameraRTPStreamManagement extends Service {
-
-  static UUID: string = '00000110-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000110-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, CameraRTPStreamManagement.UUID, subtype);
@@ -3651,8 +3497,7 @@ Service.CameraRTPStreamManagement = CameraRTPStreamManagement;
  */
 
 export class CarbonDioxideSensor extends Service {
-
-  static UUID: string = '00000097-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000097-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, CarbonDioxideSensor.UUID, subtype);
@@ -3678,8 +3523,7 @@ Service.CarbonDioxideSensor = CarbonDioxideSensor;
  */
 
 export class CarbonMonoxideSensor extends Service {
-
-  static UUID: string = '0000007F-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000007F-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, CarbonMonoxideSensor.UUID, subtype);
@@ -3705,8 +3549,7 @@ Service.CarbonMonoxideSensor = CarbonMonoxideSensor;
  */
 
 export class ContactSensor extends Service {
-
-  static UUID: string = '00000080-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000080-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, ContactSensor.UUID, subtype);
@@ -3730,8 +3573,7 @@ Service.ContactSensor = ContactSensor;
  */
 
 export class Door extends Service {
-
-  static UUID: string = '00000081-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000081-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Door.UUID, subtype);
@@ -3755,8 +3597,7 @@ Service.Door = Door;
  */
 
 export class Doorbell extends Service {
-
-  static UUID: string = '00000121-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000121-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Doorbell.UUID, subtype);
@@ -3778,8 +3619,7 @@ Service.Doorbell = Doorbell;
  */
 
 export class Fan extends Service {
-
-  static UUID: string = '00000040-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000040-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Fan.UUID, subtype);
@@ -3801,8 +3641,7 @@ Service.Fan = Fan;
  */
 
 export class Fanv2 extends Service {
-
-  static UUID: string = '000000B7-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000B7-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Fanv2.UUID, subtype);
@@ -3828,8 +3667,7 @@ Service.Fanv2 = Fanv2;
  */
 
 export class FilterMaintenance extends Service {
-
-  static UUID: string = '000000BA-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000BA-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, FilterMaintenance.UUID, subtype);
@@ -3851,8 +3689,7 @@ Service.FilterMaintenance = FilterMaintenance;
  */
 
 export class Faucet extends Service {
-
-  static UUID: string = '000000D7-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000D7-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Faucet.UUID, subtype);
@@ -3873,8 +3710,7 @@ Service.Faucet = Faucet;
  */
 
 export class GarageDoorOpener extends Service {
-
-  static UUID: string = '00000041-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000041-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, GarageDoorOpener.UUID, subtype);
@@ -3898,8 +3734,7 @@ Service.GarageDoorOpener = GarageDoorOpener;
  */
 
 export class HeaterCooler extends Service {
-
-  static UUID: string = '000000BC-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000BC-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, HeaterCooler.UUID, subtype);
@@ -3928,8 +3763,7 @@ Service.HeaterCooler = HeaterCooler;
  */
 
 export class HumidifierDehumidifier extends Service {
-
-  static UUID: string = '000000BD-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000BD-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, HumidifierDehumidifier.UUID, subtype);
@@ -3958,8 +3792,7 @@ Service.HumidifierDehumidifier = HumidifierDehumidifier;
  */
 
 export class HumiditySensor extends Service {
-
-  static UUID: string = '00000082-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000082-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, HumiditySensor.UUID, subtype);
@@ -3983,8 +3816,7 @@ Service.HumiditySensor = HumiditySensor;
  */
 
 export class IrrigationSystem extends Service {
-
-  static UUID: string = '000000CF-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000CF-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, IrrigationSystem.UUID, subtype);
@@ -4008,8 +3840,7 @@ Service.IrrigationSystem = IrrigationSystem;
  */
 
 export class LeakSensor extends Service {
-
-  static UUID: string = '00000083-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000083-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, LeakSensor.UUID, subtype);
@@ -4033,8 +3864,7 @@ Service.LeakSensor = LeakSensor;
  */
 
 export class LightSensor extends Service {
-
-  static UUID: string = '00000084-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000084-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, LightSensor.UUID, subtype);
@@ -4058,8 +3888,7 @@ Service.LightSensor = LightSensor;
  */
 
 export class Lightbulb extends Service {
-
-  static UUID: string = '00000043-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000043-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Lightbulb.UUID, subtype);
@@ -4083,8 +3912,7 @@ Service.Lightbulb = Lightbulb;
  */
 
 export class LockManagement extends Service {
-
-  static UUID: string = '00000044-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000044-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, LockManagement.UUID, subtype);
@@ -4112,8 +3940,7 @@ Service.LockManagement = LockManagement;
  */
 
 export class LockMechanism extends Service {
-
-  static UUID: string = '00000045-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000045-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, LockMechanism.UUID, subtype);
@@ -4134,8 +3961,7 @@ Service.LockMechanism = LockMechanism;
  */
 
 export class Microphone extends Service {
-
-  static UUID: string = '00000112-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000112-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Microphone.UUID, subtype);
@@ -4156,8 +3982,7 @@ Service.Microphone = Microphone;
  */
 
 export class MotionSensor extends Service {
-
-  static UUID: string = '00000085-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000085-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, MotionSensor.UUID, subtype);
@@ -4181,8 +4006,7 @@ Service.MotionSensor = MotionSensor;
  */
 
 export class OccupancySensor extends Service {
-
-  static UUID: string = '00000086-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000086-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, OccupancySensor.UUID, subtype);
@@ -4206,8 +4030,7 @@ Service.OccupancySensor = OccupancySensor;
  */
 
 export class Outlet extends Service {
-
-  static UUID: string = '00000047-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000047-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Outlet.UUID, subtype);
@@ -4228,8 +4051,7 @@ Service.Outlet = Outlet;
  */
 
 export class SecuritySystem extends Service {
-
-  static UUID: string = '0000007E-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000007E-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, SecuritySystem.UUID, subtype);
@@ -4253,8 +4075,7 @@ Service.SecuritySystem = SecuritySystem;
  */
 
 export class ServiceLabel extends Service {
-
-  static UUID: string = '000000CC-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000CC-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, ServiceLabel.UUID, subtype);
@@ -4274,8 +4095,7 @@ Service.ServiceLabel = ServiceLabel;
  */
 
 export class Slat extends Service {
-
-  static UUID: string = '000000B9-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000B9-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Slat.UUID, subtype);
@@ -4299,8 +4119,7 @@ Service.Slat = Slat;
  */
 
 export class SmokeSensor extends Service {
-
-  static UUID: string = '00000087-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000087-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, SmokeSensor.UUID, subtype);
@@ -4324,8 +4143,7 @@ Service.SmokeSensor = SmokeSensor;
  */
 
 export class Speaker extends Service {
-
-  static UUID: string = '00000113-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000113-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Speaker.UUID, subtype);
@@ -4346,8 +4164,7 @@ Service.Speaker = Speaker;
  */
 
 export class StatelessProgrammableSwitch extends Service {
-
-  static UUID: string = '00000089-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000089-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, StatelessProgrammableSwitch.UUID, subtype);
@@ -4368,8 +4185,7 @@ Service.StatelessProgrammableSwitch = StatelessProgrammableSwitch;
  */
 
 export class Switch extends Service {
-
-  static UUID: string = '00000049-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000049-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Switch.UUID, subtype);
@@ -4389,8 +4205,7 @@ Service.Switch = Switch;
  */
 
 export class TemperatureSensor extends Service {
-
-  static UUID: string = '0000008A-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000008A-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, TemperatureSensor.UUID, subtype);
@@ -4414,8 +4229,7 @@ Service.TemperatureSensor = TemperatureSensor;
  */
 
 export class Thermostat extends Service {
-
-  static UUID: string = '0000004A-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000004A-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Thermostat.UUID, subtype);
@@ -4443,8 +4257,7 @@ Service.Thermostat = Thermostat;
  */
 
 export class Valve extends Service {
-
-  static UUID: string = '000000D0-0000-1000-8000-0026BB765291';
+  static UUID: string = "000000D0-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Valve.UUID, subtype);
@@ -4471,8 +4284,7 @@ Service.Valve = Valve;
  */
 
 export class Window extends Service {
-
-  static UUID: string = '0000008B-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000008B-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, Window.UUID, subtype);
@@ -4496,8 +4308,7 @@ Service.Window = Window;
  */
 
 export class WindowCovering extends Service {
-
-  static UUID: string = '0000008C-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000008C-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, WindowCovering.UUID, subtype);
@@ -4525,8 +4336,7 @@ Service.WindowCovering = WindowCovering;
  */
 
 export class CameraOperatingMode extends Service {
-
-  static UUID: string = '0000021A-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000021A-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, CameraOperatingMode.UUID, subtype);
@@ -4553,8 +4363,7 @@ Service.CameraOperatingMode = CameraOperatingMode;
  */
 
 export class CameraEventRecordingManagement extends Service {
-
-  static UUID: string = '00000204-0000-1000-8000-0026BB765291';
+  static UUID: string = "00000204-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, CameraEventRecordingManagement.UUID, subtype);
@@ -4579,8 +4388,7 @@ Service.CameraEventRecordingManagement = CameraEventRecordingManagement;
  */
 
 export class WiFiRouter extends Service {
-
-  static UUID: string = '0000020A-0000-1000-8000-0026BB765291';
+  static UUID: string = "0000020A-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, WiFiRouter.UUID, subtype);
@@ -4609,7 +4417,7 @@ Service.WiFiRouter = WiFiRouter;
  */
 
 export class WiFiSatellite extends Service {
-  static readonly UUID: string = '0000020F-0000-1000-8000-0026BB765291';
+  static readonly UUID: string = "0000020F-0000-1000-8000-0026BB765291";
 
   constructor(displayName: string, subtype: string) {
     super(displayName, WiFiSatellite.UUID, subtype);

--- a/src/lib/gen/import.js
+++ b/src/lib/gen/import.js
@@ -1,9 +1,9 @@
-'use strict';
+"use strict";
 
-var path = require('path');
-var fs = require('fs');
-var plist = require('simple-plist');
-var Characteristic = require('../Characteristic').Characteristic;
+var path = require("path");
+var fs = require("fs");
+var plist = require("simple-plist");
+var Characteristic = require("../Characteristic").Characteristic;
 
 /**
  * This module is intended to be run from the command line. It is a script that extracts Apple's Service
@@ -11,11 +11,12 @@ var Characteristic = require('../Characteristic').Characteristic;
  */
 
 // assumed location of the plist we need (might want to make this a command-line argument at some point)
-var plistPath = '/Applications/HomeKit Accessory Simulator.app/Contents/Frameworks/HAPAccessoryKit.framework/Versions/A/Resources/default.metadata.plist';
+var plistPath =
+  "/Applications/HomeKit Accessory Simulator.app/Contents/Frameworks/HAPAccessoryKit.framework/Versions/A/Resources/default.metadata.plist";
 var metadata = plist.readFileSync(plistPath);
 
 // begin writing the output file
-var outputPath = path.join(__dirname, 'HomeKitTypes.js');
+var outputPath = path.join(__dirname, "HomeKitTypes.js");
 var output = fs.createWriteStream(outputPath);
 
 output.write("// THIS FILE IS AUTO-GENERATED - DO NOT MODIFY\n");
@@ -40,7 +41,7 @@ for (var index in metadata.Characteristics) {
   // index classyName for when we want to declare these in Services below
   characteristics[characteristic.UUID] = classyName;
 
-  output.write("/**\n * Characteristic \"" + characteristic.Name + "\"\n */\n\n");
+  output.write('/**\n * Characteristic "' + characteristic.Name + '"\n */\n\n');
   output.write("Characteristic." + classyName + " = function() {\n");
   output.write("  Characteristic.call(this, '" + characteristic.Name + "', '" + characteristic.UUID + "');\n");
 
@@ -53,22 +54,22 @@ for (var index in metadata.Characteristics) {
     output.write(",\n    unit: Characteristic.Units." + getCharacteristicUnitsKey(characteristic.Unit));
 
   // apply any basic constraints if present
-  if (characteristic.Constraints && typeof characteristic.Constraints.MaximumValue !== 'undefined')
+  if (characteristic.Constraints && typeof characteristic.Constraints.MaximumValue !== "undefined")
     output.write(",\n    maxValue: " + characteristic.Constraints.MaximumValue);
 
-  if (characteristic.Constraints && typeof characteristic.Constraints.MinimumValue !== 'undefined')
+  if (characteristic.Constraints && typeof characteristic.Constraints.MinimumValue !== "undefined")
     output.write(",\n    minValue: " + characteristic.Constraints.MinimumValue);
 
-  if (characteristic.Constraints && typeof characteristic.Constraints.StepValue !== 'undefined')
+  if (characteristic.Constraints && typeof characteristic.Constraints.StepValue !== "undefined")
     output.write(",\n    minStep: " + characteristic.Constraints.StepValue);
 
   output.write(",\n    perms: [");
-  var sep = ""
+  var sep = "";
   for (var i in characteristic.Properties) {
     var perms = getCharacteristicPermsKey(characteristic.Properties[i]);
     if (perms) {
-        output.write(sep + "Characteristic.Perms." + getCharacteristicPermsKey(characteristic.Properties[i]));
-        sep = ", "
+      output.write(sep + "Characteristic.Perms." + getCharacteristicPermsKey(characteristic.Properties[i]));
+      sep = ", ";
     }
   }
   output.write("]");
@@ -90,15 +91,14 @@ for (var index in metadata.Characteristics) {
     for (var value in characteristic.Constraints.ValidValues) {
       var name = characteristic.Constraints.ValidValues[value];
 
-      var constName = name.toUpperCase().replace(/[^\w]+/g, '_');
-      if ((/^[1-9]/).test(constName)) constName = "_" + constName; // variables can't start with a number
+      var constName = name.toUpperCase().replace(/[^\w]+/g, "_");
+      if (/^[1-9]/.test(constName)) constName = "_" + constName; // variables can't start with a number
       output.write("Characteristic." + classyName + "." + constName + " = " + value + ";\n");
     }
 
     output.write("\n");
   }
 }
-
 
 /**
  * Services
@@ -108,7 +108,7 @@ for (var index in metadata.Services) {
   var service = metadata.Services[index];
   var classyName = service.Name.replace(/[\s\-]/g, ""); // "Smoke Sensor" -> "SmokeSensor"
 
-  output.write("/**\n * Service \"" + service.Name + "\"\n */\n\n");
+  output.write('/**\n * Service "' + service.Name + '"\n */\n\n');
   output.write("Service." + classyName + " = function(displayName, subtype) {\n");
   // call superclass constructor
   output.write("  Service.call(this, displayName, '" + service.UUID + "', subtype);\n");
@@ -160,31 +160,32 @@ output.end();
 
 function getCharacteristicFormatsKey(format) {
   // coerce 'int32' to 'int'
-  if (format == 'int32') format = 'int';
+  if (format == "int32") format = "int";
 
   // look up the key in our known-formats dict
-  for (var key in Characteristic.Formats)
-    if (Characteristic.Formats[key] == format)
-      return key;
+  for (var key in Characteristic.Formats) if (Characteristic.Formats[key] == format) return key;
 
   throw new Error("Unknown characteristic format '" + format + "'");
 }
 
 function getCharacteristicUnitsKey(units) {
   // look up the key in our known-units dict
-  for (var key in Characteristic.Units)
-    if (Characteristic.Units[key] == units)
-      return key;
+  for (var key in Characteristic.Units) if (Characteristic.Units[key] == units) return key;
 
   throw new Error("Unknown characteristic units '" + units + "'");
 }
 
 function getCharacteristicPermsKey(perm) {
   switch (perm) {
-    case "read": return "READ";
-    case "write": return "WRITE";
-    case "cnotify": return "NOTIFY";
-    case "uncnotify": return undefined;
-    default: throw new Error("Unknown characteristic permission '" + perm + "'");
+    case "read":
+      return "READ";
+    case "write":
+      return "WRITE";
+    case "cnotify":
+      return "NOTIFY";
+    case "uncnotify":
+      return undefined;
+    default:
+      throw new Error("Unknown characteristic permission '" + perm + "'");
   }
 }

--- a/src/lib/gen/importAsClasses.ts
+++ b/src/lib/gen/importAsClasses.ts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
-import plist from 'simple-plist';
+import plist from "simple-plist";
 
 import { Characteristic, Formats, Units } from "../Characteristic";
 
@@ -11,11 +11,12 @@ import { Characteristic, Formats, Units } from "../Characteristic";
  */
 
 // assumed location of the plist we need (might want to make this a command-line argument at some point)
-var plistPath = '/Applications/HomeKit Accessory Simulator.app/Contents/Frameworks/HAPAccessoryKit.framework/Versions/A/Resources/default.metadata.plist';
+var plistPath =
+  "/Applications/HomeKit Accessory Simulator.app/Contents/Frameworks/HAPAccessoryKit.framework/Versions/A/Resources/default.metadata.plist";
 var metadata = plist.readFileSync(plistPath);
 
 // begin writing the output file
-var outputPath = path.join(__dirname, '..', '..', '..', 'src', 'lib', 'gen', 'HomeKitTypes.generated.ts');
+var outputPath = path.join(__dirname, "..", "..", "..", "src", "lib", "gen", "HomeKitTypes.generated.ts");
 var output = fs.createWriteStream(outputPath);
 
 output.write("// THIS FILE IS AUTO-GENERATED - DO NOT MODIFY\n");
@@ -58,16 +59,16 @@ for (var index in metadata.Characteristics) {
     for (var value in characteristic.Constraints.ValidValues) {
       var name = characteristic.Constraints.ValidValues[value];
 
-      var constName = name.toUpperCase().replace(/[^\w]+/g, '_');
-      if ((/^[1-9]/).test(constName)) constName = "_" + constName; // variables can't start with a number
+      var constName = name.toUpperCase().replace(/[^\w]+/g, "_");
+      if (/^[1-9]/.test(constName)) constName = "_" + constName; // variables can't start with a number
       output.write(`  static readonly ${constName} = ${value};\n`);
     }
-    output.write('\n');
+    output.write("\n");
   }
 
   // constructor
   output.write("  constructor(\n");
-  output.write("    displayName = \"\",\n");
+  output.write('    displayName = "",\n');
   output.write("    props?: CharacteristicProps,\n");
   output.write("  ) {\n");
   output.write("    props = props || {\n");
@@ -77,26 +78,25 @@ for (var index in metadata.Characteristics) {
   output.write("      format: Formats." + getCharacteristicFormatsKey(characteristic.Format));
 
   // special unit type?
-  if (characteristic.Unit)
-    output.write(",\n      unit: Units." + getCharacteristicUnitsKey(characteristic.Unit));
+  if (characteristic.Unit) output.write(",\n      unit: Units." + getCharacteristicUnitsKey(characteristic.Unit));
 
   // apply any basic constraints if present
-  if (characteristic.Constraints && typeof characteristic.Constraints.MaximumValue !== 'undefined')
+  if (characteristic.Constraints && typeof characteristic.Constraints.MaximumValue !== "undefined")
     output.write(",\n      maxValue: " + characteristic.Constraints.MaximumValue);
 
-  if (characteristic.Constraints && typeof characteristic.Constraints.MinimumValue !== 'undefined')
+  if (characteristic.Constraints && typeof characteristic.Constraints.MinimumValue !== "undefined")
     output.write(",\n      minValue: " + characteristic.Constraints.MinimumValue);
 
-  if (characteristic.Constraints && typeof characteristic.Constraints.StepValue !== 'undefined')
+  if (characteristic.Constraints && typeof characteristic.Constraints.StepValue !== "undefined")
     output.write(",\n      minStep: " + characteristic.Constraints.StepValue);
 
   output.write(",\n      perms: [");
-  var sep = ""
+  var sep = "";
   for (var i in characteristic.Properties) {
     var perms = getCharacteristicPermsKey(characteristic.Properties[i]);
     if (perms) {
-        output.write(sep + "Perms." + getCharacteristicPermsKey(characteristic.Properties[i]));
-        sep = ", "
+      output.write(sep + "Perms." + getCharacteristicPermsKey(characteristic.Properties[i]));
+      sep = ", ";
     }
   }
   output.write("]");
@@ -175,31 +175,32 @@ output.end();
 
 function getCharacteristicFormatsKey(format: string) {
   // coerce 'int32' to 'int'
-  if (format == 'int32') format = 'int';
+  if (format == "int32") format = "int";
 
   // look up the key in our known-formats dict
-  for (var key in Formats)
-    if (Formats[key as keyof typeof Formats] == format)
-      return key;
+  for (var key in Formats) if (Formats[key as keyof typeof Formats] == format) return key;
 
   throw new Error("Unknown characteristic format '" + format + "'");
 }
 
 function getCharacteristicUnitsKey(units: string) {
   // look up the key in our known-units dict
-  for (var key in Units)
-    if (Units[key as keyof typeof Units] == units)
-      return key;
+  for (var key in Units) if (Units[key as keyof typeof Units] == units) return key;
 
   throw new Error("Unknown characteristic units '" + units + "'");
 }
 
 function getCharacteristicPermsKey(perm: string) {
   switch (perm) {
-    case "read": return "READ";
-    case "write": return "WRITE";
-    case "cnotify": return "NOTIFY";
-    case "uncnotify": return undefined;
-    default: throw new Error("Unknown characteristic permission '" + perm + "'");
+    case "read":
+      return "READ";
+    case "write":
+      return "WRITE";
+    case "cnotify":
+      return "NOTIFY";
+    case "uncnotify":
+      return undefined;
+    default:
+      throw new Error("Unknown characteristic permission '" + perm + "'");
   }
 }

--- a/src/lib/gen/index.ts
+++ b/src/lib/gen/index.ts
@@ -1,12 +1,11 @@
-import * as gen from './HomeKit';
-import * as bridged from './HomeKit-Bridge';
-import * as tv from './HomeKit-TV';
-import * as remote from './HomeKit-Remote';
-import * as dataStream from './HomeKit-DataStream';
+import * as gen from "./HomeKit";
+import * as bridged from "./HomeKit-Bridge";
+import * as tv from "./HomeKit-TV";
+import * as remote from "./HomeKit-Remote";
+import * as dataStream from "./HomeKit-DataStream";
 
 export const Generated = gen;
 export const Bridged = bridged;
 export const TV = tv;
 export const Remote = remote;
 export const DataStream = dataStream;
-

--- a/src/lib/model/AccessoryInfo.spec.ts
+++ b/src/lib/model/AccessoryInfo.spec.ts
@@ -1,32 +1,32 @@
 import { AccessoryInfo } from "./AccessoryInfo";
 import { AssertionError } from "assert";
 
-describe('AccessoryInfo', () => {
-    describe('#assertValidUsername()', () => {
-        it('should verify correct device id', function () {
-            const VALUE = "0E:AE:FC:45:7B:91";
-            expect(() => AccessoryInfo.assertValidUsername(VALUE)).not.toThrow(AssertionError);
-        });
-
-        it('should fail to verify too long device id', function () {
-            const VALUE = "00:2c:44:f9:30:8f:d1:2e";
-            expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
-        });
-
-        it('should fail to verify too short device id', function () {
-            const VALUE = "00:2c:d1:2e";
-            expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
-        });
-
-        it('should fail to verify device id containing invalid characters', function () {
-            const VALUE = "0E:AG:FC:45:7B:91";
-            expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
-        });
-
-        it('should fail to verify undefined device id', function () {
-            const VALUE = undefined;
-            // @ts-ignore
-            expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
-        });
+describe("AccessoryInfo", () => {
+  describe("#assertValidUsername()", () => {
+    it("should verify correct device id", function() {
+      const VALUE = "0E:AE:FC:45:7B:91";
+      expect(() => AccessoryInfo.assertValidUsername(VALUE)).not.toThrow(AssertionError);
     });
+
+    it("should fail to verify too long device id", function() {
+      const VALUE = "00:2c:44:f9:30:8f:d1:2e";
+      expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
+    });
+
+    it("should fail to verify too short device id", function() {
+      const VALUE = "00:2c:d1:2e";
+      expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
+    });
+
+    it("should fail to verify device id containing invalid characters", function() {
+      const VALUE = "0E:AG:FC:45:7B:91";
+      expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
+    });
+
+    it("should fail to verify undefined device id", function() {
+      const VALUE = undefined;
+      // @ts-ignore
+      expect(() => AccessoryInfo.assertValidUsername(VALUE)).toThrow(AssertionError);
+    });
+  });
 });

--- a/src/lib/model/IdentifierCache.spec.ts
+++ b/src/lib/model/IdentifierCache.spec.ts
@@ -1,17 +1,15 @@
 // @ts-ignore
-import storage from 'node-persist';
+import storage from "node-persist";
 
-import { IdentifierCache } from './IdentifierCache';
+import { IdentifierCache } from "./IdentifierCache";
 
-const createIdentifierCache = (username = 'username') => {
+const createIdentifierCache = (username = "username") => {
   return new IdentifierCache(username);
-}
+};
 
-describe('IdentifierCache', () => {
-
-  describe('#startTrackingUsage()', () => {
-
-    it ('creates a cache to track usage and expiring keys', () => {
+describe("IdentifierCache", () => {
+  describe("#startTrackingUsage()", () => {
+    it("creates a cache to track usage and expiring keys", () => {
       const identifierCache = createIdentifierCache();
 
       expect(identifierCache._usedCache).toBeNull();
@@ -20,8 +18,8 @@ describe('IdentifierCache', () => {
     });
   });
 
-  describe('#stopTrackingUsageAndExpireUnused()', () => {
-    it ('creates a cache to track usage and expiring keys', () => {
+  describe("#stopTrackingUsageAndExpireUnused()", () => {
+    it("creates a cache to track usage and expiring keys", () => {
       const identifierCache = createIdentifierCache();
 
       expect(identifierCache._usedCache).toBeNull();
@@ -32,77 +30,73 @@ describe('IdentifierCache', () => {
     });
   });
 
-  describe('#getCache()', () => {
-    it ('retrieves an item from the cache', () => {
+  describe("#getCache()", () => {
+    it("retrieves an item from the cache", () => {
       const identifierCache = createIdentifierCache();
 
       const VALUE = 1;
-      identifierCache.setCache('foo', VALUE);
+      identifierCache.setCache("foo", VALUE);
 
-      expect(identifierCache.getCache('foo')).toEqual(VALUE);
+      expect(identifierCache.getCache("foo")).toEqual(VALUE);
     });
 
-    it ('returns undefined if an item is not found in the cache', () => {
+    it("returns undefined if an item is not found in the cache", () => {
       const identifierCache = createIdentifierCache();
 
-      expect(identifierCache.getCache('foo')).toBeUndefined();
+      expect(identifierCache.getCache("foo")).toBeUndefined();
     });
   });
 
-  describe('#setCache()', () => {
-    it ('overwrites an existing item in the cache', () => {
+  describe("#setCache()", () => {
+    it("overwrites an existing item in the cache", () => {
       const identifierCache = createIdentifierCache();
 
       const VALUE = 2;
-      identifierCache.setCache('foo', 1);
-      identifierCache.setCache('foo', VALUE);
+      identifierCache.setCache("foo", 1);
+      identifierCache.setCache("foo", VALUE);
 
-      expect(identifierCache.getCache('foo')).toEqual(VALUE);
+      expect(identifierCache.getCache("foo")).toEqual(VALUE);
     });
   });
 
-  describe('#getAID()', () => {
-    it('creates an entry in the cache if the key is not found', () => {
+  describe("#getAID()", () => {
+    it("creates an entry in the cache if the key is not found", () => {
       const identifierCache = createIdentifierCache();
 
-      const result = identifierCache.getAID('00');
+      const result = identifierCache.getAID("00");
       expect(result).toEqual(2);
     });
   });
 
-  describe('#getIID()', () => {
-    it('creates an entry in the cache if the key is not found', () => {
+  describe("#getIID()", () => {
+    it("creates an entry in the cache if the key is not found", () => {
       const identifierCache = createIdentifierCache();
 
-      const result = identifierCache.getIID('00', '11', 'subtype', '99');
+      const result = identifierCache.getIID("00", "11", "subtype", "99");
       expect(result).toEqual(2);
     });
 
-    it('creates an entry in the cache if the key is not found, without a characteristic UUID', () => {
+    it("creates an entry in the cache if the key is not found, without a characteristic UUID", () => {
       const identifierCache = createIdentifierCache();
 
-      const result = identifierCache.getIID('00', '11', 'subtype');
+      const result = identifierCache.getIID("00", "11", "subtype");
       expect(result).toEqual(2);
     });
 
-    it('creates an entry in the cache if the key is not found, without a service subtype or characteristic UUID', () => {
+    it("creates an entry in the cache if the key is not found, without a service subtype or characteristic UUID", () => {
       const identifierCache = createIdentifierCache();
 
-      const result = identifierCache.getIID('00', '11');
+      const result = identifierCache.getIID("00", "11");
       expect(result).toEqual(2);
     });
   });
 
-  describe('#getNextAID()', () => {
+  describe("#getNextAID()", () => {});
 
-  });
+  describe("#getNextIID()", () => {});
 
-  describe('#getNextIID()', () => {
-
-  });
-
-  describe('#save()', () => {
-    it('persists the cache to file storage', () => {
+  describe("#save()", () => {
+    it("persists the cache to file storage", () => {
       const identifierCache = createIdentifierCache();
       identifierCache.save();
 
@@ -111,8 +105,8 @@ describe('IdentifierCache', () => {
     });
   });
 
-  describe('#remove()', () => {
-    it('removes the cache from file storage', () => {
+  describe("#remove()", () => {
+    it("removes the cache from file storage", () => {
       const identifierCache = createIdentifierCache();
       identifierCache.remove();
 
@@ -120,14 +114,12 @@ describe('IdentifierCache', () => {
     });
   });
 
-  describe('persistKey()', () => {
-    it('returns a correctly formatted key for persistence', () => {
-      const key = IdentifierCache.persistKey('username');
-      expect(key).toEqual('IdentifierCache.USERNAME.json');
+  describe("persistKey()", () => {
+    it("returns a correctly formatted key for persistence", () => {
+      const key = IdentifierCache.persistKey("username");
+      expect(key).toEqual("IdentifierCache.USERNAME.json");
     });
   });
 
-  describe('load()', () => {
-
-  });
+  describe("load()", () => {});
 });

--- a/src/lib/util/chacha20poly1305.ts
+++ b/src/lib/util/chacha20poly1305.ts
@@ -5,8 +5,8 @@
 // Implementation derived from chacha-ref.c version 20080118
 // See for details: http://cr.yp.to/chacha/chacha-20080128.pdf
 
-var Chacha20KeySize   = 32;
-var Chacha20NonceSize =  8;
+var Chacha20KeySize = 32;
+var Chacha20NonceSize = 8;
 
 export class Chacha20Ctx {
   input: any[];
@@ -21,148 +21,155 @@ export class Chacha20Ctx {
 }
 
 export function load32(x: Uint8Array, i: number) {
-    return x[i] | (x[i+1]<<8) | (x[i+2]<<16) | (x[i+3]<<24);
+  return x[i] | (x[i + 1] << 8) | (x[i + 2] << 16) | (x[i + 3] << 24);
 }
 
 export function store32(x: any, i: number, u: number) {
-    x[i]   = u & 0xff; u >>>= 8;
-    x[i+1] = u & 0xff; u >>>= 8;
-    x[i+2] = u & 0xff; u >>>= 8;
-    x[i+3] = u & 0xff;
+  x[i] = u & 0xff;
+  u >>>= 8;
+  x[i + 1] = u & 0xff;
+  u >>>= 8;
+  x[i + 2] = u & 0xff;
+  u >>>= 8;
+  x[i + 3] = u & 0xff;
 }
 
 export function plus(v: number, w: number) {
-    return (v + w) >>> 0;
+  return (v + w) >>> 0;
 }
 
 export function rotl32(v: number, c: number) {
-    return ((v << c) >>> 0) | (v >>> (32 - c));
+  return ((v << c) >>> 0) | (v >>> (32 - c));
 }
 
 export function quarterRound(x: any, a: number, b: number, c: number, d: number) {
-    x[a] = plus(x[a], x[b]); x[d] = rotl32(x[d] ^ x[a], 16);
-    x[c] = plus(x[c], x[d]); x[b] = rotl32(x[b] ^ x[c], 12);
-    x[a] = plus(x[a], x[b]); x[d] = rotl32(x[d] ^ x[a],  8);
-    x[c] = plus(x[c], x[d]); x[b] = rotl32(x[b] ^ x[c],  7);
+  x[a] = plus(x[a], x[b]);
+  x[d] = rotl32(x[d] ^ x[a], 16);
+  x[c] = plus(x[c], x[d]);
+  x[b] = rotl32(x[b] ^ x[c], 12);
+  x[a] = plus(x[a], x[b]);
+  x[d] = rotl32(x[d] ^ x[a], 8);
+  x[c] = plus(x[c], x[d]);
+  x[b] = rotl32(x[b] ^ x[c], 7);
 }
 
 export function chacha20_keysetup(ctx: Chacha20Ctx, key: Uint8Array) {
-    ctx.input[0] = 1634760805;
-    ctx.input[1] =  857760878;
-    ctx.input[2] = 2036477234;
-    ctx.input[3] = 1797285236;
-    for (var i = 0; i < 8; i++) {
-        ctx.input[i+4] = load32(key, i*4);
-    }
+  ctx.input[0] = 1634760805;
+  ctx.input[1] = 857760878;
+  ctx.input[2] = 2036477234;
+  ctx.input[3] = 1797285236;
+  for (var i = 0; i < 8; i++) {
+    ctx.input[i + 4] = load32(key, i * 4);
+  }
 }
 
 export function chacha20_ivsetup(ctx: Chacha20Ctx, iv: Uint8Array) {
-    ctx.input[12] = 0;
-    ctx.input[13] = 0;
-    ctx.input[14] = load32(iv, 0);
-    ctx.input[15] = load32(iv, 4);
+  ctx.input[12] = 0;
+  ctx.input[13] = 0;
+  ctx.input[14] = load32(iv, 0);
+  ctx.input[15] = load32(iv, 4);
 }
 
 export function chacha20_encrypt(ctx: Chacha20Ctx, dst: Uint8Array, src: Uint8Array, len: number) {
-    var x = new Array(16);
-    var buf = new Array(64);
-    var i = 0, dpos = 0, spos = 0;
+  var x = new Array(16);
+  var buf = new Array(64);
+  var i = 0,
+    dpos = 0,
+    spos = 0;
 
-    while (len > 0 ) {
-        for (i = 16; i--;) x[i] = ctx.input[i];
-        for (i = 20; i > 0; i -= 2) {
-            quarterRound(x, 0, 4, 8,12);
-            quarterRound(x, 1, 5, 9,13);
-            quarterRound(x, 2, 6,10,14);
-            quarterRound(x, 3, 7,11,15);
-            quarterRound(x, 0, 5,10,15);
-            quarterRound(x, 1, 6,11,12);
-            quarterRound(x, 2, 7, 8,13);
-            quarterRound(x, 3, 4, 9,14);
-        }
-        for (i = 16; i--;) x[i] += ctx.input[i];
-        for (i = 16; i--;) store32(buf, 4*i, x[i]);
-
-        ctx.input[12] = plus(ctx.input[12], 1);
-        if (!ctx.input[12]) {
-            ctx.input[13] = plus(ctx.input[13], 1);
-        }
-        if (len <= 64) {
-            for (i = len; i--;) {
-                dst[i+dpos] = src[i+spos] ^ buf[i];
-            }
-            return;
-        }
-        for (i = 64; i--;) {
-            dst[i+dpos] = src[i+spos] ^ buf[i];
-        }
-        len -= 64;
-        spos += 64;
-        dpos += 64;
+  while (len > 0) {
+    for (i = 16; i--; ) x[i] = ctx.input[i];
+    for (i = 20; i > 0; i -= 2) {
+      quarterRound(x, 0, 4, 8, 12);
+      quarterRound(x, 1, 5, 9, 13);
+      quarterRound(x, 2, 6, 10, 14);
+      quarterRound(x, 3, 7, 11, 15);
+      quarterRound(x, 0, 5, 10, 15);
+      quarterRound(x, 1, 6, 11, 12);
+      quarterRound(x, 2, 7, 8, 13);
+      quarterRound(x, 3, 4, 9, 14);
     }
+    for (i = 16; i--; ) x[i] += ctx.input[i];
+    for (i = 16; i--; ) store32(buf, 4 * i, x[i]);
+
+    ctx.input[12] = plus(ctx.input[12], 1);
+    if (!ctx.input[12]) {
+      ctx.input[13] = plus(ctx.input[13], 1);
+    }
+    if (len <= 64) {
+      for (i = len; i--; ) {
+        dst[i + dpos] = src[i + spos] ^ buf[i];
+      }
+      return;
+    }
+    for (i = 64; i--; ) {
+      dst[i + dpos] = src[i + spos] ^ buf[i];
+    }
+    len -= 64;
+    spos += 64;
+    dpos += 64;
+  }
 }
 
 export function chacha20_decrypt(ctx: Chacha20Ctx, dst: Buffer, src: Buffer, len: number) {
-    chacha20_encrypt(ctx, dst, src, len);
+  chacha20_encrypt(ctx, dst, src, len);
 }
 
 export function chacha20_update(ctx: Chacha20Ctx, dst: Buffer, src: Buffer, inlen: number) {
-    var bytes = 0;
-    var out_start = 0;
-    var out_inc = 0;
+  var bytes = 0;
+  var out_start = 0;
+  var out_inc = 0;
 
-    if ((ctx.leftover + inlen) >= 64) {
+  if (ctx.leftover + inlen >= 64) {
+    if (ctx.leftover != 0) {
+      bytes = 64 - ctx.leftover;
 
-        if (ctx.leftover != 0) {
-            bytes = 64 - ctx.leftover;
+      if (src.length > 0) {
+        src.copy(ctx.buffer, ctx.leftover, 0, bytes);
+        src = src.slice(bytes, src.length);
+      }
 
-            if (src.length > 0) {
-                src.copy(ctx.buffer,ctx.leftover,0,bytes);
-                src = src.slice(bytes,src.length);
-            }
-
-            chacha20_encrypt(ctx,dst,ctx.buffer,64);
-            inlen -= bytes;
-            dst = dst.slice(64,dst.length);
-            out_inc += 64;
-            ctx.leftover = 0;
-        }
-
-        bytes = (inlen & (~63));
-        if (bytes > 0) {
-            chacha20_encrypt(ctx, dst, src, bytes);
-            inlen -= bytes;
-            src = src.slice(bytes,src.length);
-            dst = dst.slice(bytes,dst.length);
-            out_inc += bytes;
-        }
-
+      chacha20_encrypt(ctx, dst, ctx.buffer, 64);
+      inlen -= bytes;
+      dst = dst.slice(64, dst.length);
+      out_inc += 64;
+      ctx.leftover = 0;
     }
 
-    if (inlen > 0) {
-        if (src.length > 0) {
-            src.copy(ctx.buffer,ctx.leftover,0,src.length);
-        } else {
-            var zeros = Buffer.alloc(inlen);
-            zeros.copy(ctx.buffer,ctx.leftover,0,inlen);
-        }
-        ctx.leftover += inlen;
+    bytes = inlen & ~63;
+    if (bytes > 0) {
+      chacha20_encrypt(ctx, dst, src, bytes);
+      inlen -= bytes;
+      src = src.slice(bytes, src.length);
+      dst = dst.slice(bytes, dst.length);
+      out_inc += bytes;
     }
+  }
 
-    return out_inc - out_start;
+  if (inlen > 0) {
+    if (src.length > 0) {
+      src.copy(ctx.buffer, ctx.leftover, 0, src.length);
+    } else {
+      var zeros = Buffer.alloc(inlen);
+      zeros.copy(ctx.buffer, ctx.leftover, 0, inlen);
+    }
+    ctx.leftover += inlen;
+  }
+
+  return out_inc - out_start;
 }
 
 export function chacha20_final(ctx: Chacha20Ctx, dst: Buffer) {
-    if (ctx.leftover != 0) {
-        chacha20_encrypt(ctx, dst, ctx.buffer, 64);
-    }
+  if (ctx.leftover != 0) {
+    chacha20_encrypt(ctx, dst, ctx.buffer, 64);
+  }
 
-    return ctx.leftover;
+  return ctx.leftover;
 }
 
 export function chacha20_keystream(ctx: Chacha20Ctx, dst: Buffer, len: number) {
-    for (var i = 0; i < len; ++i) dst[i] = 0;
-    chacha20_encrypt(ctx, dst, dst, len);
+  for (var i = 0; i < len; ++i) dst[i] = 0;
+  chacha20_encrypt(ctx, dst, dst, len);
 }
 
 /* poly1305 */
@@ -176,7 +183,6 @@ var Poly1305KeySize = 32;
 var Poly1305TagSize = 16;
 
 export class Poly1305Ctx {
-
   buffer: Buffer;
   leftover: number;
   r: any[];
@@ -185,7 +191,7 @@ export class Poly1305Ctx {
   finished: number;
 
   constructor() {
-    this.buffer = new Array(Poly1305TagSize) as unknown as Buffer;
+    this.buffer = (new Array(Poly1305TagSize) as unknown) as Buffer;
     this.leftover = 0;
     this.r = new Array(10);
     this.h = new Array(10);
@@ -195,203 +201,212 @@ export class Poly1305Ctx {
 }
 
 export function U8TO16(p: Uint8Array, pos: number) {
-    return ((p[pos] & 0xff) & 0xffff) | (((p[pos+1] & 0xff) & 0xffff) << 8);
+  return (p[pos] & 0xff & 0xffff) | ((p[pos + 1] & 0xff & 0xffff) << 8);
 }
 
 export function U16TO8(p: Uint8Array, pos: number, v: number) {
-    p[pos]   = (v      ) & 0xff;
-    p[pos+1] = (v >>> 8) & 0xff;
+  p[pos] = v & 0xff;
+  p[pos + 1] = (v >>> 8) & 0xff;
 }
 
 export function poly1305_init(ctx: Poly1305Ctx, key: Buffer) {
-    var t = [], i = 0;
+  var t = [],
+    i = 0;
 
-    for (i = 8; i--;) t[i] = U8TO16(key, i*2);
+  for (i = 8; i--; ) t[i] = U8TO16(key, i * 2);
 
-    ctx.r[0] =   t[0]                         & 0x1fff;
-    ctx.r[1] = ((t[0] >>> 13) | (t[1] <<  3)) & 0x1fff;
-    ctx.r[2] = ((t[1] >>> 10) | (t[2] <<  6)) & 0x1f03;
-    ctx.r[3] = ((t[2] >>>  7) | (t[3] <<  9)) & 0x1fff;
-    ctx.r[4] = ((t[3] >>>  4) | (t[4] << 12)) & 0x00ff;
-    ctx.r[5] =  (t[4] >>>  1)                 & 0x1ffe;
-    ctx.r[6] = ((t[4] >>> 14) | (t[5] <<  2)) & 0x1fff;
-    ctx.r[7] = ((t[5] >>> 11) | (t[6] <<  5)) & 0x1f81;
-    ctx.r[8] = ((t[6] >>>  8) | (t[7] <<  8)) & 0x1fff;
-    ctx.r[9] =  (t[7] >>>  5)                 & 0x007f;
+  ctx.r[0] = t[0] & 0x1fff;
+  ctx.r[1] = ((t[0] >>> 13) | (t[1] << 3)) & 0x1fff;
+  ctx.r[2] = ((t[1] >>> 10) | (t[2] << 6)) & 0x1f03;
+  ctx.r[3] = ((t[2] >>> 7) | (t[3] << 9)) & 0x1fff;
+  ctx.r[4] = ((t[3] >>> 4) | (t[4] << 12)) & 0x00ff;
+  ctx.r[5] = (t[4] >>> 1) & 0x1ffe;
+  ctx.r[6] = ((t[4] >>> 14) | (t[5] << 2)) & 0x1fff;
+  ctx.r[7] = ((t[5] >>> 11) | (t[6] << 5)) & 0x1f81;
+  ctx.r[8] = ((t[6] >>> 8) | (t[7] << 8)) & 0x1fff;
+  ctx.r[9] = (t[7] >>> 5) & 0x007f;
 
-    for (i = 8; i--;) {
-        ctx.h[i]   = 0;
-        ctx.pad[i] = U8TO16(key, 16+(2*i));
-    }
-    ctx.h[8] = 0;
-    ctx.h[9] = 0;
-    ctx.leftover = 0;
-    ctx.finished = 0;
+  for (i = 8; i--; ) {
+    ctx.h[i] = 0;
+    ctx.pad[i] = U8TO16(key, 16 + 2 * i);
+  }
+  ctx.h[8] = 0;
+  ctx.h[9] = 0;
+  ctx.leftover = 0;
+  ctx.finished = 0;
 }
 
 export function poly1305_blocks(ctx: Poly1305Ctx, m: Uint8Array, mpos: number, bytes: number) {
-    var hibit = ctx.finished ? 0 : (1 << 11);
-    var t = [], d = [], c = 0, i = 0, j = 0;
+  var hibit = ctx.finished ? 0 : 1 << 11;
+  var t = [],
+    d = [],
+    c = 0,
+    i = 0,
+    j = 0;
 
-    while (bytes >= Poly1305TagSize) {
-        for (i = 8; i--;) t[i] = U8TO16(m, i*2+mpos);
+  while (bytes >= Poly1305TagSize) {
+    for (i = 8; i--; ) t[i] = U8TO16(m, i * 2 + mpos);
 
-        ctx.h[0] +=   t[0]                         & 0x1fff;
-        ctx.h[1] += ((t[0] >>> 13) | (t[1] <<  3)) & 0x1fff;
-        ctx.h[2] += ((t[1] >>> 10) | (t[2] <<  6)) & 0x1fff;
-        ctx.h[3] += ((t[2] >>>  7) | (t[3] <<  9)) & 0x1fff;
-        ctx.h[4] += ((t[3] >>>  4) | (t[4] << 12)) & 0x1fff;
-        ctx.h[5] +=  (t[4] >>>  1)                 & 0x1fff;
-        ctx.h[6] += ((t[4] >>> 14) | (t[5] <<  2)) & 0x1fff;
-        ctx.h[7] += ((t[5] >>> 11) | (t[6] <<  5)) & 0x1fff;
-        ctx.h[8] += ((t[6] >>>  8) | (t[7] <<  8)) & 0x1fff;
-        ctx.h[9] +=  (t[7] >>>  5)                 | hibit;
+    ctx.h[0] += t[0] & 0x1fff;
+    ctx.h[1] += ((t[0] >>> 13) | (t[1] << 3)) & 0x1fff;
+    ctx.h[2] += ((t[1] >>> 10) | (t[2] << 6)) & 0x1fff;
+    ctx.h[3] += ((t[2] >>> 7) | (t[3] << 9)) & 0x1fff;
+    ctx.h[4] += ((t[3] >>> 4) | (t[4] << 12)) & 0x1fff;
+    ctx.h[5] += (t[4] >>> 1) & 0x1fff;
+    ctx.h[6] += ((t[4] >>> 14) | (t[5] << 2)) & 0x1fff;
+    ctx.h[7] += ((t[5] >>> 11) | (t[6] << 5)) & 0x1fff;
+    ctx.h[8] += ((t[6] >>> 8) | (t[7] << 8)) & 0x1fff;
+    ctx.h[9] += (t[7] >>> 5) | hibit;
 
-        for (i = 0, c = 0; i < 10; i++) {
-            d[i] = c;
-            for (j = 0; j < 10; j++) {
-                d[i] += (ctx.h[j] & 0xffffffff) * ((j <= i) ? ctx.r[i-j] : (5 * ctx.r[i+10-j]));
-                if (j === 4) {
-                    c = (d[i] >>> 13);
-                    d[i] &= 0x1fff;
-                }
-            }
-            c += (d[i] >>> 13);
-            d[i] &= 0x1fff;
+    for (i = 0, c = 0; i < 10; i++) {
+      d[i] = c;
+      for (j = 0; j < 10; j++) {
+        d[i] += (ctx.h[j] & 0xffffffff) * (j <= i ? ctx.r[i - j] : 5 * ctx.r[i + 10 - j]);
+        if (j === 4) {
+          c = d[i] >>> 13;
+          d[i] &= 0x1fff;
         }
-        c = ((c << 2) + c);
-        c += d[0];
-        d[0] = ((c & 0xffff) & 0x1fff);
-        c = (c >>> 13);
-        d[1] += c;
-
-        for (i = 10; i--;) ctx.h[i] = d[i] & 0xffff;
-
-        mpos += Poly1305TagSize;
-        bytes -= Poly1305TagSize;
+      }
+      c += d[i] >>> 13;
+      d[i] &= 0x1fff;
     }
+    c = (c << 2) + c;
+    c += d[0];
+    d[0] = c & 0xffff & 0x1fff;
+    c = c >>> 13;
+    d[1] += c;
+
+    for (i = 10; i--; ) ctx.h[i] = d[i] & 0xffff;
+
+    mpos += Poly1305TagSize;
+    bytes -= Poly1305TagSize;
+  }
 }
 
 export function poly1305_update(ctx: Poly1305Ctx, m: Uint8Array, bytes: number) {
-    var want = 0, i = 0, mpos = 0;
+  var want = 0,
+    i = 0,
+    mpos = 0;
 
-    if (ctx.leftover) {
-        want = (Poly1305TagSize - ctx.leftover);
-        if (want > bytes)
-            want = bytes;
-        for (i = want; i--;) {
-            ctx.buffer[ctx.leftover+i] = m[i+mpos];
-        }
-        bytes -= want;
-        mpos += want;
-        ctx.leftover += want;
-        if (ctx.leftover < Poly1305TagSize)
-            return;
-        poly1305_blocks(ctx, ctx.buffer, 0, Poly1305TagSize);
-        ctx.leftover = 0;
+  if (ctx.leftover) {
+    want = Poly1305TagSize - ctx.leftover;
+    if (want > bytes) want = bytes;
+    for (i = want; i--; ) {
+      ctx.buffer[ctx.leftover + i] = m[i + mpos];
     }
+    bytes -= want;
+    mpos += want;
+    ctx.leftover += want;
+    if (ctx.leftover < Poly1305TagSize) return;
+    poly1305_blocks(ctx, ctx.buffer, 0, Poly1305TagSize);
+    ctx.leftover = 0;
+  }
 
-    if (bytes >= Poly1305TagSize) {
-        want = (bytes & ~(Poly1305TagSize - 1));
-        poly1305_blocks(ctx, m, mpos, want);
-        mpos += want;
-        bytes -= want;
-    }
+  if (bytes >= Poly1305TagSize) {
+    want = bytes & ~(Poly1305TagSize - 1);
+    poly1305_blocks(ctx, m, mpos, want);
+    mpos += want;
+    bytes -= want;
+  }
 
-    if (bytes) {
-        for (i = bytes; i--;) {
-            ctx.buffer[ctx.leftover+i] = m[i+mpos];
-        }
-        ctx.leftover += bytes;
+  if (bytes) {
+    for (i = bytes; i--; ) {
+      ctx.buffer[ctx.leftover + i] = m[i + mpos];
     }
+    ctx.leftover += bytes;
+  }
 }
 
 export function poly1305_finish(ctx: Poly1305Ctx, mac: Uint8Array) {
-    var g = [], c = 0, mask = 0, f = 0, i = 0;
+  var g = [],
+    c = 0,
+    mask = 0,
+    f = 0,
+    i = 0;
 
-    if (ctx.leftover) {
-        i = ctx.leftover;
-        ctx.buffer[i++] = 1;
-        for (; i < Poly1305TagSize; i++) {
-            ctx.buffer[i] = 0;
-        }
-        ctx.finished = 1;
-        poly1305_blocks(ctx, ctx.buffer, 0, Poly1305TagSize);
+  if (ctx.leftover) {
+    i = ctx.leftover;
+    ctx.buffer[i++] = 1;
+    for (; i < Poly1305TagSize; i++) {
+      ctx.buffer[i] = 0;
     }
+    ctx.finished = 1;
+    poly1305_blocks(ctx, ctx.buffer, 0, Poly1305TagSize);
+  }
 
-    c = ctx.h[1] >>> 13;
-    ctx.h[1] &= 0x1fff;
-    for (i = 2; i < 10; i++) {
-        ctx.h[i] += c;
-        c = ctx.h[i] >>> 13;
-        ctx.h[i] &= 0x1fff;
-    }
-    ctx.h[0] += (c * 5);
-    c = ctx.h[0] >>> 13;
-    ctx.h[0] &= 0x1fff;
-    ctx.h[1] += c;
-    c = ctx.h[1] >>> 13;
-    ctx.h[1] &= 0x1fff;
-    ctx.h[2] += c;
+  c = ctx.h[1] >>> 13;
+  ctx.h[1] &= 0x1fff;
+  for (i = 2; i < 10; i++) {
+    ctx.h[i] += c;
+    c = ctx.h[i] >>> 13;
+    ctx.h[i] &= 0x1fff;
+  }
+  ctx.h[0] += c * 5;
+  c = ctx.h[0] >>> 13;
+  ctx.h[0] &= 0x1fff;
+  ctx.h[1] += c;
+  c = ctx.h[1] >>> 13;
+  ctx.h[1] &= 0x1fff;
+  ctx.h[2] += c;
 
-    g[0] = ctx.h[0] + 5;
-    c = g[0] >>> 13;
-    g[0] &= 0x1fff;
-    for (i = 1; i < 10; i++) {
-        g[i] = ctx.h[i] + c;
-        c = g[i] >>> 13;
-        g[i] &= 0x1fff;
-    }
-    g[9] -= (1 << 13);
-    g[9] &= 0xffff;
+  g[0] = ctx.h[0] + 5;
+  c = g[0] >>> 13;
+  g[0] &= 0x1fff;
+  for (i = 1; i < 10; i++) {
+    g[i] = ctx.h[i] + c;
+    c = g[i] >>> 13;
+    g[i] &= 0x1fff;
+  }
+  g[9] -= 1 << 13;
+  g[9] &= 0xffff;
 
-    mask = (g[9] >>> 15) - 1;
-    for (i = 10; i--;) g[i] &= mask;
-    mask = ~mask;
-    for (i = 10; i--;) {
-        ctx.h[i] = (ctx.h[i] & mask) | g[i];
-    }
+  mask = (g[9] >>> 15) - 1;
+  for (i = 10; i--; ) g[i] &= mask;
+  mask = ~mask;
+  for (i = 10; i--; ) {
+    ctx.h[i] = (ctx.h[i] & mask) | g[i];
+  }
 
-    ctx.h[0] = ((ctx.h[0]      ) | (ctx.h[1] << 13)) & 0xffff;
-    ctx.h[1] = ((ctx.h[1] >>  3) | (ctx.h[2] << 10)) & 0xffff;
-    ctx.h[2] = ((ctx.h[2] >>  6) | (ctx.h[3] <<  7)) & 0xffff;
-    ctx.h[3] = ((ctx.h[3] >>  9) | (ctx.h[4] <<  4)) & 0xffff;
-    ctx.h[4] = ((ctx.h[4] >> 12) | (ctx.h[5] <<  1) | (ctx.h[6] << 14)) & 0xffff;
-    ctx.h[5] = ((ctx.h[6] >>  2) | (ctx.h[7] << 11)) & 0xffff;
-    ctx.h[6] = ((ctx.h[7] >>  5) | (ctx.h[8] <<  8)) & 0xffff;
-    ctx.h[7] = ((ctx.h[8] >>  8) | (ctx.h[9] <<  5)) & 0xffff;
+  ctx.h[0] = (ctx.h[0] | (ctx.h[1] << 13)) & 0xffff;
+  ctx.h[1] = ((ctx.h[1] >> 3) | (ctx.h[2] << 10)) & 0xffff;
+  ctx.h[2] = ((ctx.h[2] >> 6) | (ctx.h[3] << 7)) & 0xffff;
+  ctx.h[3] = ((ctx.h[3] >> 9) | (ctx.h[4] << 4)) & 0xffff;
+  ctx.h[4] = ((ctx.h[4] >> 12) | (ctx.h[5] << 1) | (ctx.h[6] << 14)) & 0xffff;
+  ctx.h[5] = ((ctx.h[6] >> 2) | (ctx.h[7] << 11)) & 0xffff;
+  ctx.h[6] = ((ctx.h[7] >> 5) | (ctx.h[8] << 8)) & 0xffff;
+  ctx.h[7] = ((ctx.h[8] >> 8) | (ctx.h[9] << 5)) & 0xffff;
 
-    f = (ctx.h[0] & 0xffffffff) + ctx.pad[0];
-    ctx.h[0] = f & 0xffff;
-    for (i = 1; i < 8; i++) {
-        f = (ctx.h[i] & 0xffffffff) + ctx.pad[i] + (f >>> 16);
-        ctx.h[i] = f & 0xffff;
-    }
+  f = (ctx.h[0] & 0xffffffff) + ctx.pad[0];
+  ctx.h[0] = f & 0xffff;
+  for (i = 1; i < 8; i++) {
+    f = (ctx.h[i] & 0xffffffff) + ctx.pad[i] + (f >>> 16);
+    ctx.h[i] = f & 0xffff;
+  }
 
-    for (i = 8; i--;) {
-        U16TO8(mac, i*2, ctx.h[i]);
-        ctx.pad[i] = 0;
-    }
-    for (i = 10; i--;) {
-        ctx.h[i] = 0;
-        ctx.r[i] = 0;
-    }
+  for (i = 8; i--; ) {
+    U16TO8(mac, i * 2, ctx.h[i]);
+    ctx.pad[i] = 0;
+  }
+  for (i = 10; i--; ) {
+    ctx.h[i] = 0;
+    ctx.r[i] = 0;
+  }
 }
 
 export function poly1305_auth(mac: Uint8Array, m: Uint8Array, bytes: number, key: Buffer) {
-    var ctx = new Poly1305Ctx();
-    poly1305_init(ctx, key);
-    poly1305_update(ctx, m, bytes);
-    poly1305_finish(ctx, mac);
+  var ctx = new Poly1305Ctx();
+  poly1305_init(ctx, key);
+  poly1305_update(ctx, m, bytes);
+  poly1305_finish(ctx, mac);
 }
 
 export function poly1305_verify(mac1: any, mac2: any) {
-    var dif = 0;
-    for (var i = 0; i < 16; i++) {
-        dif |= (mac1[i] ^ mac2[i]);
-    }
-    dif = (dif - 1) >>> 31;
-    return (dif & 1);
+  var dif = 0;
+  for (var i = 0; i < 16; i++) {
+    dif |= mac1[i] ^ mac2[i];
+  }
+  dif = (dif - 1) >>> 31;
+  return dif & 1;
 }
 
 /* chacha20poly1305 AEAD */
@@ -413,77 +428,84 @@ export class AeadCtx {
 }
 
 export function aead_init(c20ctx: Chacha20Ctx, key: Buffer, nonce: Buffer) {
-    chacha20_keysetup(c20ctx, key);
-    chacha20_ivsetup(c20ctx, nonce);
+  chacha20_keysetup(c20ctx, key);
+  chacha20_ivsetup(c20ctx, nonce);
 
-    var subkey: any = [];
-    chacha20_keystream(c20ctx, subkey, 64);
+  var subkey: any = [];
+  chacha20_keystream(c20ctx, subkey, 64);
 
-    return subkey.slice(0, 32);
+  return subkey.slice(0, 32);
 }
 
 export function store64(dst: Uint8Array, pos: number, num: number) {
-    var hi = 0, lo = num >>> 0;
-    if ((+(Math.abs(num))) >= 1) {
-        if (num > 0) {
-            hi = ((Math.min((+(Math.floor(num/4294967296))), 4294967295))|0) >>> 0;
-        } else {
-            hi = (~~((+(Math.ceil((num - +(((~~(num)))>>>0))/4294967296))))) >>> 0;
-        }
+  var hi = 0,
+    lo = num >>> 0;
+  if (+Math.abs(num) >= 1) {
+    if (num > 0) {
+      hi = (Math.min(+Math.floor(num / 4294967296), 4294967295) | 0) >>> 0;
+    } else {
+      hi = ~~+Math.ceil((num - +(~~num >>> 0)) / 4294967296) >>> 0;
     }
-    dst[pos]   = lo & 0xff; lo >>>= 8;
-    dst[pos+1] = lo & 0xff; lo >>>= 8;
-    dst[pos+2] = lo & 0xff; lo >>>= 8;
-    dst[pos+3] = lo & 0xff;
-    dst[pos+4] = hi & 0xff; hi >>>= 8;
-    dst[pos+5] = hi & 0xff; hi >>>= 8;
-    dst[pos+6] = hi & 0xff; hi >>>= 8;
-    dst[pos+7] = hi & 0xff;
+  }
+  dst[pos] = lo & 0xff;
+  lo >>>= 8;
+  dst[pos + 1] = lo & 0xff;
+  lo >>>= 8;
+  dst[pos + 2] = lo & 0xff;
+  lo >>>= 8;
+  dst[pos + 3] = lo & 0xff;
+  dst[pos + 4] = hi & 0xff;
+  hi >>>= 8;
+  dst[pos + 5] = hi & 0xff;
+  hi >>>= 8;
+  dst[pos + 6] = hi & 0xff;
+  hi >>>= 8;
+  dst[pos + 7] = hi & 0xff;
 }
 
 export function aead_mac(key: Buffer, ciphertext: string, data: string) {
-    var clen = ciphertext.length;
-    var dlen = data.length;
-    var m: any = new Array(clen + dlen + 16);
-    var i = dlen;
+  var clen = ciphertext.length;
+  var dlen = data.length;
+  var m: any = new Array(clen + dlen + 16);
+  var i = dlen;
 
-    for (; i--;) m[i] = data[i];
-    store64(m, dlen, dlen);
+  for (; i--; ) m[i] = data[i];
+  store64(m, dlen, dlen);
 
-    for (i = clen; i--;) m[dlen+8+i] = ciphertext[i];
-    store64(m, clen+dlen+8, clen);
+  for (i = clen; i--; ) m[dlen + 8 + i] = ciphertext[i];
+  store64(m, clen + dlen + 8, clen);
 
-    var mac: any = [];
-    poly1305_auth(mac, m, m.length, key);
+  var mac: any = [];
+  poly1305_auth(mac, m, m.length, key);
 
-    return mac;
+  return mac;
 }
 
 export function aead_encrypt(ctx: AeadCtx, nonce: Buffer, input: Buffer, ad: string) {
-    var c = new Chacha20Ctx();
-    var key = aead_init(c, ctx.key, nonce);
+  var c = new Chacha20Ctx();
+  var key = aead_init(c, ctx.key, nonce);
 
-    var ciphertext: any = [];
-    chacha20_encrypt(c, ciphertext, input, input.length);
+  var ciphertext: any = [];
+  chacha20_encrypt(c, ciphertext, input, input.length);
 
-    var mac = aead_mac(key, ciphertext, ad);
+  var mac = aead_mac(key, ciphertext, ad);
 
-    var out: any = [];
-    out = out.concat(ciphertext, mac);
+  var out: any = [];
+  out = out.concat(ciphertext, mac);
 
-    return out;
+  return out;
 }
 
 export function aead_decrypt(ctx: AeadCtx, nonce: Buffer, ciphertext: any, ad: string) {
-    var c = new Chacha20Ctx();
-    var key = aead_init(c, ctx.key, nonce);
-    var clen = ciphertext.length - Poly1305TagSize;
-    var digest = ciphertext.slice(clen);
-    var mac = aead_mac(key, ciphertext.slice(0, clen), ad);
+  var c = new Chacha20Ctx();
+  var key = aead_init(c, ctx.key, nonce);
+  var clen = ciphertext.length - Poly1305TagSize;
+  var digest = ciphertext.slice(clen);
+  var mac = aead_mac(key, ciphertext.slice(0, clen), ad);
 
-    if (poly1305_verify(digest, mac) !== 1) return false;
+  if (poly1305_verify(digest, mac) !== 1) return false;
 
-    var out: any = [];
-    chacha20_decrypt(c, out, ciphertext, clen);
-    return out;
+  var out: any = [];
+  chacha20_decrypt(c, out, ciphertext, clen);
+  return out;
 }

--- a/src/lib/util/clone.ts
+++ b/src/lib/util/clone.ts
@@ -3,7 +3,6 @@
  * added to the cloned copy of the original object passed.
  */
 export function clone<T, U>(object: T, extend?: U): T & U {
-
   var cloned = {} as Record<any, any>;
 
   for (var key in object) {
@@ -15,4 +14,4 @@ export function clone<T, U>(object: T, extend?: U): T & U {
   }
 
   return cloned;
-};
+}

--- a/src/lib/util/encryption.ts
+++ b/src/lib/util/encryption.ts
@@ -1,22 +1,24 @@
-import assert from 'assert';
-import crypto from 'crypto';
+import assert from "assert";
+import crypto from "crypto";
 
-import createDebug from 'debug';
-import tweetnacl from 'tweetnacl';
+import createDebug from "debug";
+import tweetnacl from "tweetnacl";
 
-import * as chacha20poly1305 from './chacha20poly1305';
+import * as chacha20poly1305 from "./chacha20poly1305";
 
-const debug = createDebug('encryption');
+const debug = createDebug("encryption");
 
 function fromHex(h: string) {
-  h.replace(/([^0-9a-f])/g, '');
-  var out = [], len = h.length, w = '';
+  h.replace(/([^0-9a-f])/g, "");
+  var out = [],
+    len = h.length,
+    w = "";
   for (var i = 0; i < len; i += 2) {
     w = h[i];
-    if (((i+1) >= len) || typeof h[i+1] === 'undefined') {
-        w += '0';
+    if (i + 1 >= len || typeof h[i + 1] === "undefined") {
+      w += "0";
     } else {
-        w += h[i+1];
+      w += h[i + 1];
     }
     out.push(parseInt(w, 16));
   }
@@ -35,7 +37,7 @@ export function generateCurve25519SharedSecKey(priKey: Uint8Array, pubKey: Uint8
 
 type Count = {
   value: any;
-}
+};
 
 export function layerEncrypt(data: Buffer, count: Count, key: Buffer) {
   var result = Buffer.alloc(0);
@@ -43,19 +45,18 @@ export function layerEncrypt(data: Buffer, count: Count, key: Buffer) {
   for (var offset = 0; offset < total; ) {
     var length = Math.min(total - offset, 0x400);
     var leLength = Buffer.alloc(2);
-    leLength.writeUInt16LE(length,0);
+    leLength.writeUInt16LE(length, 0);
 
     var nonce = Buffer.alloc(8);
     writeUInt64LE(count.value++, nonce, 0);
 
     var result_Buffer = Buffer.alloc(length);
     var result_mac = Buffer.alloc(16);
-    encryptAndSeal(key, nonce, data.slice(offset, offset + length),
-      leLength,result_Buffer, result_mac);
+    encryptAndSeal(key, nonce, data.slice(offset, offset + length), leLength, result_Buffer, result_mac);
 
     offset += length;
 
-    result = Buffer.concat([result,leLength,result_Buffer,result_mac]);
+    result = Buffer.concat([result, leLength, result_Buffer, result_mac]);
   }
   return result;
 }
@@ -69,8 +70,8 @@ export function layerDecrypt(packet: Buffer, count: Count, key: Buffer, extraInf
   var result = Buffer.alloc(0);
   var total = packet.length;
 
-  for (var offset = 0; offset < total;) {
-    var realDataLength = packet.slice(offset,offset+2).readUInt16LE(0);
+  for (var offset = 0; offset < total; ) {
+    var realDataLength = packet.slice(offset, offset + 2).readUInt16LE(0);
 
     var availableDataLength = total - offset - 2 - 16;
     if (realDataLength > availableDataLength) {
@@ -86,29 +87,43 @@ export function layerDecrypt(packet: Buffer, count: Count, key: Buffer, extraInf
 
     var result_Buffer = Buffer.alloc(realDataLength);
 
-    if (verifyAndDecrypt(key, nonce, packet.slice(offset + 2, offset + 2 + realDataLength),
-      packet.slice(offset + 2 + realDataLength, offset + 2 + realDataLength + 16),
-      packet.slice(offset,offset+2),result_Buffer)) {
-        result = Buffer.concat([result,result_Buffer]);
-        offset += (18 + realDataLength);
-      } else {
-        debug('Layer Decrypt fail!');
-        debug('Packet: %s', packet.toString('hex'));
-        throw new Error("Layer verification failed!");
-      }
+    if (
+      verifyAndDecrypt(
+        key,
+        nonce,
+        packet.slice(offset + 2, offset + 2 + realDataLength),
+        packet.slice(offset + 2 + realDataLength, offset + 2 + realDataLength + 16),
+        packet.slice(offset, offset + 2),
+        result_Buffer
+      )
+    ) {
+      result = Buffer.concat([result, result_Buffer]);
+      offset += 18 + realDataLength;
+    } else {
+      debug("Layer Decrypt fail!");
+      debug("Packet: %s", packet.toString("hex"));
+      throw new Error("Layer verification failed!");
+    }
   }
 
   return result;
 }
 
 //General Enc/Dec
-export function verifyAndDecrypt(key: Buffer, nonce: Buffer, ciphertext: Buffer, mac: Buffer, addData: Buffer | null | undefined, plaintext: Buffer) {
+export function verifyAndDecrypt(
+  key: Buffer,
+  nonce: Buffer,
+  ciphertext: Buffer,
+  mac: Buffer,
+  addData: Buffer | null | undefined,
+  plaintext: Buffer
+) {
   var ctx = new chacha20poly1305.Chacha20Ctx();
   chacha20poly1305.chacha20_keysetup(ctx, key);
   chacha20poly1305.chacha20_ivsetup(ctx, nonce);
   var poly1305key = Buffer.alloc(64);
   var zeros = Buffer.alloc(64);
-  chacha20poly1305.chacha20_update(ctx,poly1305key,zeros,zeros.length);
+  chacha20poly1305.chacha20_update(ctx, poly1305key, zeros, zeros.length);
 
   var poly1305_contxt = new chacha20poly1305.Poly1305Ctx();
   chacha20poly1305.poly1305_init(poly1305_contxt, poly1305key);
@@ -117,14 +132,22 @@ export function verifyAndDecrypt(key: Buffer, nonce: Buffer, ciphertext: Buffer,
   if (addData != undefined) {
     addDataLength = addData.length;
     chacha20poly1305.poly1305_update(poly1305_contxt, addData, addData.length);
-    if ((addData.length % 16) != 0) {
-      chacha20poly1305.poly1305_update(poly1305_contxt, Buffer.alloc(16-(addData.length%16)), 16-(addData.length%16));
+    if (addData.length % 16 != 0) {
+      chacha20poly1305.poly1305_update(
+        poly1305_contxt,
+        Buffer.alloc(16 - (addData.length % 16)),
+        16 - (addData.length % 16)
+      );
     }
   }
 
   chacha20poly1305.poly1305_update(poly1305_contxt, ciphertext, ciphertext.length);
-  if ((ciphertext.length % 16) != 0) {
-    chacha20poly1305.poly1305_update(poly1305_contxt, Buffer.alloc(16-(ciphertext.length%16)), 16-(ciphertext.length%16));
+  if (ciphertext.length % 16 != 0) {
+    chacha20poly1305.poly1305_update(
+      poly1305_contxt,
+      Buffer.alloc(16 - (ciphertext.length % 16)),
+      16 - (ciphertext.length % 16)
+    );
   }
 
   var leAddDataLen = Buffer.alloc(8);
@@ -135,29 +158,36 @@ export function verifyAndDecrypt(key: Buffer, nonce: Buffer, ciphertext: Buffer,
   writeUInt64LE(ciphertext.length, leTextDataLen, 0);
   chacha20poly1305.poly1305_update(poly1305_contxt, leTextDataLen, 8);
 
-  var poly_out = [] as unknown as Uint8Array;
+  var poly_out = ([] as unknown) as Uint8Array;
   chacha20poly1305.poly1305_finish(poly1305_contxt, poly_out);
 
   if (chacha20poly1305.poly1305_verify(mac, poly_out) != 1) {
-    debug('Verify Fail');
+    debug("Verify Fail");
     return false;
   } else {
-    var written = chacha20poly1305.chacha20_update(ctx,plaintext,ciphertext,ciphertext.length);
-    chacha20poly1305.chacha20_final(ctx,plaintext.slice(written, ciphertext.length));
+    var written = chacha20poly1305.chacha20_update(ctx, plaintext, ciphertext, ciphertext.length);
+    chacha20poly1305.chacha20_final(ctx, plaintext.slice(written, ciphertext.length));
     return true;
   }
 }
 
-export function encryptAndSeal(key: Buffer, nonce: Buffer, plaintext: Buffer, addData: Buffer | null | undefined, ciphertext: Buffer, mac: Buffer) {
+export function encryptAndSeal(
+  key: Buffer,
+  nonce: Buffer,
+  plaintext: Buffer,
+  addData: Buffer | null | undefined,
+  ciphertext: Buffer,
+  mac: Buffer
+) {
   var ctx = new chacha20poly1305.Chacha20Ctx();
   chacha20poly1305.chacha20_keysetup(ctx, key);
   chacha20poly1305.chacha20_ivsetup(ctx, nonce);
   var poly1305key = Buffer.alloc(64);
   var zeros = Buffer.alloc(64);
-  chacha20poly1305.chacha20_update(ctx,poly1305key,zeros,zeros.length);
+  chacha20poly1305.chacha20_update(ctx, poly1305key, zeros, zeros.length);
 
-  var written = chacha20poly1305.chacha20_update(ctx,ciphertext,plaintext,plaintext.length);
-  chacha20poly1305.chacha20_final(ctx,ciphertext.slice(written,plaintext.length));
+  var written = chacha20poly1305.chacha20_update(ctx, ciphertext, plaintext, plaintext.length);
+  chacha20poly1305.chacha20_final(ctx, ciphertext.slice(written, plaintext.length));
 
   var poly1305_contxt = new chacha20poly1305.Poly1305Ctx();
   chacha20poly1305.poly1305_init(poly1305_contxt, poly1305key);
@@ -166,14 +196,22 @@ export function encryptAndSeal(key: Buffer, nonce: Buffer, plaintext: Buffer, ad
   if (addData != undefined) {
     addDataLength = addData.length;
     chacha20poly1305.poly1305_update(poly1305_contxt, addData, addData.length);
-    if ((addData.length % 16) != 0) {
-      chacha20poly1305.poly1305_update(poly1305_contxt, Buffer.alloc(16-(addData.length%16)), 16-(addData.length%16));
+    if (addData.length % 16 != 0) {
+      chacha20poly1305.poly1305_update(
+        poly1305_contxt,
+        Buffer.alloc(16 - (addData.length % 16)),
+        16 - (addData.length % 16)
+      );
     }
   }
 
   chacha20poly1305.poly1305_update(poly1305_contxt, ciphertext, ciphertext.length);
-  if ((ciphertext.length % 16) != 0) {
-    chacha20poly1305.poly1305_update(poly1305_contxt, Buffer.alloc(16-(ciphertext.length%16)), 16-(ciphertext.length%16));
+  if (ciphertext.length % 16 != 0) {
+    chacha20poly1305.poly1305_update(
+      poly1305_contxt,
+      Buffer.alloc(16 - (ciphertext.length % 16)),
+      16 - (ciphertext.length % 16)
+    );
   }
 
   var leAddDataLen = Buffer.alloc(8);
@@ -187,54 +225,53 @@ export function encryptAndSeal(key: Buffer, nonce: Buffer, plaintext: Buffer, ad
   chacha20poly1305.poly1305_finish(poly1305_contxt, mac);
 }
 
-var MAX_UINT32 = 0x00000000FFFFFFFF
-var MAX_INT53 =  0x001FFFFFFFFFFFFF
+var MAX_UINT32 = 0x00000000ffffffff;
+var MAX_INT53 = 0x001fffffffffffff;
 
 function onesComplement(number: number) {
-  number = ~number
+  number = ~number;
   if (number < 0) {
-    number = (number & 0x7FFFFFFF) + 0x80000000
+    number = (number & 0x7fffffff) + 0x80000000;
   }
-  return number
+  return number;
 }
 
 function uintHighLow(number: number) {
-  assert(number > -1 && number <= MAX_INT53, "number out of range")
-  assert(Math.floor(number) === number, "number must be an integer")
-  var high = 0
-  var signbit = number & 0xFFFFFFFF
-  var low = signbit < 0 ? (number & 0x7FFFFFFF) + 0x80000000 : signbit
+  assert(number > -1 && number <= MAX_INT53, "number out of range");
+  assert(Math.floor(number) === number, "number must be an integer");
+  var high = 0;
+  var signbit = number & 0xffffffff;
+  var low = signbit < 0 ? (number & 0x7fffffff) + 0x80000000 : signbit;
   if (number > MAX_UINT32) {
-    high = (number - low) / (MAX_UINT32 + 1)
+    high = (number - low) / (MAX_UINT32 + 1);
   }
-  return [high, low]
+  return [high, low];
 }
 
 function intHighLow(number: number) {
   if (number > -1) {
-    return uintHighLow(number)
+    return uintHighLow(number);
   }
-  var hl = uintHighLow(-number)
-  var high = onesComplement(hl[0])
-  var low = onesComplement(hl[1])
+  var hl = uintHighLow(-number);
+  var high = onesComplement(hl[0]);
+  var low = onesComplement(hl[1]);
   if (low === MAX_UINT32) {
-    high += 1
-    low = 0
+    high += 1;
+    low = 0;
+  } else {
+    low += 1;
   }
-  else {
-    low += 1
-  }
-  return [high, low]
+  return [high, low];
 }
 
 function writeUInt64BE(number: number, buffer: Buffer, offset: number = 0) {
-  var hl = uintHighLow(number)
-  buffer.writeUInt32BE(hl[0], offset)
-  buffer.writeUInt32BE(hl[1], offset + 4)
+  var hl = uintHighLow(number);
+  buffer.writeUInt32BE(hl[0], offset);
+  buffer.writeUInt32BE(hl[1], offset + 4);
 }
 
-export function writeUInt64LE (number: number, buffer: Buffer, offset: number = 0) {
-  var hl = uintHighLow(number)
-  buffer.writeUInt32LE(hl[1], offset)
-  buffer.writeUInt32LE(hl[0], offset + 4)
+export function writeUInt64LE(number: number, buffer: Buffer, offset: number = 0) {
+  var hl = uintHighLow(number);
+  buffer.writeUInt32LE(hl[1], offset);
+  buffer.writeUInt32LE(hl[0], offset + 4);
 }

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -1,30 +1,39 @@
-import net, { AddressInfo, Socket } from 'net';
-import http, { IncomingMessage, OutgoingMessage, ServerResponse } from 'http';
+import net, { AddressInfo, Socket } from "net";
+import http, { IncomingMessage, OutgoingMessage, ServerResponse } from "http";
 
-import createDebug from 'debug';
-import srp from 'fast-srp-hap';
+import createDebug from "debug";
+import srp from "fast-srp-hap";
 
-import * as uuid from './uuid';
-import { Nullable, SessionIdentifier } from '../../types';
-import { EventEmitter } from '../EventEmitter';
-import { HAPEncryption } from '../HAPServer';
+import * as uuid from "./uuid";
+import { Nullable, SessionIdentifier } from "../../types";
+import { EventEmitter } from "../EventEmitter";
+import { HAPEncryption } from "../HAPServer";
 
-const debug = createDebug('EventedHTTPServer');
+const debug = createDebug("EventedHTTPServer");
 
 export enum EventedHTTPServerEvents {
-  LISTENING = 'listening',
-  REQUEST = 'request',
-  DECRYPT = 'decrypt',
-  ENCRYPT = 'encrypt',
-  CLOSE = 'close',
-  SESSION_CLOSE = 'session-close',
+  LISTENING = "listening",
+  REQUEST = "request",
+  DECRYPT = "decrypt",
+  ENCRYPT = "encrypt",
+  CLOSE = "close",
+  SESSION_CLOSE = "session-close",
 }
 
 export type Events = {
   [EventedHTTPServerEvents.LISTENING]: (port: number) => void;
-  [EventedHTTPServerEvents.REQUEST]: (request: IncomingMessage, response: ServerResponse, session: Session, events: any) => void;
-  [EventedHTTPServerEvents.DECRYPT]: (data: Buffer, decrypted: { data: Buffer; error: Error | null }, session: Session) => void;
-  [EventedHTTPServerEvents.ENCRYPT]: (data: Buffer, encrypted: { data: number | Buffer; }, session: Session) => void;
+  [EventedHTTPServerEvents.REQUEST]: (
+    request: IncomingMessage,
+    response: ServerResponse,
+    session: Session,
+    events: any
+  ) => void;
+  [EventedHTTPServerEvents.DECRYPT]: (
+    data: Buffer,
+    decrypted: { data: Buffer; error: Error | null },
+    session: Session
+  ) => void;
+  [EventedHTTPServerEvents.ENCRYPT]: (data: Buffer, encrypted: { data: number | Buffer }, session: Session) => void;
   [EventedHTTPServerEvents.CLOSE]: (events: any) => void;
   [EventedHTTPServerEvents.SESSION_CLOSE]: (sessionID: string, events: any) => void;
 };
@@ -65,7 +74,6 @@ export type Events = {
  *        'encrypted' argument to be the encrypted data and it will be sent instead.
  */
 export class EventedHTTPServer extends EventEmitter<Events> {
-
   _tcpServer: net.Server;
   _connections: EventedHTTPServerConnection[];
 
@@ -84,62 +92,67 @@ export class EventedHTTPServer extends EventEmitter<Events> {
   listen = (targetPort: number) => {
     this._tcpServer.listen(targetPort);
 
-    this._tcpServer.on('listening', () => {
+    this._tcpServer.on("listening", () => {
       const address = this._tcpServer.address();
 
-      if (address && typeof address !== 'string') {
+      if (address && typeof address !== "string") {
         var port = address.port;
         debug("Server listening on port %s", port);
         this.emit(EventedHTTPServerEvents.LISTENING, port);
       }
-
     });
 
-    this._tcpServer.on('connection', this._onConnection);
-  }
+    this._tcpServer.on("connection", this._onConnection);
+  };
 
   stop = () => {
     this._tcpServer.close();
-    this._connections.forEach((connection) => {
+    this._connections.forEach(connection => {
       connection.close();
     });
     this._connections = [];
-  }
+  };
 
-  sendEvent = (
-    event: string,
-    data: Buffer | string,
-    contentType: string,
-    exclude?: Record<string, boolean>
-  ) => {
+  sendEvent = (event: string, data: Buffer | string, contentType: string, exclude?: Record<string, boolean>) => {
     for (var index in this._connections) {
       var connection = this._connections[index];
       connection.sendEvent(event, data, contentType, exclude);
     }
-  }
+  };
 
-// Called by net.Server when a new client connects. We will set up a new EventedHTTPServerConnection to manage the
-// lifetime of this connection.
+  // Called by net.Server when a new client connects. We will set up a new EventedHTTPServerConnection to manage the
+  // lifetime of this connection.
   _onConnection = (socket: Socket) => {
     var connection = new EventedHTTPServerConnection(this, socket);
 
     // pass on session events to our listeners directly
-    connection.on(EventedHTTPServerEvents.REQUEST, (request: IncomingMessage, response: ServerResponse, session: Session, events: any) => { this.emit(EventedHTTPServerEvents.REQUEST, request, response, session, events); });
-    connection.on(EventedHTTPServerEvents.ENCRYPT, (data: Buffer, encrypted: { data: Buffer; }, session: Session) => { this.emit(EventedHTTPServerEvents.ENCRYPT, data, encrypted, session); });
-    connection.on(EventedHTTPServerEvents.DECRYPT, (data: Buffer, decrypted: { data: number | Buffer; }, session: Session) => { this.emit(EventedHTTPServerEvents.DECRYPT, data, decrypted, session); });
-    connection.on(EventedHTTPServerEvents.CLOSE, (events: any) => { this._handleConnectionClose(connection, events); });
+    connection.on(
+      EventedHTTPServerEvents.REQUEST,
+      (request: IncomingMessage, response: ServerResponse, session: Session, events: any) => {
+        this.emit(EventedHTTPServerEvents.REQUEST, request, response, session, events);
+      }
+    );
+    connection.on(EventedHTTPServerEvents.ENCRYPT, (data: Buffer, encrypted: { data: Buffer }, session: Session) => {
+      this.emit(EventedHTTPServerEvents.ENCRYPT, data, encrypted, session);
+    });
+    connection.on(
+      EventedHTTPServerEvents.DECRYPT,
+      (data: Buffer, decrypted: { data: number | Buffer }, session: Session) => {
+        this.emit(EventedHTTPServerEvents.DECRYPT, data, decrypted, session);
+      }
+    );
+    connection.on(EventedHTTPServerEvents.CLOSE, (events: any) => {
+      this._handleConnectionClose(connection, events);
+    });
     this._connections.push(connection);
-  }
+  };
 
-  _handleConnectionClose = (
-    connection: EventedHTTPServerConnection,
-    events: Record<string, boolean>
-  ) => {
+  _handleConnectionClose = (connection: EventedHTTPServerConnection, events: Record<string, boolean>) => {
     this.emit(EventedHTTPServerEvents.SESSION_CLOSE, connection.sessionID, events);
 
     // remove it from our array of connections for events
     this._connections.splice(this._connections.indexOf(connection), 1);
-  }
+  };
 }
 
 export enum HAPSessionEvents {
@@ -148,10 +161,9 @@ export enum HAPSessionEvents {
 
 export type HAPSessionEventMap = {
   [HAPSessionEvents.CLOSED]: () => void;
-}
+};
 
 export class Session extends EventEmitter<HAPSessionEventMap> {
-
   readonly _server: EventedHTTPServer;
   readonly _connection: EventedHTTPServerConnection;
   /*
@@ -243,7 +255,6 @@ export class Session extends EventEmitter<HAPSessionEventMap> {
   static getSession(sessionID: string) {
     return this.sessionsBySessionID[sessionID];
   }
-
 }
 
 /**
@@ -255,7 +266,6 @@ export class Session extends EventEmitter<HAPSessionEventMap> {
  * @event 'close' => function() { }
  */
 class EventedHTTPServerConnection extends EventEmitter<Events> {
-
   readonly server: EventedHTTPServer;
   sessionID: string;
   _remoteAddress: string;
@@ -275,7 +285,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     super();
 
     this.server = server;
-    this.sessionID = uuid.generate(clientSocket.remoteAddress + ':' + clientSocket.remotePort);
+    this.sessionID = uuid.generate(clientSocket.remoteAddress + ":" + clientSocket.remotePort);
     this._remoteAddress = clientSocket.remoteAddress!; // cache because it becomes undefined in 'onClientSocketClose'
     this._pendingClientSocketData = Buffer.alloc(0); // data received from client before HTTP proxy is fully setup
     this._fullySetup = false; // true when we are finished establishing connections
@@ -284,18 +294,18 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     this._pendingEventData = []; // queue of unencrypted event data waiting to be sent until after an in-progress HTTP response is being written
     // clientSocket is the socket connected to the actual iOS device
     this._clientSocket = clientSocket;
-    this._clientSocket.on('data', this._onClientSocketData);
-    this._clientSocket.on('close', this._onClientSocketClose);
-    this._clientSocket.on('error', this._onClientSocketError); // we MUST register for this event, otherwise the error will bubble up to the top and crash the node process entirely.
+    this._clientSocket.on("data", this._onClientSocketData);
+    this._clientSocket.on("close", this._onClientSocketClose);
+    this._clientSocket.on("error", this._onClientSocketError); // we MUST register for this event, otherwise the error will bubble up to the top and crash the node process entirely.
     // serverSocket is our connection to our own internal httpServer
     this._serverSocket = null; // created after httpServer 'listening' event
     // create our internal HTTP server for this connection that we will proxy data to and from
     this._httpServer = http.createServer();
     this._httpServer.timeout = 0; // clients expect to hold connections open as long as they want
     this._httpServer.keepAliveTimeout = 0; // workaround for https://github.com/nodejs/node/issues/13391
-    this._httpServer.on('listening', this._onHttpServerListening);
-    this._httpServer.on('request', this._onHttpServerRequest);
-    this._httpServer.on('error', this._onHttpServerError);
+    this._httpServer.on("listening", this._onHttpServerListening);
+    this._httpServer.on("request", this._onHttpServerRequest);
+    this._httpServer.on("error", this._onHttpServerError);
     this._httpServer.listen(0);
     // an arbitrary dict that users of this class can store values in to associate with this particular connection
     this._session = new Session(this);
@@ -311,22 +321,29 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     }
     // does this connection's 'events' object match the excludeEvents object? if so, don't send the event.
     if (excludeEvents === this._events) {
-      debug("[%s] Muting event '%s' notification for this connection since it originated here.", this._remoteAddress, event);
+      debug(
+        "[%s] Muting event '%s' notification for this connection since it originated here.",
+        this._remoteAddress,
+        event
+      );
       return;
     }
-    debug("[%s] Sending HTTP event '%s' with data: %s", this._remoteAddress, event, data.toString('utf8'));
+    debug("[%s] Sending HTTP event '%s' with data: %s", this._remoteAddress, event, data.toString("utf8"));
     // ensure data is a Buffer
-    if (typeof data === 'string') {
+    if (typeof data === "string") {
       data = Buffer.from(data);
     }
     // format this payload as an HTTP response
     var linebreak = Buffer.from("0D0A", "hex");
     data = Buffer.concat([
-      Buffer.from('EVENT/1.0 200 OK'), linebreak,
-      Buffer.from('Content-Type: ' + contentType), linebreak,
-      Buffer.from('Content-Length: ' + data.length), linebreak,
+      Buffer.from("EVENT/1.0 200 OK"),
       linebreak,
-      data
+      Buffer.from("Content-Type: " + contentType),
+      linebreak,
+      Buffer.from("Content-Length: " + data.length),
+      linebreak,
+      linebreak,
+      data,
     ]);
 
     // if we're in the middle of writing an HTTP response already, put this event in the queue for when
@@ -335,7 +352,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
       this._pendingEventData.push(data);
     } else {
       // give listeners an opportunity to encrypt this data before sending it to the client
-      var encrypted = {data: null};
+      var encrypted = { data: null };
       this.emit(EventedHTTPServerEvents.ENCRYPT, data, encrypted, this._session);
       if (encrypted.data) {
         // @ts-ignore
@@ -344,11 +361,11 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
 
       this._clientSocket.write(data);
     }
-  }
+  };
 
   close = () => {
     this._clientSocket.end();
-  }
+  };
 
   _sendPendingEvents = () => {
     if (this._pendingEventData.length === 0) {
@@ -358,7 +375,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     // an existing HTTP response was finished, so let's flush our pending event buffer if necessary!
     debug("[%s] Writing pending HTTP event data", this._remoteAddress);
     this._pendingEventData.forEach(event => {
-      const encrypted = {data: null};
+      const encrypted = { data: null };
       this.emit(EventedHTTPServerEvents.ENCRYPT, event, encrypted, this._session);
       if (encrypted.data) {
         // @ts-ignore
@@ -370,21 +387,21 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
 
     // clear the queue
     this._pendingEventData = [];
-  }
+  };
 
   // Called only once right after constructor finishes
   _onHttpServerListening = () => {
     this._httpPort = (this._httpServer.address() as AddressInfo).port;
     debug("[%s] HTTP server listening on port %s", this._remoteAddress, this._httpPort);
     // closes before this are due to retrying listening, which don't need to be handled
-    this._httpServer.on('close', this._onHttpServerClose);
+    this._httpServer.on("close", this._onHttpServerClose);
     // now we can establish a connection to this running HTTP server for proxying data
     this._serverSocket = net.createConnection(this._httpPort);
-    this._serverSocket.on('connect', this._onServerSocketConnect);
-    this._serverSocket.on('data', this._onServerSocketData);
-    this._serverSocket.on('close', this._onServerSocketClose);
-    this._serverSocket.on('error', this._onServerSocketError); // we MUST register for this event, otherwise the error will bubble up to the top and crash the node process entirely.
-  }
+    this._serverSocket.on("connect", this._onServerSocketConnect);
+    this._serverSocket.on("data", this._onServerSocketData);
+    this._serverSocket.on("close", this._onServerSocketClose);
+    this._serverSocket.on("error", this._onServerSocketError); // we MUST register for this event, otherwise the error will bubble up to the top and crash the node process entirely.
+  };
 
   // Called only once right after onHttpServerListening
   _onServerSocketConnect = () => {
@@ -398,7 +415,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
       this._serverSocket && this._serverSocket.write(this._pendingClientSocketData);
       this._pendingClientSocketData = null;
     }
-  }
+  };
 
   // Received data from client (iOS)
   _onClientSocketData = (data: Buffer) => {
@@ -406,7 +423,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     this._writingResponse = true;
 
     // give listeners an opportunity to decrypt this data before processing it as HTTP
-    var decrypted: {data: Buffer | null, error: Error | null} = {data: null, error: null};
+    var decrypted: { data: Buffer | null; error: Error | null } = { data: null, error: null };
     this.emit(EventedHTTPServerEvents.DECRYPT, data, decrypted, this._session);
 
     if (decrypted.error) {
@@ -426,15 +443,14 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
         this._pendingClientSocketData = Buffer.concat([this._pendingClientSocketData!, data]);
       }
     }
-  }
+  };
 
   // Received data from HTTP Server
   _onServerSocketData = (data: Buffer | string) => {
     // give listeners an opportunity to encrypt this data before sending it to the client
-    var encrypted = {data: null};
+    var encrypted = { data: null };
     this.emit(EventedHTTPServerEvents.ENCRYPT, data, encrypted, this._session);
-    if (encrypted.data)
-      data = encrypted.data!;
+    if (encrypted.data) data = encrypted.data!;
     // proxy it along to the client (iOS)
     this._clientSocket.write(data);
 
@@ -443,7 +459,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
         this._clientSocket.destroy();
       }, 10);
     }
-  }
+  };
 
   // Our internal HTTP Server has been closed (happens after we call this._httpServer.close() below)
   _onServerSocketClose = () => {
@@ -453,50 +469,50 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     // we only support a single long-lived connection to our internal HTTP server. Since it's closed,
     // we'll need to shut it down entirely.
     this._httpServer.close();
-  }
+  };
 
   // Our internal HTTP Server has been closed (happens after we call this._httpServer.close() below)
   _onServerSocketError = (err: Error) => {
     debug("[%s] HTTP connection error: ", this._remoteAddress, err.message);
     // _onServerSocketClose will be called next
-  }
+  };
 
   _onHttpServerRequest = (request: IncomingMessage, response: OutgoingMessage) => {
     debug("[%s] HTTP request: %s", this._remoteAddress, request.url);
 
     // sign up to know when the response is ended, so we can safely send EVENT responses
-    response.on('finish', () => {
+    response.on("finish", () => {
       debug("[%s] HTTP Response is finished", this._remoteAddress);
       this._writingResponse = false;
       this._sendPendingEvents();
     });
     // pass it along to listeners
     this.emit(EventedHTTPServerEvents.REQUEST, request, response, this._session, this._events);
-  }
+  };
 
   _onHttpServerClose = () => {
     debug("[%s] HTTP server was closed", this._remoteAddress);
     // notify listeners that we are completely closed
     this.emit(EventedHTTPServerEvents.CLOSE, this._events);
-  }
+  };
 
   _onHttpServerError = (err: Error & { code?: string }) => {
     debug("[%s] HTTP server error: %s", this._remoteAddress, err.message);
-    if (err.code === 'EADDRINUSE') {
+    if (err.code === "EADDRINUSE") {
       this._httpServer.close();
       this._httpServer.listen(0);
     }
-  }
+  };
 
   _onClientSocketClose = () => {
     debug("[%s] Client connection closed", this._remoteAddress);
     // shutdown the other side
     this._serverSocket && this._serverSocket.destroy();
     this._session._connectionDestroyed();
-  }
+  };
 
   _onClientSocketError = (err: Error) => {
     debug("[%s] Client connection error: %s", this._remoteAddress, err.message);
     // _onClientSocketClose will be called next
-  }
+  };
 }

--- a/src/lib/util/hkdf.ts
+++ b/src/lib/util/hkdf.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto';
-import { BinaryLike } from './uuid';
+import crypto from "crypto";
+import { BinaryLike } from "./uuid";
 
 export function HKDF(hashAlg: string, salt: BinaryLike, ikm: BinaryLike, info: Buffer, size: number) {
   // create the hash alg to see if it exists and get its length
@@ -18,18 +18,14 @@ export function HKDF(hashAlg: string, salt: BinaryLike, ikm: BinaryLike, info: B
 
   info = Buffer.from(info);
 
-  for (var i=0; i<num_blocks; i++) {
+  for (var i = 0; i < num_blocks; i++) {
     var blockHmac = crypto.createHmac(hashAlg, prk);
 
-    var input = Buffer.concat([
-      prev,
-      info,
-      Buffer.from(String.fromCharCode(i + 1))
-    ]);
+    var input = Buffer.concat([prev, info, Buffer.from(String.fromCharCode(i + 1))]);
     blockHmac.update(input);
     prev = blockHmac.digest();
     buffers.push(prev);
   }
   output = Buffer.concat(buffers, size);
-  return output.slice(0,size);
+  return output.slice(0, size);
 }

--- a/src/lib/util/once.spec.ts
+++ b/src/lib/util/once.spec.ts
@@ -1,7 +1,7 @@
-import { once } from './once';
+import { once } from "./once";
 
-describe('#once()', () => {
-  it('should call a function once', () => {
+describe("#once()", () => {
+  it("should call a function once", () => {
     const spy = jest.fn();
     const callback = once(spy);
     callback();
@@ -9,14 +9,14 @@ describe('#once()', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('should throw an error if a function is called more than once', () => {
+  it("should throw an error if a function is called more than once", () => {
     const spy = jest.fn();
     const callback = once(spy);
     callback();
 
     expect(() => {
       callback();
-    }).toThrow(' already been called');
+    }).toThrow(" already been called");
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/util/once.ts
+++ b/src/lib/util/once.ts
@@ -3,9 +3,10 @@ export function once(func: Function) {
 
   return (...args: any[]) => {
     if (called) {
-      throw new Error("This callback function has already been called by someone else; it can only be called one time.");
-    }
-    else {
+      throw new Error(
+        "This callback function has already been called by someone else; it can only be called one time."
+      );
+    } else {
       called = true;
       return func(...args);
     }

--- a/src/lib/util/tlv.spec.ts
+++ b/src/lib/util/tlv.spec.ts
@@ -1,22 +1,20 @@
-import { decode, encode } from './tlv';
+import { decode, encode } from "./tlv";
 
-describe('#encode()', () => {
-
-  it('encodes a single value correctly in the TLV format', () => {
-    const encoded = encode(0, Buffer.from('ASD'))
+describe("#encode()", () => {
+  it("encodes a single value correctly in the TLV format", () => {
+    const encoded = encode(0, Buffer.from("ASD"));
 
     const result = decode(encoded);
-    expect(result[0].toString()).toEqual('ASD');
+    expect(result[0].toString()).toEqual("ASD");
   });
 
-  it('encodes multiple values correctly in the TLV format', () => {
-    const encoded = encode(0, Buffer.from('ASD'), 1, Buffer.from('QWE'))
+  it("encodes multiple values correctly in the TLV format", () => {
+    const encoded = encode(0, Buffer.from("ASD"), 1, Buffer.from("QWE"));
 
     const result = decode(encoded);
-    expect(result[0].toString()).toEqual('ASD');
-    expect(result[1].toString()).toEqual('QWE');
+    expect(result[0].toString()).toEqual("ASD");
+    expect(result[1].toString()).toEqual("QWE");
   });
 });
 
-describe('#decode()', () => {
-});
+describe("#decode()", () => {});

--- a/src/lib/util/tlv.ts
+++ b/src/lib/util/tlv.ts
@@ -4,156 +4,160 @@
  */
 
 export function encode(type: number, data: Buffer | number | string, ...args: any[]) {
+  var encodedTLVBuffer = Buffer.alloc(0);
 
-    var encodedTLVBuffer = Buffer.alloc(0);
+  // coerce data to Buffer if needed
+  if (typeof data === "number") data = Buffer.from([data]) as Buffer;
+  else if (typeof data === "string") data = Buffer.from(data) as Buffer;
 
-    // coerce data to Buffer if needed
-    if (typeof data === 'number')
-      data = Buffer.from([data]) as Buffer;
-    else if (typeof data === 'string')
-      data = Buffer.from(data) as Buffer;
+  if (data.length <= 255) {
+    encodedTLVBuffer = Buffer.concat([Buffer.from([type, data.length]), data]);
+  } else {
+    var leftLength = data.length;
+    var tempBuffer = Buffer.alloc(0);
+    var currentStart = 0;
 
-    if (data.length <= 255) {
-        encodedTLVBuffer = Buffer.concat([Buffer.from([type,data.length]),data]);
-    } else {
-        var leftLength = data.length;
-        var tempBuffer = Buffer.alloc(0);
-        var currentStart = 0;
-
-        for (; leftLength > 0;) {
-            if (leftLength >= 255) {
-                tempBuffer = Buffer.concat([tempBuffer,Buffer.from([type,0xFF]),data.slice(currentStart, currentStart + 255)]);
-                leftLength -= 255;
-                currentStart = currentStart + 255;
-            } else {
-                tempBuffer = Buffer.concat([tempBuffer,Buffer.from([type,leftLength]),data.slice(currentStart, currentStart + leftLength)]);
-                leftLength -= leftLength;
-            }
-        }
-
-        encodedTLVBuffer = tempBuffer;
+    for (; leftLength > 0; ) {
+      if (leftLength >= 255) {
+        tempBuffer = Buffer.concat([
+          tempBuffer,
+          Buffer.from([type, 0xff]),
+          data.slice(currentStart, currentStart + 255),
+        ]);
+        leftLength -= 255;
+        currentStart = currentStart + 255;
+      } else {
+        tempBuffer = Buffer.concat([
+          tempBuffer,
+          Buffer.from([type, leftLength]),
+          data.slice(currentStart, currentStart + leftLength),
+        ]);
+        leftLength -= leftLength;
+      }
     }
 
-    // do we have more to encode?
-    if (args.length >= 2) {
+    encodedTLVBuffer = tempBuffer;
+  }
 
-      // chop off the first two arguments which we already processed, and process the rest recursively
-      const [ nextType, nextData, ...nextArgs ] = args;
-      const remainingTLVBuffer = encode(nextType, nextData, ...nextArgs);
+  // do we have more to encode?
+  if (args.length >= 2) {
+    // chop off the first two arguments which we already processed, and process the rest recursively
+    const [nextType, nextData, ...nextArgs] = args;
+    const remainingTLVBuffer = encode(nextType, nextData, ...nextArgs);
 
-      // append the remaining encoded arguments directly to the buffer
-      encodedTLVBuffer = Buffer.concat([encodedTLVBuffer, remainingTLVBuffer]);
-    }
+    // append the remaining encoded arguments directly to the buffer
+    encodedTLVBuffer = Buffer.concat([encodedTLVBuffer, remainingTLVBuffer]);
+  }
 
-    return encodedTLVBuffer;
+  return encodedTLVBuffer;
 }
 
 export function decode(data: Buffer) {
+  var objects: Record<number, Buffer> = {};
 
-    var objects: Record<number, Buffer> = {};
+  var leftLength = data.length;
+  var currentIndex = 0;
 
-    var leftLength = data.length;
-    var currentIndex = 0;
+  for (; leftLength > 0; ) {
+    var type = data[currentIndex];
+    var length = data[currentIndex + 1];
+    currentIndex += 2;
+    leftLength -= 2;
 
-    for (; leftLength > 0;) {
-        var type = data[currentIndex];
-        var length = data[currentIndex+1];
-        currentIndex += 2;
-        leftLength -= 2;
+    var newData = data.slice(currentIndex, currentIndex + length);
 
-        var newData = data.slice(currentIndex, currentIndex+length);
-
-        if (objects[type]) {
-            objects[type] = Buffer.concat([objects[type],newData]);
-        } else {
-            objects[type] = newData;
-        }
-
-        currentIndex += length;
-        leftLength -= length;
+    if (objects[type]) {
+      objects[type] = Buffer.concat([objects[type], newData]);
+    } else {
+      objects[type] = newData;
     }
 
-    return objects;
+    currentIndex += length;
+    leftLength -= length;
+  }
+
+  return objects;
 }
 
 export function decodeList(data: Buffer, entryStartId: number) {
-    const objectsList: Record<number, Buffer>[] = [];
+  const objectsList: Record<number, Buffer>[] = [];
 
-    let leftLength = data.length;
-    let currentIndex = 0;
+  let leftLength = data.length;
+  let currentIndex = 0;
 
-    let objects: Record<number, Buffer> | undefined = undefined;
+  let objects: Record<number, Buffer> | undefined = undefined;
 
-    for (; leftLength > 0;) {
-        const type = data[currentIndex]; // T
-        const length = data[currentIndex + 1]; // L
-        const value = data.slice(currentIndex + 2, currentIndex + 2 + length); // V
+  for (; leftLength > 0; ) {
+    const type = data[currentIndex]; // T
+    const length = data[currentIndex + 1]; // L
+    const value = data.slice(currentIndex + 2, currentIndex + 2 + length); // V
 
-        if (type === entryStartId) { // we got the start of a new entry
-            if (objects !== undefined) { // save the previous entry
-                objectsList.push(objects);
-            }
+    if (type === entryStartId) {
+      // we got the start of a new entry
+      if (objects !== undefined) {
+        // save the previous entry
+        objectsList.push(objects);
+      }
 
-            objects = {};
-        }
-
-        if (objects === undefined)
-            throw new Error("Error parsing tlv list: Encountered uninitialized storage object");
-
-        if (objects[type]) { // append to buffer if we have an already data for this type
-            objects[type] = Buffer.concat([value, objects[type]]);
-        } else {
-            objects[type] = value;
-        }
-
-        currentIndex += 2 + length;
-        leftLength -= 2 + length;
+      objects = {};
     }
 
-    if (objects !== undefined)
-        objectsList.push(objects); // push last entry
+    if (objects === undefined) throw new Error("Error parsing tlv list: Encountered uninitialized storage object");
 
-    return objectsList;
+    if (objects[type]) {
+      // append to buffer if we have an already data for this type
+      objects[type] = Buffer.concat([value, objects[type]]);
+    } else {
+      objects[type] = value;
+    }
+
+    currentIndex += 2 + length;
+    leftLength -= 2 + length;
+  }
+
+  if (objects !== undefined) objectsList.push(objects); // push last entry
+
+  return objectsList;
 }
 
 export function writeUInt64(value: number) {
-    const float64 = new Float64Array(1);
-    float64[0] = value;
+  const float64 = new Float64Array(1);
+  float64[0] = value;
 
-    const buffer = Buffer.alloc(float64.buffer.byteLength);
-    const view = new Uint8Array(float64.buffer);
-    for (let i = 0; i < buffer.length; i++) {
-        buffer[i] = view[i];
-    }
+  const buffer = Buffer.alloc(float64.buffer.byteLength);
+  const view = new Uint8Array(float64.buffer);
+  for (let i = 0; i < buffer.length; i++) {
+    buffer[i] = view[i];
+  }
 
-    return buffer;
+  return buffer;
 }
 
 export function readUInt64(buffer: Buffer) {
-    const float64 = new Float64Array(buffer);
-    return float64[0];
+  const float64 = new Float64Array(buffer);
+  return float64[0];
 }
 
 export function writeUInt32(value: number) {
-    const buffer = Buffer.alloc(4);
+  const buffer = Buffer.alloc(4);
 
-    buffer.writeUInt32LE(value, 0);
+  buffer.writeUInt32LE(value, 0);
 
-    return buffer;
+  return buffer;
 }
 
 export function readUInt32(buffer: Buffer) {
-    return buffer.readUInt32LE(0);
+  return buffer.readUInt32LE(0);
 }
 
 export function writeUInt16(value: number) {
-    const buffer = Buffer.alloc(2);
+  const buffer = Buffer.alloc(2);
 
-    buffer.writeUInt16LE(value, 0);
+  buffer.writeUInt16LE(value, 0);
 
-    return buffer;
+  return buffer;
 }
 
 export function readUInt16(buffer: Buffer) {
-    return buffer.readUInt16LE(0);
+  return buffer.readUInt16LE(0);
 }

--- a/src/lib/util/uuid.ts
+++ b/src/lib/util/uuid.ts
@@ -1,20 +1,20 @@
-import crypto from 'crypto';
+import crypto from "crypto";
 
 type Binary = Buffer | NodeJS.TypedArray | DataView;
 export type BinaryLike = string | Binary;
 
 // http://stackoverflow.com/a/25951500/66673
 export function generate(data: BinaryLike) {
-  const sha1sum = crypto.createHash('sha1');
+  const sha1sum = crypto.createHash("sha1");
   sha1sum.update(data);
-  const s = sha1sum.digest('hex');
+  const s = sha1sum.digest("hex");
   let i = -1;
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c: string) => {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c: string) => {
     i += 1;
     switch (c) {
-      case 'y':
-        return ((parseInt('0x' + s[i], 16) & 0x3) | 0x8).toString(16);
-      case 'x':
+      case "y":
+        return ((parseInt("0x" + s[i], 16) & 0x3) | 0x8).toString(16);
+      case "x":
       default:
         return s[i];
     }
@@ -30,14 +30,28 @@ export function isValid(UUID: string) {
 // https://github.com/defunctzombie/node-uuid/blob/master/uuid.js
 export function unparse(buf: Buffer | string, offset: number = 0) {
   let i = offset;
-  return buf[i++].toString(16) + buf[i++].toString(16) +
-         buf[i++].toString(16) + buf[i++].toString(16) + '-' +
-         buf[i++].toString(16) + buf[i++].toString(16) + '-' +
-         buf[i++].toString(16) + buf[i++].toString(16) + '-' +
-         buf[i++].toString(16) + buf[i++].toString(16) + '-' +
-         buf[i++].toString(16) + buf[i++].toString(16) +
-         buf[i++].toString(16) + buf[i++].toString(16) +
-         buf[i++].toString(16) + buf[i++].toString(16);
+  return (
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    "-" +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    "-" +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    "-" +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    "-" +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    buf[i++].toString(16) +
+    buf[i++].toString(16)
+  );
 }
 
 export function write(uuid: string, buf: Buffer, offset: number = 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { Status } from './lib/HAPServer';
-import { Characteristic, CharacteristicProps } from './lib/Characteristic';
+import { Status } from "./lib/HAPServer";
+import { Characteristic, CharacteristicProps } from "./lib/Characteristic";
 
 export type Nullable<T> = T | null;
 
@@ -15,14 +15,16 @@ export type VoidCallback = (err?: Nullable<Error>) => void;
 export type PairingsCallback<T> = (err: number, data?: T) => void;
 export type PrimitiveTypes = string | number | boolean;
 
-type HAPProps =
-  Pick<CharacteristicProps, 'perms' | 'format' | 'description' | 'unit' | 'maxValue' | 'minValue' | 'minStep' | 'maxLen'>
-  & Pick<Characteristic, 'valid-values' | 'valid-values-range'>
+type HAPProps = Pick<
+  CharacteristicProps,
+  "perms" | "format" | "description" | "unit" | "maxValue" | "minValue" | "minStep" | "maxLen"
+> &
+  Pick<Characteristic, "valid-values" | "valid-values-range">;
 export type HapCharacteristic = HAPProps & {
   iid: number;
   type: string;
   value: string | number | {} | null;
-}
+};
 export type CharacteristicValue = PrimitiveTypes | PrimitiveTypes[] | { [key: string]: PrimitiveTypes };
 export type CharacteristicChange = {
   newValue: CharacteristicValue;
@@ -38,7 +40,7 @@ export type HapService = {
   primary: boolean;
   hidden: boolean;
   linked: number[];
-}
+};
 
 export type CharacteristicData = {
   aid: number;
@@ -50,15 +52,15 @@ export type CharacteristicData = {
   e?: string;
   ev?: boolean;
   r?: boolean;
-}
+};
 export type AudioCodec = {
   samplerate: number;
   type: string;
-}
+};
 export type VideoCodec = {
   levels: number[];
   profiles: number[];
-}
+};
 export type Source = {
   port: number;
   srtp_key: Buffer;
@@ -69,8 +71,8 @@ export type Source = {
 };
 export type Address = {
   address: string;
-  type: 'v4' | 'v6';
-}
+  type: "v4" | "v6";
+};
 export type AudioInfo = {
   codec: string | number;
   channel: number;

--- a/src/types/bonjour-hap.d.ts
+++ b/src/types/bonjour-hap.d.ts
@@ -1,8 +1,7 @@
-declare module 'bonjour-hap' {
-
+declare module "bonjour-hap" {
   export enum Protocols {
-    TCP = 'tcp',
-    UDP = 'udp',
+    TCP = "tcp",
+    UDP = "udp",
   }
 
   export type Nullable<T> = T | null;
@@ -26,7 +25,7 @@ declare module 'bonjour-hap' {
   }
 
   export type PublishOptions = {
-    category?: any,
+    category?: any;
     host?: string;
     name?: string;
     pincode?: string;
@@ -43,7 +42,6 @@ declare module 'bonjour-hap' {
     unpublishAll(callback: () => void): void;
     destroy(): void;
   }
-
 
   export type MulticastOptions = {
     multicast: boolean;

--- a/src/types/fast-srp-hap.d.ts
+++ b/src/types/fast-srp-hap.d.ts
@@ -1,5 +1,4 @@
-declare module 'fast-srp-hap' {
-
+declare module "fast-srp-hap" {
   export const params: Record<string, any>;
   export function genKey(num: number, callback: (err: Error, key: Buffer) => void): void;
 

--- a/src/types/node-persist.d.ts
+++ b/src/types/node-persist.d.ts
@@ -1,4 +1,4 @@
-declare module 'node-persist' {
+declare module "node-persist" {
   export function create(): any;
 
   export function initSync(opts?: { dir: string }): void;

--- a/src/types/simple-plist.d.ts
+++ b/src/types/simple-plist.d.ts
@@ -1,3 +1,3 @@
-declare module 'simple-plist' {
+declare module "simple-plist" {
   export function readFileSync(path: string): Record<string, any>;
 }


### PR DESCRIPTION
While I was digging around this codebase for #763 I noticed that there were a few different code formatting styles in use. For ease of future contributions I installed prettier and configured it to match the current code style as closely as possible. I also updated the `Node-CI` GitHub action to run prettier with the `--check` flag to ensure that prettier has been run on subsequent commits.

To format, you can either configure your editor to format with prettier on save or you can run `npm run format` to reformat code in the `src` folder.

The prettier config (in `package.json`) could do with some opinions. Feel free to modify it or request changes!