### PR TITLE
Ensure Accessory is able to be republished

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/ciao": "~1.1.2",
+        "@homebridge/ciao": "~1.1.3",
         "bonjour-hap": "~3.6.3",
         "debug": "^4.3.2",
         "fast-srp-hap": "2.0.4",
@@ -666,14 +666,14 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.2.tgz",
-      "integrity": "sha512-31IfDKMqxfT+uVNXj0/TmYMou57gP8CUrh0vABzsc5QMsoCQ4Oo5uYQp0oJJyzxTBkF2pFvjR3XlWAapl0VyCg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.3.tgz",
+      "integrity": "sha512-p9WgcSYUj3rtC1g3ywJpKxvIZXPkkv88JxbuW6idMHrUOqDMJlWIsWF0yXynQf8Z28gA0j6AJN9EnAr+hg5gNA==",
       "dependencies": {
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "fast-deep-equal": "^3.1.3",
-        "source-map-support": "^0.5.19",
-        "tslib": "^2.0.3"
+        "source-map-support": "^0.5.20",
+        "tslib": "^2.3.1"
       },
       "bin": {
         "ciao-bcs": "lib/bonjour-conformance-testing.js"
@@ -5383,14 +5383,14 @@
       }
     },
     "@homebridge/ciao": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.2.tgz",
-      "integrity": "sha512-31IfDKMqxfT+uVNXj0/TmYMou57gP8CUrh0vABzsc5QMsoCQ4Oo5uYQp0oJJyzxTBkF2pFvjR3XlWAapl0VyCg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.3.tgz",
+      "integrity": "sha512-p9WgcSYUj3rtC1g3ywJpKxvIZXPkkv88JxbuW6idMHrUOqDMJlWIsWF0yXynQf8Z28gA0j6AJN9EnAr+hg5gNA==",
       "requires": {
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "fast-deep-equal": "^3.1.3",
-        "source-map-support": "^0.5.19",
-        "tslib": "^2.0.3"
+        "source-map-support": "^0.5.20",
+        "tslib": "^2.3.1"
       }
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types"
   ],
   "dependencies": {
-    "@homebridge/ciao": "~1.1.2",
+    "@homebridge/ciao": "~1.1.3",
     "bonjour-hap": "~3.6.3",
     "debug": "^4.3.2",
     "fast-srp-hap": "2.0.4",

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -309,7 +309,16 @@ export const enum AccessoryEventTypes {
    * You must call the callback for identification to be successful.
    */
   IDENTIFY = "identify",
+  /**
+   * This event is emitted once the HAP TCP socket is bound.
+   * At this point the mdns advertisement isn't yet available. Use the {@link ADVERTISED} if you require the accessory to be discoverable.
+   */
   LISTENING = "listening",
+  /**
+   * This event is emitted once the mDNS suite has fully advertised the presence of the accessory.
+   * This event is guaranteed to be called after {@link LISTENING}.
+   */
+  ADVERTISED = "advertised",
   SERVICE_CONFIGURATION_CHANGE = "service-configurationChange",
   /**
    * Emitted after a change in the value of one of the provided Service's Characteristics.
@@ -324,6 +333,7 @@ export const enum AccessoryEventTypes {
 export declare interface Accessory {
   on(event: "identify", listener: (paired: boolean, callback: VoidCallback) => void): this;
   on(event: "listening", listener: (port: number, address: string) => void): this;
+  on(event: "advertised", listener: () => void): this;
 
   on(event: "service-configurationChange", listener: (change: ServiceConfigurationChange) => void): this;
   on(event: "service-characteristic-change", listener: (change: AccessoryCharacteristicChange) => void): this;
@@ -336,6 +346,7 @@ export declare interface Accessory {
 
   emit(event: "identify", paired: boolean, callback: VoidCallback): boolean;
   emit(event: "listening", port: number, address: string): boolean;
+  emit(event: "advertised"): boolean;
 
   emit(event: "service-configurationChange", change: ServiceConfigurationChange): boolean;
   emit(event: "service-characteristic-change", change: AccessoryCharacteristicChange): boolean;
@@ -375,6 +386,12 @@ export class Accessory extends EventEmitter {
   services: Service[] = [];
   private primaryService?: Service;
   shouldPurgeUnusedIDs: boolean = true; // Purge unused ids by default
+  /**
+   * Captures if initialization steps inside {@link publish} have been called.
+   * This is important when calling {@link publish} multiple times (e.g. after calling {@link unpublish}).
+   * @private Private API
+   */
+  private initialized: boolean = false
 
   private controllers: Record<ControllerIdentifier, ControllerContext> = {};
   private serializedControllers?: Record<ControllerIdentifier, ControllerServiceMap>; // store uninitialized controller data after a Accessory.deserialize call
@@ -390,7 +407,7 @@ export class Accessory extends EventEmitter {
 
   private configurationChangeDebounceTimeout?: Timeout;
   /**
-   * This property captures the time when we last server a /accessories request.
+   * This property captures the time when we last served a /accessories request.
    * For multiple bursts of /accessories request we don't want to always contact GET handlers
    */
   private lastAccessoriesRequest: number = 0;
@@ -1114,8 +1131,8 @@ export class Accessory extends EventEmitter {
       Accessory.cleanupAccessoryData(this.lastKnownUsername); // delete old Accessory data
     }
 
-    if (info.addIdentifyingMaterial ?? true) {
-      // adding some identifying material to our displayName
+    if (!this.initialized && (info.addIdentifyingMaterial ?? true)) {
+      // adding some identifying material to our displayName if its our first publish() call
       this.displayName = this.displayName + " " + crypto.createHash('sha512')
         .update(info.username, 'utf8')
         .digest('hex').slice(0, 4).toUpperCase();
@@ -1166,7 +1183,9 @@ export class Accessory extends EventEmitter {
       this.controllerStorage.purgeUnidentifiedAccessoryData = false;
     }
 
-    this.controllerStorage.load(info.username); // initializing controller data
+    if (!this.initialized) { // controller storage is only loaded from disk the first time we publish!
+      this.controllerStorage.load(info.username); // initializing controller data
+    }
 
     // assign aid/iid
     this._assignIDs(this._identifierCache);
@@ -1231,6 +1250,8 @@ export class Accessory extends EventEmitter {
     this._server.on(HAPServerEventTypes.REQUEST_RESOURCE, this.handleResource.bind(this));
 
     this._server.listen(info.port, parsed.serverAddress);
+
+    this.initialized = true;
   }
 
   /**
@@ -1251,14 +1272,14 @@ export class Accessory extends EventEmitter {
     this.removeAllListeners();
   }
 
-  public unpublish(): void {
+  public async unpublish(): Promise<void> {
     if (this._server) {
       this._server.destroy();
       this._server = undefined;
     }
     if (this._advertiser) {
       // noinspection JSIgnoredPromiseFromCall
-      this._advertiser.destroy();
+      await this._advertiser.destroy();
       this._advertiser = undefined;
     }
   }
@@ -1291,8 +1312,10 @@ export class Accessory extends EventEmitter {
     assert(this._advertiser, "Advertiser wasn't created at onListening!");
     // the HAP server is listening, so we can now start advertising our presence.
     this._advertiser!.initPort(port);
-    // noinspection JSIgnoredPromiseFromCall
-    this._advertiser!.startAdvertising();
+
+    this._advertiser!.startAdvertising()
+      .then(() => this.emit(AccessoryEventTypes.ADVERTISED));
+
     this.emit(AccessoryEventTypes.LISTENING, port, hostname);
   }
 

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1259,8 +1259,8 @@ export class Accessory extends EventEmitter {
    * Accessory object will no longer valid after invoking this method
    * Trying to invoke publish() on the object will result undefined behavior
    */
-  public destroy(): void {
-    this.unpublish();
+  public destroy(): Promise<void> {
+    let promise = this.unpublish();
 
     if (this._accessoryInfo) {
       Accessory.cleanupAccessoryData(this._accessoryInfo.username);
@@ -1270,6 +1270,8 @@ export class Accessory extends EventEmitter {
       this.controllerStorage = new ControllerStorage(this);
     }
     this.removeAllListeners();
+
+    return promise;
   }
 
   public async unpublish(): Promise<void> {

--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -14,6 +14,7 @@ import crypto from 'crypto';
 import createDebug from "debug";
 import { EventEmitter } from "events";
 import { AccessoryInfo } from './model/AccessoryInfo';
+import { PromiseTimeout } from "./util/promise-utils";
 
 const debug = createDebug('HAP-NodeJS:Advertiser');
 
@@ -74,7 +75,7 @@ export interface Advertiser {
 
   initPort(port: number): void;
 
-  startAdvertising(): void;
+  startAdvertising(): Promise<void>;
 
   updateAdvertisement(silent?: boolean): void;
 
@@ -135,7 +136,7 @@ export class CiaoAdvertiser extends EventEmitter implements Advertiser {
   }
 
   public async destroy(): Promise<void> {
-    await this.advertisedService!.destroy();
+    // advertisedService.destroy(); is called implicitly via the shutdown call
     await this.responder.shutdown();
     this.removeAllListeners();
   }
@@ -209,7 +210,7 @@ export class BonjourHAPAdvertiser extends EventEmitter implements Advertiser {
     this.port = port;
   }
 
-  public startAdvertising(): void {
+  public startAdvertising(): Promise<void> {
     assert(!this.destroyed, "Can't advertise on a destroyed bonjour instance!");
     if (this.port == undefined) {
       throw new Error("Tried starting bonjour-hap advertisement without initializing port!");
@@ -232,6 +233,8 @@ export class BonjourHAPAdvertiser extends EventEmitter implements Advertiser {
       addUnsafeServiceEnumerationRecord: true,
       ...this.serviceOptions,
     });
+
+    return PromiseTimeout(1);
   }
 
   public updateAdvertisement(silent?: boolean): void {

--- a/src/lib/util/promise-utils.ts
+++ b/src/lib/util/promise-utils.ts
@@ -1,0 +1,6 @@
+
+export function PromiseTimeout(timeout: number): Promise<void> {
+  return new Promise<void>(resolve => {
+    setTimeout(() => resolve(), timeout);
+  });
+}


### PR DESCRIPTION
# Ensure Accessory is able to be republished

## :recycle: Current situation

Currently the ability to republish (calling `Accessory.publish` after `unpublish` has been called) isn't really supported.
Further, there are regressions introduced in the past (see #895) which now prevent this completely.

## :bulb: Proposed solution
This PR adds a minimal set of test cases to test the behavior of a `publish` call following a `unpublish` call.

### Problem that is solved
With this test we identified three issues:
* The problem reported in #895 
* If `addIdentifyingMaterial` option was turned on, this was done a second time when republishing
* When `unpublish` is called instantly on the `LISTENING` event and the CIAO advertiser is used one might encounter a race condition where the Probing step isn't properly canceled (as the `unpublish` was called while the Networking stack was still initializing). This issue isn't currently fixed. As a workaround we introduced the `ADVERTISED` event to the `Accessory` class which is triggered when the advertising step completed successfully. It is noted, that this might (due to the Probing) add significant delay to the event execution when using CIAO.

### Implications

## :heavy_plus_sign: Additional Information
Both `Accessory.unpublish` and `Accessory.destroy` calls where modified to return a Promise now, such that one can wait until the mDNS advertising was fully removed. This only has any effects when using the CIAO advertiser.

### Testing

A new test case was added to test publish and unpublish calls of an Accessory. The test case doesn't currently have extensive assertion logic (e.g. to test stuff around IdentifierCache, Accessory structure or other storage and state components). The test only expose a simple accessory (one service, no multiple service, multi controller or bridge setup).

<!-- Credits to @lschlesinger for creating this PR template :) -->
