### PR TITLE
Add helpers for async characteristic get/set handlers

### DIFF
--- a/src/accessories/Fan_accessory.ts
+++ b/src/accessories/Fan_accessory.ts
@@ -6,97 +6,122 @@ import {
   Characteristic,
   CharacteristicEventTypes, CharacteristicSetCallback,
   CharacteristicValue,
+  Formats,
+  Perms,
   NodeCallback,
   Service,
   uuid,
-  VoidCallback
+  VoidCallback,
 } from '..';
 
-var FAKE_FAN: Record<string, any> = {
+const FAKE_FAN = {
   powerOn: false,
   rSpeed: 100,
-  setPowerOn: (on: CharacteristicValue) => {
-    if(on){
+  async setPowerOn(on: boolean) {
+    if (on) {
       //put your code here to turn on the fan
       FAKE_FAN.powerOn = on;
-    }
-    else{
+    } else {
       //put your code here to turn off the fan
       FAKE_FAN.powerOn = on;
     }
   },
-  setSpeed: (value: CharacteristicValue) => {
+  async setSpeed(value: number) {
     console.log("Setting fan rSpeed to %s", value);
     FAKE_FAN.rSpeed = value;
     //put your code here to set the fan to a specific value
   },
-  identify: () => {
+  async identify() {
     //put your code here to identify the fan
     console.log("Fan Identified!");
   }
 }
 
 // This is the Accessory that we'll return to HAP-NodeJS that represents our fake fan.
-var fan = exports.accessory = new Accessory('Fan', uuid.generate('hap-nodejs:accessories:Fan'));
+export const accessory = new Accessory('Fan', uuid.generate('hap-nodejs:accessories:Fan'));
 
 // Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
 // @ts-ignore
-fan.username = "1A:2B:3C:4D:5E:FF";
+accessory.username = "1A:2B:3C:4D:5E:FF";
 // @ts-ignore
-fan.pincode = "031-45-154";
+accessory.pincode = "031-45-154";
 // @ts-ignore
-fan.category = Categories.FAN;
+accessory.category = Categories.FAN;
 
 // set some basic properties (these values are arbitrary and setting them is optional)
-fan
+accessory
   .getService(Service.AccessoryInformation)!
-  .setCharacteristic(Characteristic.Manufacturer, "Sample Company")
+  .setCharacteristic(Characteristic.Manufacturer, "Philips Lighting")
 
 // listen for the "identify" event for this Accessory
-fan.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback) => {
-  FAKE_FAN.identify();
-  callback(); // success
+accessory.on(AccessoryEventTypes.IDENTIFY, async (paired: boolean, callback: VoidCallback) => {
+  try {
+    FAKE_FAN.identify();
+    callback(); // success
+  } catch (err) {
+    callback(err);
+  }
 });
 
-// Add the actual Fan Service and listen for change events from iOS.
-// We can see the complete list of Services and Characteristics in `lib/gen/HomeKit.ts`
-fan
+accessory
+  // Add the actual Fan Service and listen for change events from iOS.
+  // We can see the complete list of Services and Characteristics in `lib/gen/HomeKit.ts`
   .addService(Service.Fan, "Fan") // services exposed to the user should have "names" like "Fake Light" for us
   .getCharacteristic(Characteristic.On)!
-  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-    FAKE_FAN.setPowerOn(value);
-    callback(); // Our fake Fan is synchronous - this value has been successfully set
-  });
+  .setHandler(async (value: CharacteristicValue) => {
+    await FAKE_FAN.setPowerOn(value as boolean);
+  })
 
-// We want to intercept requests for our current power state so we can query the hardware itself instead of
-// allowing HAP-NodeJS to return the cached Characteristic.value.
-fan
-  .getService(Service.Fan)!
-  .getCharacteristic(Characteristic.On)!
-  .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
+  // We want to intercept requests for our current power state so we can query the hardware itself instead of
+  // allowing HAP-NodeJS to return the cached Characteristic.value.
+  .getHandler(() => {
 
     // this event is emitted when you ask Siri directly whether your fan is on or not. you might query
     // the fan hardware itself to find this out, then call the callback. But if you take longer than a
     // few seconds to respond, Siri will give up.
 
     var err = null; // in case there were any problems
+    if (err) throw err;
 
     if (FAKE_FAN.powerOn) {
-      callback(err, true);
-    }
-    else {
-      callback(err, false);
+      return true;
+    } else {
+      return false;
     }
   });
 
 // also add an "optional" Characteristic for speed
-fan
+accessory
   .getService(Service.Fan)!
   .addCharacteristic(Characteristic.RotationSpeed)
-  .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-    callback(null, FAKE_FAN.rSpeed);
+  .getHandler(async () => {
+    return FAKE_FAN.rSpeed;
   })
-  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-    FAKE_FAN.setSpeed(value);
-    callback();
-  })
+  .setHandler(async (value: CharacteristicValue) => {
+    await FAKE_FAN.setSpeed(value as number);
+  });
+
+/**
+ * A custom characteristic that mirrors the fan's power state.
+ */
+class CustomCharacteristic extends Characteristic {
+  static readonly UUID = uuid.generate('hap-nodejs:custom-characteristics:MirrorPowerState');
+
+  constructor(public readonly fan: typeof FAKE_FAN) {
+    super('Custom Characteristic', CustomCharacteristic.UUID, {
+      format: Formats.BOOL,
+      perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
+    });
+  }
+
+  [Characteristic.GetValueHandler]() {
+    return this.fan.powerOn;
+  }
+
+  async [Characteristic.SetValueHandler](value: CharacteristicValue) {
+    await this.fan.setPowerOn(value as boolean);
+  }
+}
+
+// @ts-ignore
+accessory.getService(Service.Fan)!.addCharacteristic(CustomCharacteristic, FAKE_FAN);


### PR DESCRIPTION
This adds two methods for using async functions as characteristic get/set handlers. This also works for get/set handlers that don't make any asynchronous calls so they can just return/throw instead of using a callback.

#### `characteristic.getHandler(...)`, `characteristic.setHandler(...)`

```ts
characteristic.getHandler(async () => {
    // Get the value asynchronously...
});
characteristic.setHandler(async value => {
    // Set the value asynchronously...
});
```

#### Extending the Characteristic class/a predefined Characteristic

```ts
class FanOnCharacteristic extends Characteristic.On {
    constructor(public readonly fan: Fan) {
        super();
    }

    async [Characteristic.GetValueHandler]() {
        // Get the value asynchronously...
    }

    async [Characteristic.SetValueHandler]() {
        // Set the value asynchronously...
    }
}
```
