### PR TITLE
Fix: Changed VOC[maxValue:5000], for support WirenBoard MSW sensors

### DIFF
--- a/src/lib/definitions/CharacteristicDefinitions.ts
+++ b/src/lib/definitions/CharacteristicDefinitions.ts
@@ -4846,7 +4846,7 @@ export class VOCDensity extends Characteristic {
       format: Formats.FLOAT,
       perms: [Perms.NOTIFY, Perms.PAIRED_READ],
       minValue: 0,
-      maxValue: 1000,
+      maxValue: 5000,
       minStep: 1,
     });
     this.value = this.getDefaultValue();


### PR DESCRIPTION
## :recycle: Current situation

* The system does not support a VOC value greater than 1000. We use WirenBoard MSW sensors, which shows VOC from 0 to 5000. Sensor information: https://wirenboard.com/wiki/WB-MSW_v.3_Modbus_Sensor/en

## :bulb: Proposed solution

* Change maxValue for VOC to 5000

### Testing

* Values in HomeKit on iPhone are shown correctly
