### PR TITLE
Fix Validate Client Supplied Values + float min/max

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hap-nodejs",
   "version": "0.9.0",
-  "betaVersion": "0.9.2",
+  "betaVersion": "0.9.3",
   "description": "HAP-NodeJS is a Node.js implementation of HomeKit Accessory Server.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -160,6 +160,7 @@ export const enum CharacteristicWarningType {
   TIMEOUT_READ = "timeout-read",
   WARN_MESSAGE = "warn-message",
   ERROR_MESSAGE = "error-message",
+  DEBUG_MESSAGE = "debug-message",
 }
 
 export interface CharacteristicWarning {

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -328,7 +328,7 @@ describe('Characteristic', () => {
     });
   });
 
-  describe('#validClientSuppliedValue()', () => {
+  describe('#validateClientSuppliedValue()', () => {
     it('rejects undefined values from client', async () => {
       const characteristic = createCharacteristicWithProps({
         format: Formats.UINT8,
@@ -339,7 +339,7 @@ describe('Characteristic', () => {
       });
 
       // @ts-expect-error
-      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+      const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
       // set initial known good value
       characteristic.setValue(1);
@@ -352,7 +352,7 @@ describe('Characteristic', () => {
       expect(characteristic.value).toEqual(1);
 
       // ensure validator was actually called
-      expect(validClientSuppliedValueMock).toBeCalled();
+      expect(validateClientSuppliedValueMock).toBeCalled();
     });
 
     it('rejects invalid values for the boolean format type', async () => {
@@ -365,7 +365,7 @@ describe('Characteristic', () => {
       });
 
       // @ts-expect-error
-      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+      const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
       // set initial known good value
       characteristic.setValue(true);
@@ -392,7 +392,7 @@ describe('Characteristic', () => {
       expect(characteristic.value).toEqual(true);
 
       // ensure validator was actually called
-      expect(validClientSuppliedValueMock).toBeCalledTimes(4);
+      expect(validateClientSuppliedValueMock).toBeCalledTimes(4);
     });
 
     test.each([Formats.INT, Formats.FLOAT, Formats.UINT8, Formats.UINT16, Formats.UINT32, Formats.UINT64])(
@@ -406,13 +406,13 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         await characteristic.handleSetRequest(false, null as unknown as undefined);
         expect(characteristic.value).toEqual(0);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalled();
+        expect(validateClientSuppliedValueMock).toBeCalled();
       });
   
 
@@ -427,13 +427,13 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         await characteristic.handleSetRequest(true, null as unknown as undefined);
         expect(characteristic.value).toEqual(1);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalled();
+        expect(validateClientSuppliedValueMock).toBeCalled();
       });
 
     test.each([Formats.INT, Formats.FLOAT, Formats.UINT8, Formats.UINT16, Formats.UINT32, Formats.UINT64])(
@@ -447,7 +447,7 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         // set initial known good value
         characteristic.setValue(1);
@@ -460,7 +460,7 @@ describe('Characteristic', () => {
         expect(characteristic.value).toEqual(1);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalled();
+        expect(validateClientSuppliedValueMock).toBeCalled();
       });
 
     test.each([Formats.INT, Formats.FLOAT, Formats.UINT8, Formats.UINT16, Formats.UINT32, Formats.UINT64])(
@@ -474,7 +474,7 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         // set initial known good value
         characteristic.setValue(1);
@@ -498,7 +498,7 @@ describe('Characteristic', () => {
         expect(characteristic.value).toEqual(0);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalledTimes(3);
+        expect(validateClientSuppliedValueMock).toBeCalledTimes(3);
       });
 
     test.each([Formats.INT, Formats.FLOAT, Formats.UINT8, Formats.UINT16, Formats.UINT32, Formats.UINT64])(
@@ -512,7 +512,7 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         // set initial known good value
         characteristic.setValue(1);
@@ -525,7 +525,7 @@ describe('Characteristic', () => {
         expect(characteristic.value).toEqual(1);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalledTimes(1);
+        expect(validateClientSuppliedValueMock).toBeCalledTimes(1);
       });
 
     test.each([Formats.INT, Formats.FLOAT, Formats.UINT8, Formats.UINT16, Formats.UINT32, Formats.UINT64])(
@@ -536,7 +536,7 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         // set initial known good value
         characteristic.setValue(1);
@@ -549,7 +549,7 @@ describe('Characteristic', () => {
         expect(characteristic.value).toEqual(1);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalledTimes(1);
+        expect(validateClientSuppliedValueMock).toBeCalledTimes(1);
       });
 
     test.each([Formats.INT, Formats.FLOAT, Formats.UINT8, Formats.UINT16, Formats.UINT32, Formats.UINT64])(
@@ -564,7 +564,7 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         // set initial known good value
         characteristic.setValue(1);
@@ -584,7 +584,7 @@ describe('Characteristic', () => {
         expect(characteristic.value).toEqual(3);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalledTimes(2);
+        expect(validateClientSuppliedValueMock).toBeCalledTimes(2);
       });
 
     test.each([Formats.INT, Formats.FLOAT, Formats.UINT8, Formats.UINT16, Formats.UINT32, Formats.UINT64])(
@@ -599,7 +599,7 @@ describe('Characteristic', () => {
         });
 
         // @ts-expect-error
-        const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+        const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
         // set initial known good value
         characteristic.setValue(50);
@@ -623,7 +623,7 @@ describe('Characteristic', () => {
         expect(characteristic.value).toEqual(52);
 
         // ensure validator was actually called
-        expect(validClientSuppliedValueMock).toBeCalledTimes(3);
+        expect(validateClientSuppliedValueMock).toBeCalledTimes(3);
       });
 
     test.each([Formats.STRING, Formats.TLV8, Formats.DATA])(
@@ -634,7 +634,7 @@ describe('Characteristic', () => {
       });
 
       // @ts-expect-error
-      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+      const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
       // set initial known good value
       characteristic.setValue('some string');
@@ -658,7 +658,7 @@ describe('Characteristic', () => {
       expect(characteristic.value).toEqual('some other test string');
 
       // ensure validator was actually called
-      expect(validClientSuppliedValueMock).toBeCalledTimes(3);
+      expect(validateClientSuppliedValueMock).toBeCalledTimes(3);
     });
 
     it('should accept Formats.FLOAT with precision provided by client', async () => {
@@ -668,7 +668,7 @@ describe('Characteristic', () => {
       });
 
       // @ts-expect-error
-      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+      const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
       // set initial known good value
       characteristic.setValue(0.0005);
@@ -684,7 +684,7 @@ describe('Characteristic', () => {
       expect(characteristic.value).toEqual(0.0001005);
 
       // ensure validator was actually called
-      expect(validClientSuppliedValueMock).toBeCalledTimes(1);
+      expect(validateClientSuppliedValueMock).toBeCalledTimes(1);
     });
 
     it("should accept negative floats in range for Formats.FLOAT provided by the client", async () => {
@@ -696,7 +696,7 @@ describe('Characteristic', () => {
       });
 
       // @ts-expect-error - spying on private property
-      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+      const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
       // should allow negative float
       await expect(characteristic.handleSetRequest(-0.013, null as unknown as undefined))
@@ -706,7 +706,7 @@ describe('Characteristic', () => {
       expect(characteristic.value).toEqual(-0.013);
 
       // ensure validator was actually called
-      expect(validClientSuppliedValueMock).toBeCalledTimes(1);
+      expect(validateClientSuppliedValueMock).toBeCalledTimes(1);
     });
 
     it('rejects string values exceeding the max length from the client', async () => {
@@ -717,7 +717,7 @@ describe('Characteristic', () => {
       });
 
       // @ts-expect-error
-      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+      const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
       // set initial known good value
       characteristic.setValue('abcde');
@@ -737,7 +737,7 @@ describe('Characteristic', () => {
       expect(characteristic.value).toEqual('abc');
 
       // ensure validator was actually called
-      expect(validClientSuppliedValueMock).toBeCalledTimes(2);
+      expect(validateClientSuppliedValueMock).toBeCalledTimes(2);
     });
 
     it('rejects data values exceeding the max length from the client', async () => {
@@ -748,7 +748,7 @@ describe('Characteristic', () => {
       });
 
       // @ts-expect-error
-      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+      const validateClientSuppliedValueMock = jest.spyOn(characteristic, 'validateClientSuppliedValue');
 
       // set initial known good value
       characteristic.setValue('abcde');
@@ -768,7 +768,7 @@ describe('Characteristic', () => {
       expect(characteristic.value).toEqual('abc');
 
       // ensure validator was actually called
-      expect(validClientSuppliedValueMock).toBeCalledTimes(2);
+      expect(validateClientSuppliedValueMock).toBeCalledTimes(2);
     });
 
   });

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -596,12 +596,34 @@ describe('Characteristic', () => {
       // the existing valid value should remain
       expect(characteristic.value).toEqual(0.0005);
 
-      // strings should pass
+      // should allow float
       await expect(characteristic.handleSetRequest(0.0001005, null as unknown as undefined))
         .resolves.toEqual(undefined);
 
       // value should now be updated
       expect(characteristic.value).toEqual(0.0001005);
+
+      // ensure validator was actually called
+      expect(validClientSuppliedValueMock).toBeCalledTimes(1);
+    });
+
+    it("should accept negative floats in range for Formats.FLOAT provided by the cleint", async () => {
+      const characteristic = createCharacteristicWithProps({
+        format: Formats.FLOAT,
+        perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
+        minValue: -1000,
+        maxValue: 1000,
+      });
+
+      // @ts-expect-error - spying on private property
+      const validClientSuppliedValueMock = jest.spyOn(characteristic, 'validClientSuppliedValue');
+
+      // should allow negative float
+      await expect(characteristic.handleSetRequest(-0.013, null as unknown as undefined))
+        .resolves.toEqual(undefined);
+
+      // value should now be updated
+      expect(characteristic.value).toEqual(-0.013);
 
       // ensure validator was actually called
       expect(validClientSuppliedValueMock).toBeCalledTimes(1);

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -980,7 +980,7 @@ describe('Characteristic', () => {
         perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
         minValue: -1000,
         maxValue: 1000,
-      }, '00000023-0000-1000-8000-0026BB765292');
+      });
 
       // @ts-expect-error - spying on private property
       const mock = jest.spyOn(characteristic, 'characteristicWarning');
@@ -989,7 +989,6 @@ describe('Characteristic', () => {
       characteristic.setValue(-0.013);
       expect(characteristic.value).toEqual(-0.013);
       expect(mock).toBeCalledTimes(0);
-
     });
 
     it("should validate string inputs", () => {

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -974,6 +974,24 @@ describe('Characteristic', () => {
       expect(mock).toBeCalledTimes(0);
     });
 
+    it("should allow negative floats in range for Formats.FLOAT", () => {
+      const characteristic = createCharacteristicWithProps({
+        format: Formats.FLOAT,
+        perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
+        minValue: -1000,
+        maxValue: 1000,
+      }, '00000023-0000-1000-8000-0026BB765292');
+
+      // @ts-expect-error - spying on private property
+      const mock = jest.spyOn(characteristic, 'characteristicWarning');
+
+      mock.mockReset();
+      characteristic.setValue(-0.013);
+      expect(characteristic.value).toEqual(-0.013);
+      expect(mock).toBeCalledTimes(0);
+
+    });
+
     it("should validate string inputs", () => {
       const characteristic = createCharacteristicWithProps({
         format: Formats.STRING,

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -69,7 +69,7 @@ describe('Characteristic', () => {
       characteristic.setProps({
         minValue: 700,
         maxValue: 1000
-      })
+      });
 
       expect(characteristic.props.minValue).toEqual(0); // min for UINT8
       expect(characteristic.props.maxValue).toEqual(255); // max for UINT8
@@ -79,7 +79,7 @@ describe('Characteristic', () => {
       characteristic.setProps({
         minValue: -1000,
         maxValue: -500
-      })
+      });
 
       expect(characteristic.props.minValue).toEqual(0); // min for UINT8
       expect(characteristic.props.maxValue).toEqual(255); // max for UINT8
@@ -89,11 +89,28 @@ describe('Characteristic', () => {
       characteristic.setProps({
         minValue: 10,
         maxValue: 1000
-      })
+      });
 
       expect(characteristic.props.minValue).toEqual(10);
       expect(characteristic.props.maxValue).toEqual(255); // max for UINT8
       expect(mock).toBeCalledTimes(1);
+    });
+
+    it('should reject update to minValue and maxValue when minValue is greater than maxValue', function () {
+      const characteristic = createCharacteristicWithProps({
+        format: Formats.FLOAT,
+        perms: [Perms.NOTIFY, Perms.PAIRED_READ],
+      });
+
+      expect(function() {
+        characteristic.setProps({
+          minValue: 1000,
+          maxValue: 500,
+        })
+      }).toThrowError()
+
+      expect(characteristic.props.minValue).toBeUndefined();
+      expect(characteristic.props.maxValue).toBeUndefined();
     });
 
     it('should accept update to minValue and maxValue when they are in range for format type', function () {

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -11,7 +11,6 @@ import {
   Units,
   uuid
 } from '..';
-import { HAPConnection } from './util/eventedhttp';
 
 function createCharacteristic(type: Formats, customUUID?: string): Characteristic {
   return new Characteristic('Test', customUUID || uuid.generate('Foo'), { format: type, perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE] });

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -607,7 +607,7 @@ describe('Characteristic', () => {
       expect(validClientSuppliedValueMock).toBeCalledTimes(1);
     });
 
-    it("should accept negative floats in range for Formats.FLOAT provided by the cleint", async () => {
+    it("should accept negative floats in range for Formats.FLOAT provided by the client", async () => {
       const characteristic = createCharacteristicWithProps({
         format: Formats.FLOAT,
         perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1963,7 +1963,7 @@ export class Characteristic extends EventEmitter {
           } // for stepValue < 1 rounding is done only when formatting the response. We can't store the "perfect" .step anyways
         }
 
-        break;
+        return value;
       }
       case Formats.STRING: {
         if (typeof value === "number") {

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1579,7 +1579,7 @@ export class Characteristic extends EventEmitter {
           return this.value!;
         } else {
           if (writeResponse != null) {
-            this.characteristicWarning(`SET handler returned write response value, though the characteristic doesn't support write response`);
+            this.characteristicWarning(`SET handler returned write response value, though the characteristic doesn't support write response`, CharacteristicWarningType.DEBUG_MESSAGE);
           }
           this.value = value;
 
@@ -1642,7 +1642,7 @@ export class Characteristic extends EventEmitter {
               resolve(this.value!);
             } else {
               if (writeResponse != null) {
-                this.characteristicWarning(`SET handler returned write response value, though the characteristic doesn't support write response`);
+                this.characteristicWarning(`SET handler returned write response value, though the characteristic doesn't support write response`, CharacteristicWarningType.DEBUG_MESSAGE);
               }
               this.value = value;
               resolve();

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1550,19 +1550,15 @@ export class Characteristic extends EventEmitter {
     // noinspection JSDeprecatedSymbols
     this.status = null;
 
-    if (connection !== undefined && !this.validClientSuppliedValue(value)) {
+    if (connection !== undefined) {
       // if connection is undefined, the set "request" comes from the setValue method.
       // for setValue a value of "null" is allowed and checked via validateUserInput.
-      return Promise.reject(HAPStatus.INVALID_VALUE_IN_REQUEST);
-    }
-
-    if (this.props.format === Formats.BOOL && typeof value === "number") {
-      // we already validate in validClientSuppliedValue that a number value can only be 0 or 1.
-      value = value === 1;
-    }
-
-    if (isNumericFormat(this.props.format) && typeof value === "boolean") {
-      value = value ? 1 : 0;
+      try {
+         value = this.validClientSuppliedValue(value);
+      } catch (e) {
+        debug(`[${this.displayName}]`, e.message);
+        return Promise.reject(HAPStatus.INVALID_VALUE_IN_REQUEST);
+      }
     }
 
     const oldValue = this.value;
@@ -1746,137 +1742,104 @@ export class Characteristic extends EventEmitter {
    * must be returned.
    * @param value - Value supplied by the HomeKit controller
    */
-  private validClientSuppliedValue(value?: Nullable<CharacteristicValue>): boolean {
+  private validClientSuppliedValue(value?: Nullable<CharacteristicValue>): CharacteristicValue {
     if (value == undefined) {
-      return false;
+      throw new Error(`Client supplied invalid value for ${this.props.format}: undefined`)
     }
 
-    let numericMin: number | undefined = undefined;
-    let numericMax: number | undefined = undefined;
-
     switch (this.props.format) {
-      case Formats.BOOL:
-        if (!(typeof value === "boolean" || value == 0 || value == 1)) {
-          return false;
-        }
-        break;
-      case Formats.INT: // 32-bit signed int
-        if (typeof value === "boolean") {
-          value = value ? 1 : 0;
-        }
-        if (typeof value !== "number") {
-          return false;
+      case Formats.BOOL: {
+        if (typeof value === 'boolean') {
+          return value;
         }
 
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.INT));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.INT));
-        break;
+        if (typeof value === 'number' && (value === 1 || value === 0)) {
+          return Boolean(value);
+        }
+        
+        throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
+      }
+      case Formats.INT:
       case Formats.FLOAT:
-        if (typeof value === "boolean") {
-          value = value ? 1 : 0;
-        }
-        if (typeof value !== "number") {
-          return false;
-        }
-
-        if (this.props.minValue != null) {
-          numericMin = this.props.minValue;
-        }
-        if (this.props.maxValue != null) {
-          numericMax = this.props.maxValue;
-        }
-        break;
       case Formats.UINT8:
-        if (typeof value === "boolean") {
-          value = value ? 1 : 0;
-        } if (typeof value !== "number") {
-          return false;
-        }
-
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT8));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT8));
-        break;
       case Formats.UINT16:
-        if (typeof value === "boolean") {
-          value = value ? 1 : 0;
-        } if (typeof value !== "number") {
-          return false;
-        }
-
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT16));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT16));
-        break;
       case Formats.UINT32:
+      case Formats.UINT64: {
         if (typeof value === "boolean") {
           value = value ? 1 : 0;
-        } if (typeof value !== "number") {
-          return false;
         }
 
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT32));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT32));
-        break;
-      case Formats.UINT64:
-        if (typeof value === "boolean") {
-          value = value ? 1 : 0;
-        } if (typeof value !== "number") {
-          return false;
+        if (typeof value !== "number") {
+          throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
         }
 
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT64));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT64));
-        break;
+        if (isNaN(value)) {
+          throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
+        }
+
+        const numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(this.props.format));
+        const numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(this.props.format));
+
+        if (typeof numericMin === 'number' && value < numericMin) {
+          throw new Error(`Client supplied value of ${value} is less than the minimum allowed value of ${numericMin}`);
+        }
+
+        if (typeof numericMax === 'number' && value > numericMax) {
+          throw new Error(`Client supplied value of ${value} is greater than the maximum allowed value of ${numericMax}`);
+        }
+
+        if (this.props.validValues && !this.props.validValues.includes(value)) {
+          throw new Error(`Client supplied value of ${value} is not in ${this.props.validValues.toString()}`);
+        }
+
+        if (this.props.validValueRanges && this.props.validValueRanges.length === 2) {
+          if (value < this.props.validValueRanges[0]) {
+            throw new Error(`Client supplied value of ${value} is less than the minimum allowed value of ${this.props.validValueRanges[0]}`);
+          } 
+          if (value > this.props.validValueRanges[1]) {
+            throw new Error(`Client supplied value of ${value} is greater than the maximum allowed value of ${this.props.validValueRanges[1]}`);
+          }
+        }
+
+        // should we enforce min step from the client as well?
+
+        return value;
+      }
       case Formats.STRING: {
         if (typeof value !== "string") {
-          return false;
+          throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
         }
 
         const maxLength = this.props.maxLen != null? this.props.maxLen: 64; // default is 64; max is 256 which is set in setProps
         if (value.length > maxLength) {
-          return false;
+          throw new Error(`Client supplied value length of ${value.length} exceeds maximum length allowed of ${maxLength}`)
         }
-        break;
+        
+        return value;
       }
       case Formats.DATA: {
         if (typeof value !== "string") {
-          return false;
+          throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
         }
+
         // we don't validate base64 here
 
         const maxLength = this.props.maxDataLen != null? this.props.maxDataLen: 0x200000; // default is 0x200000
         if (value.length > maxLength) {
-          return false;
+          throw new Error(`Client supplied value length of ${value.length} exceeds maximum length allowed of ${maxLength}`)
         }
-        break;
+        
+        return value;
       }
       case Formats.TLV8:
         if (typeof value !== "string") {
-          return false;
+          throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
         }
-        break;
+        
+        return value;
     }
 
-    if (typeof value === "number") {
-      if (numericMin != null && value < numericMin) {
-        return false;
-      }
-      if (numericMax != null && value > numericMax) {
-        return false;
-      }
-
-      if (this.props.validValues && !this.props.validValues.includes(value)) {
-        return false;
-      }
-      if (this.props.validValueRanges && this.props.validValueRanges.length === 2) {
-        if (value < this.props.validValueRanges[0]) {
-          return false;
-        } else if (value > this.props.validValueRanges[1]) {
-          return false;
-        }
-      }
-    }
-
-    return true;
+    return value;
   }
 
   /**
@@ -1921,144 +1884,32 @@ export class Characteristic extends EventEmitter {
       }
     }
 
-    let numericMin: number | undefined = undefined;
-    let numericMax: number | undefined = undefined;
-    let stepValue: number | undefined = undefined;
-
     switch (this.props.format) {
       case Formats.BOOL: {
         if (typeof value === "boolean") {
           return value;
-        } else if (typeof value === "number") {
+        }
+        if (typeof value === "number") {
           return value === 1;
-        } else if (typeof value === "string") {
+        }
+        if (typeof value === "string") {
           return value === "1" || value === "true";
-        } else {
-          this.characteristicWarning("characteristic value expected boolean and received " + typeof value);
-          return false;
-        }
-      }
-      case Formats.INT: {
-        if (typeof value === "boolean") {
-          value = value ? 1: 0;
-        }
-        if (typeof value === "string") {
-           // this.characteristicWarning(`characteristic was supplied illegal value: string instead of number. Supplying illegal values will throw errors in the future!`);
-          value = parseInt(value, 10);
-        }
-        if (typeof value === 'number' && isNaN(value)) {
-          this.characteristicWarning("characteristic was expected valid number and received NaN");
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-        if (typeof value !== "number") {
-          this.characteristicWarning("characteristic value expected number and received " + typeof value,);
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
         }
 
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.INT));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.INT));
-        stepValue = maxWithUndefined(this.props.minStep, 1);
-        break;
+        this.characteristicWarning("characteristic value expected boolean and received " + typeof value);
+        return false;
       }
-      case Formats.FLOAT: {
-        if (typeof value === "boolean") {
-          value = value? 1: 0;
-        }
-        if (typeof value === "string") {
-          // this.characteristicWarning(`characteristic was supplied illegal value: string instead of float. Supplying illegal values will throw errors in the future!`);
-          value = parseFloat(value);
-        }
-        if (typeof value === 'number' && isNaN(value)) {
-          this.characteristicWarning("characteristic was expected valid number and received NaN");
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-        if (typeof value !== "number") {
-          this.characteristicWarning("characteristic value expected float and received " + typeof value);
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-
-        if (this.props.minValue != null) {
-          numericMin = this.props.minValue;
-        }
-        if (this.props.maxValue != null) {
-          numericMax = this.props.maxValue;
-        }
-        stepValue = this.props.minStep;
-        break;
-      }
-      case Formats.UINT8: {
-        if (typeof value === "boolean") {
-          value = value? 1: 0;
-        }
-        if (typeof value === "string") {
-          // this.characteristicWarning(`characteristic was supplied illegal value: string instead of number. Supplying illegal values will throw errors in the future!`);
-          value = parseInt(value, 10);
-        }
-        if (typeof value === 'number' && isNaN(value)) {
-          this.characteristicWarning("characteristic was expected valid number and received NaN");
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-        if (typeof value !== "number") {
-          this.characteristicWarning("characteristic value expected number and received " + typeof value);
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT8));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT8));
-        stepValue = maxWithUndefined(this.props.minStep, 1);
-        break;
-      }
-      case Formats.UINT16: {
-        if (typeof value === "boolean") {
-          value = value? 1: 0;
-        }
-        if (typeof value === "string") {
-          // this.characteristicWarning(`characteristic was supplied illegal value: string instead of number. Supplying illegal values will throw errors in the future!`);
-          value = parseInt(value, 10);
-        }
-        if (typeof value === 'number' && isNaN(value)) {
-          this.characteristicWarning("characteristic was expected valid number and received NaN");
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-        if (typeof value !== "number") {
-          this.characteristicWarning("characteristic value expected number and received " + typeof value);
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT16));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT16));
-        stepValue = maxWithUndefined(this.props.minStep, 1);
-        break;
-      }
-      case Formats.UINT32: {
-        if (typeof value === "boolean") {
-          value = value? 1: 0;
-        }
-        if (typeof value === "string") {
-          // this.characteristicWarning(`characteristic was supplied illegal value: string instead of number. Supplying illegal values will throw errors in the future!`);
-          value = parseInt(value, 10);
-        }
-        if (typeof value === 'number' && isNaN(value)) {
-          this.characteristicWarning("characteristic was expected valid number and received NaN");
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-        if (typeof value !== "number") {
-          this.characteristicWarning("characteristic value expected number and received " + typeof value);
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT32));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT32));
-        stepValue = maxWithUndefined(this.props.minStep, 1);
-        break;
-      }
+      case Formats.INT:
+      case Formats.FLOAT:
+      case Formats.UINT8:
+      case Formats.UINT16:
+      case Formats.UINT32:
       case Formats.UINT64: {
         if (typeof value === "boolean") {
-          value = value? 1: 0;
+          value = value ? 1 : 0;
         }
         if (typeof value === "string") {
-          // this.characteristicWarning(`characteristic was supplied illegal value: string instead of number. Supplying illegal values will throw errors in the future!`);
-          value = parseInt(value, 10);
+          value = this.props.format === Formats.FLOAT ? parseFloat(value) : parseInt(value, 10);
         }
         if (typeof value === 'number' && isNaN(value)) {
           this.characteristicWarning("characteristic was expected valid number and received NaN");
@@ -2069,9 +1920,49 @@ export class Characteristic extends EventEmitter {
           value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
         }
 
-        numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT64));
-        numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT64));
-        stepValue = maxWithUndefined(this.props.minStep, 1);
+        const numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT64));
+        const numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT64));
+
+        let stepValue: number | undefined = undefined;
+        if (this.props.format === Formats.FLOAT) {
+          stepValue = this.props.minStep;
+        } else {
+          stepValue = maxWithUndefined(this.props.minStep, 1);
+        }
+
+        if (numericMin != null && value < numericMin) {
+          this.characteristicWarning(`characteristic was supplied illegal value: number ${value} exceeded minimum of ${numericMin}`);
+          value = numericMin;
+        }
+        if (numericMax != null && value > numericMax) {
+          this.characteristicWarning(`characteristic was supplied illegal value: number ${value} exceeded maximum of ${numericMax}`);
+          value = numericMax;
+        }
+
+        if (this.props.validValues && !this.props.validValues.includes(value)) {
+          this.characteristicWarning(`characteristic value ${value} is not contained in valid values array`);
+          return this.props.validValues.includes(this.value as number) ? this.value : (this.props.validValues[0] || 0);
+        }
+
+        if (this.props.validValueRanges && this.props.validValueRanges.length === 2) {
+          if (value < this.props.validValueRanges[0]) {
+            this.characteristicWarning(`characteristic was supplied illegal value: number ${value} not contained in valid value range of ${this.props.validValueRanges}, supplying illegal values will throw errors in the future`);
+            value = this.props.validValueRanges[0];
+          } else if (value > this.props.validValueRanges[1]) {
+            this.characteristicWarning(`characteristic was supplied illegal value: number ${value} not contained in valid value range of ${this.props.validValueRanges}, supplying illegal values will throw errors in the future`);
+            value = this.props.validValueRanges[1];
+          }
+        }
+
+        if (stepValue != undefined) {
+          if (stepValue === 1) {
+            value = Math.round(value);
+          } else if (stepValue > 1) {
+            value = Math.round(value);
+            value = value - (value % stepValue);
+          } // for stepValue < 1 rounding is done only when formatting the response. We can't store the "perfect" .step anyways
+        }
+
         break;
       }
       case Formats.STRING: {
@@ -2113,41 +2004,6 @@ export class Characteristic extends EventEmitter {
           return this.value;
         }
         return value; // we trust that this is valid tlv8
-    }
-
-    if (typeof value === "number") {
-      if (numericMin != null && value < numericMin) {
-        this.characteristicWarning(`characteristic was supplied illegal value: number ${value} exceeded minimum of ${numericMin}`);
-        value = numericMin;
-      }
-      if (numericMax != null && value > numericMax) {
-        this.characteristicWarning(`characteristic was supplied illegal value: number ${value} exceeded maximum of ${numericMax}`);
-        value = numericMax;
-      }
-
-      if (this.props.validValues && !this.props.validValues.includes(value)) {
-        this.characteristicWarning(`characteristic value ${value} is not contained in valid values array`);
-        return this.props.validValues.includes(this.value as number) ? this.value : (this.props.validValues[0] || 0);
-      }
-
-      if (this.props.validValueRanges && this.props.validValueRanges.length === 2) {
-        if (value < this.props.validValueRanges[0]) {
-          this.characteristicWarning(`characteristic was supplied illegal value: number ${value} not contained in valid value range of ${this.props.validValueRanges}, supplying illegal values will throw errors in the future`);
-          value = this.props.validValueRanges[0];
-        } else if (value > this.props.validValueRanges[1]) {
-          this.characteristicWarning(`characteristic was supplied illegal value: number ${value} not contained in valid value range of ${this.props.validValueRanges}, supplying illegal values will throw errors in the future`);
-          value = this.props.validValueRanges[1];
-        }
-      }
-
-      if (stepValue != undefined) {
-        if (stepValue === 1) {
-          value = Math.round(value);
-        } else if (stepValue > 1) {
-          value = Math.round(value);
-          value = value - (value % stepValue);
-        } // for stepValue < 1 rounding is done only when formatting the response. We can't store the "perfect" .step anyways
-      }
     }
 
     // hopefully it shouldn't get to this point

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1746,7 +1746,7 @@ export class Characteristic extends EventEmitter {
    * must be returned.
    * @param value - Value supplied by the HomeKit controller
    */
-  private validClientSuppliedValue(value?: Nullable<CharacteristicValue>): Nullable<CharacteristicValue> {
+  private validClientSuppliedValue(value?: Nullable<CharacteristicValue>): boolean {
     if (value == undefined) {
       return false;
     }

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1998,7 +1998,7 @@ export class Characteristic extends EventEmitter {
         }
 
         if (this.props.maxDataLen != null && value.length > this.props.maxDataLen) {
-          // can't cut it as we would basically yet binary rubbish afterwards
+          // can't cut it as we would basically set binary rubbish afterwards
           throw new Error("characteristic with DATA format exceeds specified maxDataLen");
         }
         return value;

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1566,7 +1566,7 @@ export class Characteristic extends EventEmitter {
       // if connection is undefined, the set "request" comes from the setValue method.
       // for setValue a value of "null" is allowed and checked via validateUserInput.
       try {
-         value = this.validClientSuppliedValue(value);
+         value = this.validateClientSuppliedValue(value);
       } catch (e) {
         debug(`[${this.displayName}]`, e.message);
         return Promise.reject(HAPStatus.INVALID_VALUE_IN_REQUEST);
@@ -1754,7 +1754,7 @@ export class Characteristic extends EventEmitter {
    * must be returned.
    * @param value - Value supplied by the HomeKit controller
    */
-  private validClientSuppliedValue(value?: Nullable<CharacteristicValue>): CharacteristicValue {
+  private validateClientSuppliedValue(value?: Nullable<CharacteristicValue>): CharacteristicValue {
     if (value == undefined) {
       throw new Error(`Client supplied invalid value for ${this.props.format}: undefined`)
     }

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1002,7 +1002,7 @@ export class Characteristic extends EventEmitter {
         props.minValue = undefined;
       } else if (typeof props.minValue !== 'number' || !Number.isFinite(props.minValue)) {
         this.characteristicWarning(
-          `Characteristic Property 'minValue' must be a finite number, received ${props.minValue} (${typeof props.minValue})`,
+          `Characteristic Property 'minValue' must be a finite number, received "${props.minValue}" (${typeof props.minValue})`,
           CharacteristicWarningType.ERROR_MESSAGE
         );
         props.minValue = undefined;
@@ -1039,7 +1039,7 @@ export class Characteristic extends EventEmitter {
         props.maxValue = undefined;
       } else if (typeof props.maxValue !== 'number' || !Number.isFinite(props.maxValue)) {
         this.characteristicWarning(
-          `Characteristic Property 'maxValue' must be a finite number, received ${props.maxValue} (${typeof props.maxValue})`,
+          `Characteristic Property 'maxValue' must be a finite number, received "${props.maxValue}" (${typeof props.maxValue})`,
           CharacteristicWarningType.ERROR_MESSAGE
         );
         props.maxValue = undefined;
@@ -1781,11 +1781,7 @@ export class Characteristic extends EventEmitter {
           value = value ? 1 : 0;
         }
 
-        if (typeof value !== "number") {
-          throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
-        }
-
-        if (!Number.isFinite(value)) {
+        if (typeof value !== "number" || !Number.isFinite(value)) {
           throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
         }
 
@@ -1923,12 +1919,8 @@ export class Characteristic extends EventEmitter {
         if (typeof value === "string") {
           value = this.props.format === Formats.FLOAT ? parseFloat(value) : parseInt(value, 10);
         }
-        if (typeof value === 'number' && !Number.isFinite(value)) {
-          this.characteristicWarning(`characteristic value expected valid finite number and received '${value}'`);
-          value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
-        }
-        if (typeof value !== "number") {
-          this.characteristicWarning("characteristic value expected number and received " + typeof value);
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+          this.characteristicWarning(`characteristic value expected valid finite number and received "${value}" (${typeof value})`);
           value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
         }
 

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1813,8 +1813,6 @@ export class Characteristic extends EventEmitter {
           }
         }
 
-        // should we enforce min step from the client as well?
-
         return value;
       }
       case Formats.STRING: {

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1470,9 +1470,10 @@ export class Characteristic extends EventEmitter {
         return value;
       } catch (error) {
         if (typeof error === "number") {
-          this.statusCode = error;
+          const hapStatusError = new HapStatusError(error);
+          this.statusCode = hapStatusError.hapStatus;
           // noinspection JSDeprecatedSymbols
-          this.status = new HapStatusError(error);
+          this.status = hapStatusError;
         } else if (error instanceof HapStatusError) {
           this.statusCode = error.hapStatus;
           // noinspection JSDeprecatedSymbols
@@ -1505,9 +1506,10 @@ export class Characteristic extends EventEmitter {
         this.emit(CharacteristicEventTypes.GET, once((status?: Error | HAPStatus | null, value?: Nullable<CharacteristicValue>) => {
           if (status) {
             if (typeof status === "number") {
-              this.statusCode = status;
+              const hapStatusError = new HapStatusError(status);
+              this.statusCode = hapStatusError.hapStatus;
               // noinspection JSDeprecatedSymbols
-              this.status = new HapStatusError(status);
+              this.status = hapStatusError;
             } else if (status instanceof HapStatusError) {
               this.statusCode = status.hapStatus;
               // noinspection JSDeprecatedSymbols
@@ -1600,9 +1602,10 @@ export class Characteristic extends EventEmitter {
         }
       } catch (error) {
         if (typeof error === "number") {
-          this.statusCode = error;
+          const hapStatusError = new HapStatusError(error);
+          this.statusCode = hapStatusError.hapStatus;
           // noinspection JSDeprecatedSymbols
-          this.status = new HapStatusError(error);
+          this.status = hapStatusError;
         } else if (error instanceof HapStatusError) {
           this.statusCode = error.hapStatus;
           // noinspection JSDeprecatedSymbols
@@ -1627,9 +1630,10 @@ export class Characteristic extends EventEmitter {
           this.emit(CharacteristicEventTypes.SET, value, once((status?: Error | HAPStatus | null, writeResponse?: Nullable<CharacteristicValue>) => {
             if (status) {
               if (typeof status === "number") {
-                this.statusCode = status;
+                const hapStatusError = new HapStatusError(status);
+                this.statusCode = hapStatusError.hapStatus;
                 // noinspection JSDeprecatedSymbols
-                this.status = new HapStatusError(status);
+                this.status = hapStatusError;
               } else if (status instanceof HapStatusError) {
                 this.statusCode = status.hapStatus;
                 // noinspection JSDeprecatedSymbols

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1920,8 +1920,8 @@ export class Characteristic extends EventEmitter {
           value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
         }
 
-        const numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(Formats.UINT64));
-        const numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(Formats.UINT64));
+        const numericMin = maxWithUndefined(this.props.minValue, numericLowerBound(this.props.format));
+        const numericMax = minWithUndefined(this.props.maxValue, numericUpperBound(this.props.format));
 
         let stepValue: number | undefined = undefined;
         if (this.props.format === Formats.FLOAT) {

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -996,21 +996,27 @@ export class Characteristic extends EventEmitter {
         props.minValue = undefined;
       } else if (!isNumericFormat(this.props.format)) {
         this.characteristicWarning(
-          "Characteristic Property `minValue` can only be set for characteristics with numeric format, but not for " + this.props.format,
+          "Characteristic Property 'minValue' can only be set for characteristics with numeric format, but not for " + this.props.format,
           CharacteristicWarningType.ERROR_MESSAGE
         );
         props.minValue = undefined;
-      } else if (isUnsignedNumericFormat(this.props.format)) {
+      } else if (typeof props.minValue !== 'number' || !Number.isFinite(props.minValue)) {
+        this.characteristicWarning(
+          `Characteristic Property 'minValue' must be a finite number, received ${props.minValue} (${typeof props.minValue})`,
+          CharacteristicWarningType.ERROR_MESSAGE
+        );
+        props.minValue = undefined;
+      } else {
         if (props.minValue < numericLowerBound(this.props.format)) {
           this.characteristicWarning(
-            "Characteristic Property `minValue` was set to " + props.minValue + ", but for numeric format " +
+            "Characteristic Property 'minValue' was set to " + props.minValue + ", but for numeric format " +
             this.props.format + " minimum possible is " + numericLowerBound(this.props.format),
             CharacteristicWarningType.ERROR_MESSAGE
           )
           props.minValue = numericLowerBound(this.props.format);
         } else if (props.minValue > numericUpperBound(this.props.format)) {
           this.characteristicWarning(
-            "Characteristic Property `minValue` was set to " + props.minValue + ", but for numeric format " +
+            "Characteristic Property 'minValue' was set to " + props.minValue + ", but for numeric format " +
             this.props.format + " maximum possible is " + numericUpperBound(this.props.format),
             CharacteristicWarningType.ERROR_MESSAGE
           );
@@ -1027,21 +1033,27 @@ export class Characteristic extends EventEmitter {
         props.maxValue = undefined
       } else if (!isNumericFormat(this.props.format)) {
         this.characteristicWarning(
-          "Characteristic Property `maxValue` can only be set for characteristics with numeric format, but not for " + this.props.format,
+          "Characteristic Property 'maxValue' can only be set for characteristics with numeric format, but not for " + this.props.format,
           CharacteristicWarningType.ERROR_MESSAGE
         );
         props.maxValue = undefined;
-      } else if (isUnsignedNumericFormat(this.props.format)) {
+      } else if (typeof props.maxValue !== 'number' || !Number.isFinite(props.maxValue)) {
+        this.characteristicWarning(
+          `Characteristic Property 'maxValue' must be a finite number, received ${props.maxValue} (${typeof props.maxValue})`,
+          CharacteristicWarningType.ERROR_MESSAGE
+        );
+        props.maxValue = undefined;
+      } else {
         if (props.maxValue > numericUpperBound(this.props.format)) {
           this.characteristicWarning(
-            "Characteristic Property `maxValue` was set to " + props.maxValue + ", but for numeric format " +
+            "Characteristic Property 'maxValue' was set to " + props.maxValue + ", but for numeric format " +
             this.props.format + " maximum possible is " + numericUpperBound(this.props.format),
             CharacteristicWarningType.ERROR_MESSAGE
           );
           props.maxValue = numericUpperBound(this.props.format);
         } else if (props.maxValue < numericLowerBound(this.props.format)) {
           this.characteristicWarning(
-            "Characteristic Property `maxValue` was set to " + props.maxValue + ", but for numeric format " +
+            "Characteristic Property 'maxValue' was set to " + props.maxValue + ", but for numeric format " +
             this.props.format + " minimum possible is " + numericUpperBound(this.props.format),
             CharacteristicWarningType.ERROR_MESSAGE
           );
@@ -1725,7 +1737,7 @@ export class Characteristic extends EventEmitter {
             if (this.props.validValues?.length && typeof this.props.validValues[0] === 'number') {
               return this.props.validValues[0];
             }
-            if (typeof this.props.minValue === 'number') {
+            if (typeof this.props.minValue === 'number' && Number.isFinite(this.props.minValue)) {
               return this.props.minValue;
             }
             return 0;
@@ -1773,7 +1785,7 @@ export class Characteristic extends EventEmitter {
           throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
         }
 
-        if (isNaN(value)) {
+        if (!Number.isFinite(value)) {
           throw new Error(`Client supplied invalid type for ${this.props.format}: "${value}" (${typeof value})`)
         }
 
@@ -1911,8 +1923,8 @@ export class Characteristic extends EventEmitter {
         if (typeof value === "string") {
           value = this.props.format === Formats.FLOAT ? parseFloat(value) : parseInt(value, 10);
         }
-        if (typeof value === 'number' && isNaN(value)) {
-          this.characteristicWarning("characteristic was expected valid number and received NaN");
+        if (typeof value === 'number' && !Number.isFinite(value)) {
+          this.characteristicWarning(`characteristic value expected valid finite number and received '${value}'`);
           value = typeof this.value === 'number' ? this.value : this.props.minValue || 0;
         }
         if (typeof value !== "number") {

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1561,6 +1561,10 @@ export class Characteristic extends EventEmitter {
       value = value === 1;
     }
 
+    if (isNumericFormat(this.props.format) && typeof value === "boolean") {
+      value = value ? 1 : 0;
+    }
+
     const oldValue = this.value;
 
     if (this.setHandler) {
@@ -1742,7 +1746,7 @@ export class Characteristic extends EventEmitter {
    * must be returned.
    * @param value - Value supplied by the HomeKit controller
    */
-  private validClientSuppliedValue(value?: Nullable<CharacteristicValue>): boolean {
+  private validClientSuppliedValue(value?: Nullable<CharacteristicValue>): Nullable<CharacteristicValue> {
     if (value == undefined) {
       return false;
     }
@@ -1758,8 +1762,9 @@ export class Characteristic extends EventEmitter {
         break;
       case Formats.INT: // 32-bit signed int
         if (typeof value === "boolean") {
-          value = value? 1: 0;
-        } if (typeof value !== "number") {
+          value = value ? 1 : 0;
+        }
+        if (typeof value !== "number") {
           return false;
         }
 
@@ -1768,8 +1773,9 @@ export class Characteristic extends EventEmitter {
         break;
       case Formats.FLOAT:
         if (typeof value === "boolean") {
-          value = value? 1: 0;
-        } if (typeof value !== "number") {
+          value = value ? 1 : 0;
+        }
+        if (typeof value !== "number") {
           return false;
         }
 
@@ -1782,7 +1788,7 @@ export class Characteristic extends EventEmitter {
         break;
       case Formats.UINT8:
         if (typeof value === "boolean") {
-          value = value? 1: 0;
+          value = value ? 1 : 0;
         } if (typeof value !== "number") {
           return false;
         }
@@ -1792,7 +1798,7 @@ export class Characteristic extends EventEmitter {
         break;
       case Formats.UINT16:
         if (typeof value === "boolean") {
-          value = value? 1: 0;
+          value = value ? 1 : 0;
         } if (typeof value !== "number") {
           return false;
         }
@@ -1802,7 +1808,7 @@ export class Characteristic extends EventEmitter {
         break;
       case Formats.UINT32:
         if (typeof value === "boolean") {
-          value = value? 1: 0;
+          value = value ? 1 : 0;
         } if (typeof value !== "number") {
           return false;
         }
@@ -1812,7 +1818,7 @@ export class Characteristic extends EventEmitter {
         break;
       case Formats.UINT64:
         if (typeof value === "boolean") {
-          value = value? 1: 0;
+          value = value ? 1 : 0;
         } if (typeof value !== "number") {
           return false;
         }

--- a/src/lib/definitions/CharacteristicDefinitions.ts
+++ b/src/lib/definitions/CharacteristicDefinitions.ts
@@ -1014,7 +1014,7 @@ export class CurrentTemperature extends Characteristic {
       format: Formats.FLOAT,
       perms: [Perms.NOTIFY, Perms.PAIRED_READ],
       unit: Units.CELSIUS,
-      minValue: -273.15,
+      minValue: -270,
       maxValue: 100,
       minStep: 0.1,
     });

--- a/src/lib/definitions/generator-configuration.ts
+++ b/src/lib/definitions/generator-configuration.ts
@@ -76,7 +76,7 @@ export const CharacteristicOverriding: Map<string, (generated: GeneratedCharacte
     generated.units = "percentage";
   }],
   ["temperature.current", generated => {
-    generated.minValue = -273.15;
+    generated.minValue = -270;
   }],
   ["characteristic-value-transition-control", generated => {
     generated.properties |= PropertyId.WRITE_RESPONSE;

--- a/src/lib/util/hapStatusError.spec.ts
+++ b/src/lib/util/hapStatusError.spec.ts
@@ -1,0 +1,19 @@
+import { HAPStatus } from '../HAPServer';
+import { HapStatusError } from './hapStatusError';
+
+describe('HapStatusError', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("sets the hap status code correctly", async () => {
+    const error = new HapStatusError(HAPStatus.RESOURCE_BUSY);
+    expect(error.hapStatus).toEqual(HAPStatus.RESOURCE_BUSY);
+  });
+
+  it("reverts to SERVICE_COMMUNICATION_FAILURE if an invalid code is passed in", async () => {
+    const error = new HapStatusError(23452352352323423423);
+    expect(error.hapStatus).toEqual(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+  });
+
+});

--- a/src/lib/util/request-util.ts
+++ b/src/lib/util/request-util.ts
@@ -74,7 +74,7 @@ export function numericLowerBound(format: Formats | string): number {
     case Formats.INT:
       return -2147483648;
     case Formats.FLOAT:
-      return Number.MIN_SAFE_INTEGER;
+      return Number.NEGATIVE_INFINITY;
     case Formats.UINT8:
     case Formats.UINT16:
     case Formats.UINT32:
@@ -90,7 +90,7 @@ export function numericUpperBound(format: Formats | string): number {
     case Formats.INT:
       return 2147483647;
     case Formats.FLOAT:
-      return Number.MAX_SAFE_INTEGER;
+      return Number.POSITIVE_INFINITY;
     case Formats.UINT8:
       return 255;
     case Formats.UINT16:

--- a/src/lib/util/request-util.ts
+++ b/src/lib/util/request-util.ts
@@ -73,6 +73,8 @@ export function numericLowerBound(format: Formats | string): number {
   switch (format) {
     case Formats.INT:
       return -2147483648;
+    case Formats.FLOAT:
+      return Number.MIN_SAFE_INTEGER;
     case Formats.UINT8:
     case Formats.UINT16:
     case Formats.UINT32:
@@ -87,6 +89,8 @@ export function numericUpperBound(format: Formats | string): number {
   switch (format) {
     case Formats.INT:
       return 2147483647;
+    case Formats.FLOAT:
+      return Number.MAX_SAFE_INTEGER;
     case Formats.UINT8:
       return 255;
     case Formats.UINT16:

--- a/src/lib/util/request-util.ts
+++ b/src/lib/util/request-util.ts
@@ -74,7 +74,7 @@ export function numericLowerBound(format: Formats | string): number {
     case Formats.INT:
       return -2147483648;
     case Formats.FLOAT:
-      return Number.NEGATIVE_INFINITY;
+      return -Number.MAX_VALUE;
     case Formats.UINT8:
     case Formats.UINT16:
     case Formats.UINT32:
@@ -90,7 +90,7 @@ export function numericUpperBound(format: Formats | string): number {
     case Formats.INT:
       return 2147483647;
     case Formats.FLOAT:
-      return Number.POSITIVE_INFINITY;
+      return Number.MAX_VALUE;
     case Formats.UINT8:
       return 255;
     case Formats.UINT16:


### PR DESCRIPTION
* Fix the `validateClientSuppliedValue` (renamed from `validClientSuppliedValue`)  method so it now transforms values to their corresponding types as expected (eg. transforms `false` to `0` for a UINT8 data type).
* Floats now have an upper and lower value defined so the validation methods used on INTs can largely be reused here.
* Check for non-finite numbers such as `Infinity` and `NaN` in client and user validation methods.
* When a `number` type is thrown or returned as a callback error, HAP will now verify it's a valid hap status number, or transform it into `HAPStatus.SERVICE_COMMUNICATION_FAILURE`.
* Added the `DEBUG_MESSAGE` level to `CharacteristicWarningType`
* Warnings about invalid write responses from a `SET` handler are now debug level characteristic warnings.