### PR TITLE
Incorrect rounding breaking temperature values

### DIFF
--- a/src/lib/util/request-util.spec.ts
+++ b/src/lib/util/request-util.spec.ts
@@ -49,4 +49,22 @@ describe("request-util", () => {
     });
     expect(formatOutgoingCharacteristicValue(36.135795, props)).toBe(36.1);
   });
+
+  it("should handle negative minumum values", () => {
+    const props = createProps(Formats.INT, {
+      minStep: 0.1,
+      minValue: -100,
+      maxValue: 100,
+    });
+    expect(formatOutgoingCharacteristicValue(25.1, props)).toBe(25.1);
+  });
+
+  it("should handle small minumum values", () => {
+    const props = createProps(Formats.INT, {
+      minStep: 0.1,
+      minValue: 0.1,
+      maxValue: 10000,
+    });
+    expect(formatOutgoingCharacteristicValue(2.3, props)).toBe(2.3);
+  });
 });

--- a/src/lib/util/request-util.ts
+++ b/src/lib/util/request-util.ts
@@ -24,7 +24,7 @@ export function formatOutgoingCharacteristicValue(value: Nullable<Characteristic
     const base = props.minValue ?? 0;
     const inverse = 1 / props.minStep;
 
-    return (Math.round((value - base) * inverse) / inverse) + base;
+    return Math.round(((Math.round((value - base) * inverse) / inverse) + base) * 10000) / 10000;
   }
 
   return value;


### PR DESCRIPTION
Saw this with my temperature sensors that are used outdoor.

```
HAP-NodeJS:Accessory [Bart-Dev-1 C734] Got Characteristic "Current Temperature" value: "-2.299999999999997"
```
And after delving into the code found this issue with javascript math and negative or decimal values. This issue is only triggered when the minValue for a characteristic is a negative or decimal number.

Added 2 test cases to cover the identified scenarios

The fix is a bit of kludge versus adding in a proper math library.