### PR TITLE
Add support for promise based Characteristic setters and getters

### DIFF
--- a/src/accessories/Fan_accessory.ts
+++ b/src/accessories/Fan_accessory.ts
@@ -4,9 +4,7 @@ import {
   AccessoryEventTypes,
   Categories,
   Characteristic,
-  CharacteristicEventTypes, CharacteristicSetCallback,
   CharacteristicValue,
-  NodeCallback,
   Service,
   uuid,
   VoidCallback
@@ -62,9 +60,8 @@ fan.on(AccessoryEventTypes.IDENTIFY, (paired: boolean, callback: VoidCallback) =
 fan
   .addService(Service.Fan, "Fan") // services exposed to the user should have "names" like "Fake Light" for us
   .getCharacteristic(Characteristic.On)!
-  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+  .onSet((value) => {
     FAKE_FAN.setPowerOn(value);
-    callback(); // Our fake Fan is synchronous - this value has been successfully set
   });
 
 // We want to intercept requests for our current power state so we can query the hardware itself instead of
@@ -72,19 +69,17 @@ fan
 fan
   .getService(Service.Fan)!
   .getCharacteristic(Characteristic.On)!
-  .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
+  .onGet(() => {
 
     // this event is emitted when you ask Siri directly whether your fan is on or not. you might query
     // the fan hardware itself to find this out, then call the callback. But if you take longer than a
     // few seconds to respond, Siri will give up.
 
-    const err = null; // in case there were any problems
-
     if (FAKE_FAN.powerOn) {
-      callback(err, true);
+      return true;
     }
     else {
-      callback(err, false);
+      return false;
     }
   });
 
@@ -92,10 +87,9 @@ fan
 fan
   .getService(Service.Fan)!
   .addCharacteristic(Characteristic.RotationSpeed)
-  .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-    callback(null, FAKE_FAN.rSpeed);
+  .onGet(async () => {
+    return FAKE_FAN.rSpeed;
   })
-  .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+  .onSet(async (value) => {
     FAKE_FAN.setSpeed(value);
-    callback();
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export * from './lib/controller';
 export * from './lib/util/clone';
 export * from './lib/util/once';
 export * from './lib/util/tlv';
+export * from './lib/util/hapStatusError';
 
 export * from './types';
 export const LegacyTypes = legacyTypes;

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -8,6 +8,7 @@ import { HAPStatus } from "./HAPServer";
 import { IdentifierCache } from './model/IdentifierCache';
 import { clone } from "./util/clone";
 import { HAPConnection } from "./util/eventedhttp";
+import { HapStatusError } from './util/hapStatusError';
 import { once } from './util/once';
 import { toShortForm } from './util/uuid';
 
@@ -490,6 +491,9 @@ export class Characteristic extends EventEmitter {
   status: HAPStatus = HAPStatus.SUCCESS;
   props: CharacteristicProps;
 
+  private getHandler?: () => Promise<Nullable<CharacteristicValue>> | Nullable<CharacteristicValue>;
+  private setHandler?: (value: CharacteristicValue) => Promise<Nullable<CharacteristicValue> | void> | Nullable<CharacteristicValue> | void;
+
   private subscriptions: number = 0;
   /**
    * @internal
@@ -506,6 +510,50 @@ export class Characteristic extends EventEmitter {
     };
 
     this.setProps(props || {}); // ensure sanity checks are called
+  }
+
+  /**
+   * Accepts a function that will be called to retrieve the current value of a Characteristic.
+   * The function must return a valid Characteristic value for the Characteristic type.
+   * May optionally return a promise.
+   * 
+   * @example
+   * ```ts
+   * Characteristic.onGet(async () => {
+   *   return true;
+   * });
+   * ```
+   * @param handler
+   */
+  public onGet(handler: () => Promise<Nullable<CharacteristicValue>> | Nullable<CharacteristicValue>) {
+    if (typeof handler !== 'function' || handler.length !== 0) {
+      console.warn(`[${this.displayName}] .onGet handler must be a function with exactly zero input arguments.`);
+      return this;
+    }
+    this.getHandler = handler;
+    return this;
+  }
+
+  /**
+   * Accepts a function that will be called when setting the value of a Characteristic.
+   * If the Characteristic expects a set response value, the returned value will be used.
+   * May optionally return a promise.
+   * 
+   * @example
+   * ```ts
+   * Characteristic.onSet(async (value: CharacteristicValue) => {
+   *   console.log(value);
+   * });
+   * ```
+   * @param handler
+   */
+  public onSet(handler: (value: CharacteristicValue) => Promise<Nullable<CharacteristicValue> | void> | Nullable<CharacteristicValue> | void) {
+    if (typeof handler !== 'function' || handler.length !== 1) {
+      console.warn(`[${this.displayName}] .onSet handler must be a function with exactly one input argument.`);
+      return this;
+    }
+    this.setHandler = handler;
+    return this;
   }
 
   /**
@@ -712,7 +760,7 @@ export class Characteristic extends EventEmitter {
    * @param context - Deprecated parameter. There for backwards compatibility.
    * @internal Used by the Accessory to load the characteristic value
    */
-  handleGetRequest(connection?: HAPConnection, context?: any): Promise<Nullable<CharacteristicValue>> {
+  async handleGetRequest(connection?: HAPConnection, context?: any): Promise<Nullable<CharacteristicValue>> {
     if (!this.props.perms.includes(Perms.PAIRED_READ)) { // check if we are allowed to read from this characteristic
       return Promise.reject(HAPStatus.WRITE_ONLY_CHARACTERISTIC);
     }
@@ -720,6 +768,33 @@ export class Characteristic extends EventEmitter {
     if (this.UUID === Characteristic.ProgrammableSwitchEvent.UUID) {
       // special workaround for event only programmable switch event, which must always return null
       return Promise.resolve(null);
+    }
+
+    if (this.getHandler) {
+      if (this.listeners(CharacteristicEventTypes.GET).length > 0) {
+        console.warn(`[${this.displayName}] Ignoring on('get') handler as onGet handler was defined instead.`);
+      }
+
+      try {
+        let value = await this.getHandler();
+        this.status = HAPStatus.SUCCESS;
+        value = this.validateUserInput(value);
+        const oldValue = this.value;
+        this.value = value;
+
+        if (oldValue !== value) { // emit a change event if necessary
+          this.emit(CharacteristicEventTypes.CHANGE, { originator: connection, oldValue: oldValue, newValue: value, context: context });
+        }
+      } catch (error) {
+        if (error instanceof HapStatusError) {
+          this.status = (error as HapStatusError).hapStatus;
+          throw this.status;
+        } else {
+          console.warn(`[${this.displayName}] Unhandled error thrown inside read handler for characteristic: ${error.stack}`);
+          this.status = HAPStatus.SERVICE_COMMUNICATION_FAILURE;
+          throw HAPStatus.SERVICE_COMMUNICATION_FAILURE;
+        }
+      }
     }
 
     if (this.listeners(CharacteristicEventTypes.GET).length === 0) {
@@ -732,6 +807,8 @@ export class Characteristic extends EventEmitter {
           if (status) {
             if (typeof status === "number") {
               this.status = status;
+            } else if (status instanceof HapStatusError) {
+              this.status = (status as HapStatusError).hapStatus;
             } else {
               this.status = extractHAPStatusFromError(status);
               debug("[%s] Received error from get handler %s", this.displayName, status.stack);
@@ -771,7 +848,7 @@ export class Characteristic extends EventEmitter {
    *  write response value is resolved.
    * @internal
    */
-  handleSetRequest(value: CharacteristicValue, connection?: HAPConnection, context?: any): Promise<CharacteristicValue | void> {
+  async handleSetRequest(value: CharacteristicValue, connection?: HAPConnection, context?: any): Promise<CharacteristicValue | void> {
     this.status = HAPStatus.SUCCESS;
 
     if (!this.validClientSuppliedValue(value)) {
@@ -783,6 +860,38 @@ export class Characteristic extends EventEmitter {
     }
 
     const oldValue = this.value;
+
+    if (this.setHandler) {
+      if (this.listeners(CharacteristicEventTypes.SET).length > 0) {
+        console.warn(`[${this.displayName}] Ignoring on('set') handler as onSet handler was defined instead.`);
+      }
+
+      try {
+        const writeResponse = await this.setHandler(value);
+        this.status = HAPStatus.SUCCESS;
+
+        if (writeResponse != null && writeResponse !== undefined && this.props.perms.includes(Perms.WRITE_RESPONSE)) {
+          this.value = writeResponse;
+        } else {
+          if (writeResponse != null && writeResponse !== undefined) {
+            console.warn(`[${this.displayName}] SET handler returned write response value, though the characteristic doesn't support write response!`);
+          }
+          this.value = value;
+        }
+
+        this.emit(CharacteristicEventTypes.CHANGE, { originator: connection, oldValue: oldValue, newValue: value, context: context });
+        return this.value;
+      } catch (error) {
+        if (error instanceof HapStatusError) {
+          this.status = (error as HapStatusError).hapStatus;
+          throw this.status;
+        } else {
+          console.warn(`[${this.displayName}] Unhandled error thrown inside write handler for characteristic: ${error.stack}`);
+          this.status = HAPStatus.SERVICE_COMMUNICATION_FAILURE;
+          throw HAPStatus.SERVICE_COMMUNICATION_FAILURE;
+        }
+      }
+    }
 
     if (this.listeners(CharacteristicEventTypes.SET).length === 0) {
       this.value = value;
@@ -799,6 +908,8 @@ export class Characteristic extends EventEmitter {
             if (status) {
               if (typeof status === "number") {
                 this.status = status;
+              } else if (status instanceof HapStatusError) {
+                this.status = (status as HapStatusError).hapStatus;
               } else {
                 this.status = extractHAPStatusFromError(status);
                 debug("[%s] Received error from set handler %s", this.displayName, status.stack);

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -491,7 +491,14 @@ export class Characteristic extends EventEmitter {
   status: HAPStatus = HAPStatus.SUCCESS;
   props: CharacteristicProps;
 
+  /**
+   * The .onGet handler
+   */
   private getHandler?: () => Promise<Nullable<CharacteristicValue>> | Nullable<CharacteristicValue>;
+
+  /**
+   * The .onSet handler
+   */
   private setHandler?: (value: CharacteristicValue) => Promise<Nullable<CharacteristicValue> | void> | Nullable<CharacteristicValue> | void;
 
   private subscriptions: number = 0;

--- a/src/lib/util/hapStatusError.ts
+++ b/src/lib/util/hapStatusError.ts
@@ -1,0 +1,26 @@
+import { HAPStatus } from "../HAPServer";
+
+/**
+ * Throws a HAP status error that is sent back to HomeKit.
+ * 
+ * @example
+ * ```ts
+ * throw new HapStatusError(HAPStatus.OPERATION_TIMED_OUT);
+ * ```
+ */
+export class HapStatusError extends Error {
+  public hapStatus: HAPStatus;
+
+  constructor(status: HAPStatus) {
+    super('HAP Status Error: ' + status);
+
+    Object.setPrototypeOf(this, HapStatusError.prototype);
+
+    if (status >= HAPStatus.INSUFFICIENT_PRIVILEGES && status <= HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE) {
+      this.hapStatus = status;
+    } else {
+      this.hapStatus = HAPStatus.SERVICE_COMMUNICATION_FAILURE;
+    }
+  }
+}
+


### PR DESCRIPTION
I didn't see the other PR until after I went to make this PR...

Usage (async is optional):

```ts
fan
  .getService(Service.Fan)!
  .addCharacteristic(Characteristic.RotationSpeed)
  .onGet(async () => {
    return FAKE_FAN.rSpeed;
  })
  .onSet(async (value) => {
    FAKE_FAN.setSpeed(value);
  });
```

The user can also throw a specific HAP error:

```ts
fan
  .getService(Service.Fan)!
  .addCharacteristic(Characteristic.RotationSpeed)
  .onGet(async () => {
    throw new HapStatusError(HAPStatus.OPERATION_TIMED_OUT);
  });
```

If any other error types are thrown while executing the handler, it will fallback to `HAPStatus.SERVICE_COMMUNICATION_FAILURE`.

`HapStatusError` can also be used in the current style listeners:

```ts
fan
  .getService(Service.Fan)!
  .addCharacteristic(Characteristic.RotationSpeed)
  .on('get', (callback) => {
    callback(new HapStatusError(HAPStatus.OPERATION_TIMED_OUT));
  });
```

Characteristic that require a  `WRITE_RESPONSE` can return the value in their `onSet` handler. Returned values for characteristics that do not implement `WRITE_RESPONSE` (99% of them) are ignored.

```ts
fan
  .getService(Service.Fan)!
  .addCharacteristic(Characteristic.RotationSpeed)
  .onSet(async (value) => {
    return 99;
  });
```

If the user attempts to setup both an `onSet` / `onGet` handler and the current style `.on('get' / 'set')` listeners, the `onSet` / `onGet` will take priority and a warning will be displayed in the log.