### PR TITLE
Added a working version of windows to the ci job; added a 'clean' script.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-2016]
 
     runs-on: ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "typescript": "^3.5.3"
   },
   "scripts": {
-    "build": "rimraf dist/ && tsc",
+    "clean": "rimraf dist/",
+    "build": "npm run clean && tsc",
     "prepublishOnly": "npm run build",
     "test": "jest",
     "start": "node dist/BridgedCore.js"


### PR DESCRIPTION
It seems that jest only crashes on the latest version of the windows image. `windows-2016` is the newest available version on which jest doesn't crash 🤷🏽‍♂️

Additionally I added a clean script (`npm run clean`) to easily delete the build folder.