### PR TITLE
Adding CD using GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,3 +25,22 @@ jobs:
           npm test
         env:
           CI: true
+
+  publish-npm:
+    # publish should only ran on 'push' event and if a version tag was created
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    needs: build # only run if build succeeds
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10 # use the minimum required version
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
Added a second job which automatically publishes the npm package.

It does only run if all previous build jobs were successful, the triggering event was `push` (so it doesn't run for pull_request or other future events) and the job got executed because a new version tag (a tag that starts with v; we cannot really use regex to match the version string exactly) was pushed.

For this to work you would need to add a secret called `npm_token` to the project (via settings) which contains a npm publish token.

Edit: You could also create a completely new workflow for publishing which only runs on the 'release' event. However you would then need to manually create a new release in GitHub to trigger this event. As this project didn't create a single GitHub release, I think checking for tags is probably the better way.