### PR TITLE
Bump bonjour-hap to 3.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1497,14 +1497,14 @@
       }
     },
     "node_modules/bonjour-hap": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.6.2.tgz",
-      "integrity": "sha512-uwMGUJ2Yql/sqvxAqR4nkE4qypo5JJk7EtGMkB/ikHMHa7/0djDjB8Ct0ES+8OK8SKZzthrLngDo+e2VjcfdXw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.6.3.tgz",
+      "integrity": "sha512-qyLU96ICCYbpOFiMCjA3aNYH5Jc83XH1YX6+EXWukyyiNXzXH2LZv8AVmGW33FceF3gfUM4jYoKX2xChtNDUnA==",
       "dependencies": {
         "array-flatten": "^2.1.2",
         "deep-equal": "^2.0.5",
         "ip": "^1.1.5",
-        "multicast-dns": "^7.2.2",
+        "multicast-dns": "^7.2.3",
         "multicast-dns-service-types": "^1.1.0"
       }
     },
@@ -7262,14 +7262,14 @@
       "dev": true
     },
     "bonjour-hap": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.6.2.tgz",
-      "integrity": "sha512-uwMGUJ2Yql/sqvxAqR4nkE4qypo5JJk7EtGMkB/ikHMHa7/0djDjB8Ct0ES+8OK8SKZzthrLngDo+e2VjcfdXw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.6.3.tgz",
+      "integrity": "sha512-qyLU96ICCYbpOFiMCjA3aNYH5Jc83XH1YX6+EXWukyyiNXzXH2LZv8AVmGW33FceF3gfUM4jYoKX2xChtNDUnA==",
       "requires": {
         "array-flatten": "^2.1.2",
         "deep-equal": "^2.0.5",
         "ip": "^1.1.5",
-        "multicast-dns": "^7.2.2",
+        "multicast-dns": "^7.2.3",
         "multicast-dns-service-types": "^1.1.0"
       }
     },


### PR DESCRIPTION
To receive multicast-dns update to 7.2.3 per https://github.com/homebridge/bonjour/issues/11

Signed-off-by: GitHub <noreply@github.com>