### PR TITLE
Catch validation errors in set update

### DIFF
--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1031,7 +1031,16 @@ export class Characteristic extends EventEmitter {
       callback = undefined;
     }
 
-    value = this.validateUserInput(value)!;
+    try {
+      value = this.validateUserInput(value)!;
+    } catch (e) {
+      this.characteristicWarning(e.message);
+      if (callback) {
+        callback(e);
+      }
+      return this;
+    }
+
     this.handleSetRequest(value, undefined, context).then(value => {
       if (callback) {
         if (value) { // possible write response
@@ -1107,7 +1116,16 @@ export class Characteristic extends EventEmitter {
     // noinspection JSDeprecatedSymbols
     this.status = null;
 
-    value = this.validateUserInput(value);
+    try {
+      value = this.validateUserInput(value)!;
+    } catch (e) {
+      this.characteristicWarning(e.message);
+      if (callback) {
+        callback();
+      }
+      return this;
+    }
+
     const oldValue = this.value;
     this.value = value;
 


### PR DESCRIPTION
If an existing homebridge plugin were to provide an invalid values using the `.setValue` or `.updateValue` methods the bridge would crash without reporting which plugin or characteristic caused the problem.

After this change, it should handle invalid values the same way we do if one is provided by the on set/get handlers.