### PR TITLE
Ability to catch 'EADDRINUSE'

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -90,6 +90,7 @@ export enum AccessoryEventTypes {
   SERVICE_CHARACTERISTIC_CHANGE = "service-characteristic-change",
   PAIRED = "paired",
   UNPAIRED = "unpaired",
+  ADDRESS_IN_USE = "address-in-use"
 }
 
 type Events = {
@@ -99,6 +100,7 @@ type Events = {
   "service-characteristic-change": (change: ServiceCharacteristicChange) => void;
   [AccessoryEventTypes.PAIRED]: () => void;
   [AccessoryEventTypes.UNPAIRED]: () => void;
+  [AccessoryEventTypes.ADDRESS_IN_USE]: (port: number) => void;
 }
 
 /**
@@ -724,6 +726,7 @@ export class Accessory extends EventEmitter<Events> {
     this._server.on(HAPServerEventTypes.SET_CHARACTERISTICS, this._handleSetCharacteristics);
     this._server.on(HAPServerEventTypes.SESSION_CLOSE, this._handleSessionClose);
     this._server.on(HAPServerEventTypes.REQUEST_RESOURCE, this._handleResource);
+    this._server.on(HAPServerEventTypes.ADDRESS_IN_USE, this._handleAddInUse);
 
     const targetPort = info.port || 0;
     this._server.listen(targetPort);
@@ -786,6 +789,11 @@ export class Accessory extends EventEmitter<Events> {
     // the HAP server is listening, so we can now start advertising our presence.
     this._advertiser && this._advertiser.startAdvertising(port);
     this.emit(AccessoryEventTypes.LISTENING, port);
+  }
+                                   
+  _handleAddInUse = (port: number) => {
+      // Network port is already in use
+      this.emit(AccessoryEventTypes.ADDRESS_IN_USE, port);
   }
 
 // Called when an unpaired client wishes for us to identify ourself

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -126,7 +126,8 @@ export enum HAPServerEventTypes {
   GET_CHARACTERISTICS = 'get-characteristics',
   SET_CHARACTERISTICS = 'set-characteristics',
   SESSION_CLOSE = "session-close",
-  REQUEST_RESOURCE = 'request-resource'
+  REQUEST_RESOURCE = 'request-resource',
+  ADDRESS_IN_USE = 'address-in-use'
 }
 
 export type Events = {
@@ -137,6 +138,7 @@ export type Events = {
   [HAPServerEventTypes.REMOVE_PAIRING]: (controller: Session, username: string, callback: PairingsCallback<void>) => void;
   [HAPServerEventTypes.LIST_PAIRINGS]: (controller: Session, callback: PairingsCallback<PairingInformation[]>) => void;
   [HAPServerEventTypes.ACCESSORIES]: (cb: NodeCallback<Accessory[]>) => void;
+  [HAPServerEventTypes.ADDRESS_IN_USE]: (port: number) => void;
   [HAPServerEventTypes.GET_CHARACTERISTICS]: (
     data: CharacteristicData[],
     events: CharacteristicEvents,
@@ -247,6 +249,7 @@ export class HAPServer extends EventEmitter<Events> {
     this._httpServer.on(EventedHTTPServerEvents.ENCRYPT, this._onEncrypt);
     this._httpServer.on(EventedHTTPServerEvents.DECRYPT, this._onDecrypt);
     this._httpServer.on(EventedHTTPServerEvents.SESSION_CLOSE, this._onSessionClose);
+    this._httpServer.on(EventedHTTPServerEvents.ADDRESS_IN_USE, this._onAddInUseError);
     if (relayServer) {
       this._relayServer = relayServer;
       this._relayServer.on('request', this._onRemoteRequest);
@@ -297,6 +300,10 @@ export class HAPServer extends EventEmitter<Events> {
 
   _onListening = (port: number) => {
     this.emit(HAPServerEventTypes.LISTENING, port);
+  }
+  
+  _onAddInUseError = (port: number) => {
+      this.emit(HAPServerEventTypes.ADDRESS_IN_USE, port);
   }
 
   // Called when an HTTP request was detected.

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -18,7 +18,7 @@ export enum EventedHTTPServerEvents {
   ENCRYPT = 'encrypt',
   CLOSE = 'close',
   SESSION_CLOSE = 'session-close',
-  ADDRESS_IN_USE = 'address-in-use',
+  ADDRESS_IN_USE = 'address-in-use'
 }
 
 export type Events = {


### PR DESCRIPTION
So,
This will be my first ever PR on github (I'm kind of the new kid around here) - Be Gentle.

I use HAP-NodeJS in a non-bridged manner, in essence, I have created a collection of nodes for Node-Red, that contains (currently) 10 pre-configured, fully functional devices, including most of the optional characteristics, to make them as fully featured & ready to use as possible. 

After much studying (and of course testing), I understand we can be notified, when an Accessory has instantiated, by subscribing to `LISTENING`.

However, if one were to not change the listening port (Nodes can be copied/pasted retaining its port assignments), all hell breaks loose, and you end up with a crashed Node-Red environment (or any other host potentially that HAP is running under).

My modifications are to introduce an `ADDRESS_IN_USE ` event, that bubbles up through to the Accessory object.

What we end up with, is either the `LISTENING` or `ADDRESS_IN_USE` event being raised, with no crashed environment, allowing the developer to handle it, in much better way.

Testing this approach seems to have the desired affect.

