### PR TITLE
Improve setPrimaryService API a bit

### DIFF
--- a/src/accessories/AirConditioner_accessory.ts
+++ b/src/accessories/AirConditioner_accessory.ts
@@ -92,6 +92,7 @@ FanService.addCharacteristic(Characteristic.RotationSpeed)
 
 var ThermostatService = ACTest.addService(Service.Thermostat,"Thermostat");
 ThermostatService.addLinkedService(FanService);
+ThermostatService.setPrimaryService();
 
 ThermostatService.getCharacteristic(Characteristic.CurrentHeatingCoolingState)!
 
@@ -156,5 +157,4 @@ LightService.getCharacteristic(Characteristic.On)!
       console.log( "Characteristic Light On changed to %s",value);
       callback();
     });
-LightService.setHiddenService(true);
-ACTest.setPrimaryService(ThermostatService);
+LightService.setHiddenService();

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -182,6 +182,7 @@ export class Accessory extends EventEmitter<Events> {
   cameraSource: Nullable<Camera> = null;
   category: Categories = Categories.OTHER;
   services: Service[] = [];
+  private primaryService?: Service;
   shouldPurgeUnusedIDs: boolean = true; // Purge unused ids by default
 
   _accessoryInfo?: Nullable<AccessoryInfo>;
@@ -232,12 +233,12 @@ export class Accessory extends EventEmitter<Events> {
     }
   }
 
-  addService = (service: Service | typeof Service, ...constructorArgs: any[]) => {
+  addService = (serviceParam: Service | typeof Service, ...constructorArgs: any[]) => {
     // service might be a constructor like `Service.AccessoryInformation` instead of an instance
     // of Service. Coerce if necessary.
-    if (typeof service === 'function')
-      service = new service(constructorArgs[0], constructorArgs[1], constructorArgs[2]) as Service;
-      // service = new (Function.prototype.bind.apply(service, arguments));
+    const service: Service = typeof serviceParam === 'function'
+        ? new serviceParam(constructorArgs[0], constructorArgs[1], constructorArgs[2])
+        : serviceParam;
 
     // check for UUID+subtype conflict
     for (var index in this.services) {
@@ -254,6 +255,14 @@ export class Accessory extends EventEmitter<Events> {
 
     this.services.push(service);
 
+    if (service.isPrimaryService) { // check if a primary service was added
+      if (this.primaryService !== undefined) {
+        this.primaryService.isPrimaryService = false;
+      }
+
+      this.primaryService = service;
+    }
+
     if (!this.bridged) {
       this._updateConfiguration();
     } else {
@@ -261,6 +270,18 @@ export class Accessory extends EventEmitter<Events> {
     }
 
     service.on(ServiceEventTypes.SERVICE_CONFIGURATION_CHANGE, (change: ServiceConfigurationChange) => {
+      if (!service.isPrimaryService && service === this.primaryService) {
+        // service changed form primary to non primary service
+        this.primaryService = undefined;
+      } else if (service.isPrimaryService && service !== this.primaryService) {
+        // service changed from non primary to primary service
+        if (this.primaryService !== undefined) {
+          this.primaryService.isPrimaryService = false;
+        }
+
+        this.primaryService = service;
+      }
+
       if (!this.bridged) {
         this._updateConfiguration();
       } else {
@@ -281,48 +302,22 @@ export class Accessory extends EventEmitter<Events> {
     return service;
   }
 
+  /**
+   * @deprecated use {@link Service.setPrimaryService} directly
+   */
   setPrimaryService = (service: Service) => {
-      //find this service in the services list
-      let targetServiceIndex, existingService: Service;
-      for (let index in this.services) {
-        existingService = this.services[index];
-
-        if (existingService === service) {
-          targetServiceIndex = index;
-          break;
-        }
-      }
-
-      if (targetServiceIndex) {
-        //If the service is found, set isPrimaryService to false for everything.
-        for (let index in this.services)
-          this.services[index].isPrimaryService = false;
-
-        //Make this service the primary
-        existingService!.isPrimaryService = true
-
-        if (!this.bridged) {
-          this._updateConfiguration();
-        } else {
-          this.emit(AccessoryEventTypes.SERVICE_CONFIGURATION_CHANGE, clone({ accessory: this, service: service }));
-        }
-      }
-  }
+    service.setPrimaryService();
+  };
 
   removeService = (service: Service) => {
-    let targetServiceIndex: number | undefined = undefined;
+    const index = this.services.indexOf(service);
 
-    for (let index in this.services) {
-      var existingService = this.services[index];
+    if (index >= 0) {
+      this.services.splice(index, 1);
 
-      if (existingService === service) {
-        targetServiceIndex = Number.parseInt(index);
-        break;
+      if (this.primaryService === service) { // check if we are removing out primary service
+        this.primaryService = undefined;
       }
-    }
-
-    if (targetServiceIndex) {
-      this.services.splice(targetServiceIndex, 1);
 
       if (!this.bridged) {
         this._updateConfiguration();

--- a/src/lib/HomeKitRemoteController.ts
+++ b/src/lib/HomeKitRemoteController.ts
@@ -480,7 +480,6 @@ export class HomeKitRemoteController extends EventEmitter<RemoteControllerEventM
         }
 
         accessory.addService(this.targetControlManagementService);
-        accessory.setPrimaryService(this.targetControlManagementService);
         accessory.addService(this.targetControlService);
 
         if (this.audioSupported) {
@@ -1132,6 +1131,7 @@ export class HomeKitRemoteController extends EventEmitter<RemoteControllerEventM
             .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
                 this.handleTargetControlWrite(value, callback);
             }).getValue();
+        this.targetControlManagementService.setPrimaryService();
 
         // you can also expose multiple TargetControl services to control multiple apple tvs simultaneously.
         // should we extend this class to support multiple TargetControl services or should users just create a second accessory?

--- a/src/lib/Service.ts
+++ b/src/lib/Service.ts
@@ -144,7 +144,7 @@ export class Service extends EventEmitter<Events> {
   characteristics: Characteristic[] = [];
   optionalCharacteristics: Characteristic[] = [];
   isHiddenService: boolean = false;
-  isPrimaryService: boolean = false;
+  isPrimaryService: boolean = false; // do not write to this directly
   linkedServices: Service[] = [];
 
   constructor(public displayName: string, public UUID: string, public subtype: string) {
@@ -195,8 +195,25 @@ export class Service extends EventEmitter<Events> {
     return characteristic;
   }
 
-//Defines this service as hidden
-  setHiddenService = (isHidden: boolean) => {
+  /**
+   * Sets this service as the new primary service.
+   * Any currently active primary service will be reset to be not primary.
+   * This will happen immediately, if the service was already added to an accessory, or later
+   * when the service gets added to an accessory.
+   *
+   * @param isPrimary {boolean} - optional boolean (default true) if the service should be the primary service
+   */
+  setPrimaryService = (isPrimary: boolean = true) => {
+    this.isPrimaryService = isPrimary;
+    this.emit(ServiceEventTypes.SERVICE_CONFIGURATION_CHANGE, clone({ service: this }));
+  };
+
+  /**
+   * Marks the service as hidden
+   *
+   * @param isHidden {boolean} - optional boolean (default true) if the service should be marked hidden
+   */
+  setHiddenService = (isHidden: boolean = true) => {
     this.isHiddenService = isHidden;
     this.emit(ServiceEventTypes.SERVICE_CONFIGURATION_CHANGE, clone({ service: this }));
   }


### PR DESCRIPTION
Simplified the setPrimaryService API call a bit.

`setPrimaryService` is now a member of the Service class (the old method in the Accessory class got deprecated and just forwards the call to this method). So now primary, hidden and linked service management is all at the same place. This enables homebridge plugin devs to set primary services (wasn't really possible before).

Removing primary services and adding them again could lead to multiple primary services. This is now taken care of correctly.