### PR TITLE
Fix hapCrypto crash for OpenSSL 3.x versions shipped with node v17 on linux

### DIFF
--- a/src/lib/util/hapCrypto.ts
+++ b/src/lib/util/hapCrypto.ts
@@ -23,10 +23,6 @@ export function HKDF(hashAlg: string, salt: Buffer, ikm: Buffer, info: Buffer, s
 
 //Security Layer Enc/Dec
 
-type Count = {
-  value: any;
-}
-
 export function layerEncrypt(data: Buffer, encryption: HAPEncryption) {
   let result = Buffer.alloc(0);
   const total = data.length;
@@ -76,8 +72,15 @@ export function layerDecrypt(packet: Buffer, encryption: HAPEncryption) {
 }
 
 export function chacha20_poly1305_decryptAndVerify(key: Buffer, nonce: Buffer, aad: Buffer | null, ciphertext: Buffer, authTag: Buffer): Buffer {
+  if (nonce.length < 12) { // openssl 3.x.x requires 98 bits nonce length
+    nonce = Buffer.concat([
+      Buffer.alloc(12 - nonce.length, 0),
+      nonce
+    ])
+  }
+
   // @ts-ignore types for this a really broken
-  const decipher = crypto.createDecipheriv("chacha20-poly1305", key, nonce, { authTagLength:16 });
+  const decipher = crypto.createDecipheriv("chacha20-poly1305", key, nonce, { authTagLength: 16 });
   if (aad) {
     decipher.setAAD(aad);
   }
@@ -89,6 +92,13 @@ export function chacha20_poly1305_decryptAndVerify(key: Buffer, nonce: Buffer, a
 }
 
 export function chacha20_poly1305_encryptAndSeal(key: Buffer, nonce: Buffer, aad: Buffer | null, plaintext: Buffer): { ciphertext: Buffer, authTag: Buffer } {
+  if (nonce.length < 12) { // openssl 3.x.x requires 98 bits nonce length
+    nonce = Buffer.concat([
+      Buffer.alloc(12 - nonce.length, 0),
+      nonce
+    ])
+  }
+
   // @ts-ignore types for this a really broken
   const cipher = crypto.createCipheriv("chacha20-poly1305", key, nonce, { authTagLength: 16 });
 


### PR DESCRIPTION
## :recycle: Current situation

As reported in #916, nodejs v17 ships with OpenSSL 3 on linux machines which require 96 bits nonce length for `chacha20-poly1305` (OpneSSL 1.x did automatically fill up with zeros).

_This is the PR for release 0.9.8 and is available as a beta release already._

## :bulb: Proposed solution

This PR updates `hapCrypto` to automatically create a 96 bit buffer if necessary and fills it with zeros (as mandated by the HAP spec).

## :gear: Release Notes

* Fixed an issue which crash on any client communication when running NodeJs 17 on linux based machines

## :heavy_plus_sign: Additional Information

Removed some leftover and unused typedef.

### Testing

--

### Reviewer Nudging

--
