### PR TITLE
Fix incorrect bounds checks of HAPStatus errors

### DIFF
--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -237,7 +237,7 @@ import {
   WiFiConfigurationControl,
   WiFiSatelliteStatus,
 } from "./definitions";
-import { HAPStatus } from "./HAPServer";
+import { HAPStatus, IsKnownHAPStatusError } from "./HAPServer";
 import { IdentifierCache } from './model/IdentifierCache';
 import { Service } from "./Service";
 import { clone } from "./util/clone";
@@ -2146,7 +2146,7 @@ function extractHAPStatusFromError(error: Error) {
   if (numberPattern.test(error.message)) {
     const value = parseInt(error.message);
 
-    if (value >= HAPStatus.INSUFFICIENT_PRIVILEGES && value <= HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE) {
+	if (IsKnownHAPStatusError(value)) {
       errorValue = value;
     }
   }

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -107,7 +107,19 @@ export const enum HAPStatus {
   INSUFFICIENT_AUTHORIZATION = -70411,
   NOT_ALLOWED_IN_CURRENT_STATE = -70412,
 
-  // when adding new status codes, remember to change upper bound in extractHAPStatusFromError
+  // when adding new status codes, remember to update bounds in IsKnownHAPStatusError below
+}
+
+/**
+ * Determines if the given status code is a known {@link HAPStatus} error code.
+ */
+export function IsKnownHAPStatusError(status: HAPStatus): boolean {
+  return (
+    // Lower bound (most negative error code)
+    status >= HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE &&
+    // Upper bound (negative error code closest to zero)
+    status <= HAPStatus.INSUFFICIENT_PRIVILEGES
+  );
 }
 
 // noinspection JSUnusedGlobalSymbols

--- a/src/lib/util/hapStatusError.ts
+++ b/src/lib/util/hapStatusError.ts
@@ -1,4 +1,4 @@
-import { HAPStatus } from "../HAPServer";
+import { HAPStatus, IsKnownHAPStatusError } from "../HAPServer";
 
 /**
  * Throws a HAP status error that is sent back to HomeKit.
@@ -16,7 +16,7 @@ export class HapStatusError extends Error {
 
     Object.setPrototypeOf(this, HapStatusError.prototype);
 
-    if (status >= HAPStatus.INSUFFICIENT_PRIVILEGES && status <= HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE) {
+    if (IsKnownHAPStatusError(status)) {
       this.hapStatus = status;
     } else {
       this.hapStatus = HAPStatus.SERVICE_COMMUNICATION_FAILURE;


### PR DESCRIPTION
The upper/lower bounds of the checks were reversed due to negative number confusion. I also refactored the duplicate checks into a single IsKnownHAPStatusError() function.