### PR TITLE
Automatically use Avahi/DBus advertiser if available on platform

### DIFF
--- a/src/lib/Accessory.spec.ts
+++ b/src/lib/Accessory.spec.ts
@@ -131,7 +131,7 @@ describe('Accessory', () => {
         advertiser: advertiser
       };
 
-      accessory.publish(publishInfo);
+      await accessory.publish(publishInfo);
 
       expect(accessory.displayName.startsWith(DEFAULT_DISPLAY_NAME));
       expect(accessory.displayName.length).toEqual(DEFAULT_DISPLAY_NAME.length + 1 + 4); // added hash!
@@ -149,7 +149,7 @@ describe('Accessory', () => {
 
       await PromiseTimeout(200);
 
-      accessory.publish(publishInfo)
+      await accessory.publish(publishInfo)
 
       // ensure unification isn't done twice!
       expect(accessory.displayName).toEqual(displayNameWithIdentifyingMaterial);
@@ -157,7 +157,30 @@ describe('Accessory', () => {
       await awaitEvent(accessory, AccessoryEventTypes.ADVERTISED);
 
       await accessory.unpublish();
-    })
+    });
+
+    test("Clean Accessory publish and unpublish with default advertiser selection", async () => {
+      const accessory = new Accessory(DEFAULT_DISPLAY_NAME, uuid.generate("foo"));
+
+      const switchService = new Service.Switch("My Example Switch");
+      accessory.addService(switchService);
+
+      let publishInfo: PublishInfo = {
+        username: TEST_USERNAME,
+        pincode: "000-00-000",
+        category: Categories.SWITCH,
+        advertiser: undefined,
+      };
+
+      await accessory.publish(publishInfo);
+
+      expect(accessory.displayName.startsWith(DEFAULT_DISPLAY_NAME));
+      expect(accessory.displayName.length).toEqual(DEFAULT_DISPLAY_NAME.length + 1 + 4); // added hash!
+
+      await awaitEvent(accessory, AccessoryEventTypes.ADVERTISED);
+
+      await accessory.unpublish();
+    });
   });
 
   describe("characteristicWarning", () => {

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1109,7 +1109,7 @@ export class Accessory extends EventEmitter {
    *                                that for instance an appropriate icon can be drawn for the user while adding a
    *                                new Accessory.
    */
-  public publish(info: PublishInfo, allowInsecureRequest?: boolean): void {
+  public async publish(info: PublishInfo, allowInsecureRequest?: boolean): Promise<void> {
     // noinspection JSDeprecatedSymbols
     if (!info.advertiser && info.useLegacyAdvertiser != null) {
       // noinspection JSDeprecatedSymbols
@@ -1206,7 +1206,10 @@ export class Accessory extends EventEmitter {
     // create our Advertiser which broadcasts our presence over mdns
     const parsed = Accessory.parseBindOption(info);
 
-    switch (info.advertiser ?? MDNSAdvertiser.BONJOUR) {
+    const defaultAdvertiser = info.advertiser
+      ?? (await AvahiAdvertiser.isAvailable() ? MDNSAdvertiser.AVAHI : MDNSAdvertiser.BONJOUR);
+
+    switch (defaultAdvertiser) {
       case MDNSAdvertiser.CIAO:
         this._advertiser = new CiaoAdvertiser(this._accessoryInfo, {
           interface: parsed.advertiserAddress

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1325,7 +1325,8 @@ export class Accessory extends EventEmitter {
     this._advertiser!.initPort(port);
 
     this._advertiser!.startAdvertising()
-      .then(() => this.emit(AccessoryEventTypes.ADVERTISED));
+      .then(() => this.emit(AccessoryEventTypes.ADVERTISED))
+      .catch(reason => console.error("Could not create mDNS advertisement. The HAP-Server won't be discoverable: " + reason))
 
     this.emit(AccessoryEventTypes.LISTENING, port, hostname);
   }

--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -285,6 +285,11 @@ export class AvahiAdvertiser extends EventEmitter implements Advertiser {
 
     this.bus = AvahiAdvertiser.globalBus ?? dbus.systemBus();
 
+    // TODO debug remove!
+    this.bus.connection.on("message", message => {
+      console.log("Received MESSAGE: " + message);
+    });
+
     console.log(`Preparing Advertiser for '${this.accessoryInfo.displayName}' using Avahi backend!`);
   }
 
@@ -349,8 +354,9 @@ export class AvahiAdvertiser extends EventEmitter implements Advertiser {
     }
 
     try {
-      const result = await this.avahiInvoke(this.globalBus, "/", "Server", "GetVersionString")
-      console.log("BUS_RESULT: " + result); // TODO remove!
+      // TODO avahi might be installed but not running!
+      const version = await this.avahiInvoke(this.globalBus, "/", "Server", "GetVersionString")
+      debug("Detected Avahi over DBus interface running version '%s'.", version);
     } catch (error) {
       debug("Avahi/DBus classified unavailable due to missing avahi interface!");
       return false;

--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -273,8 +273,8 @@ export class AvahiAdvertiser extends EventEmitter implements Advertiser {
 
   private port?: number;
 
-  private readonly bus?: MessageBus;
-  private path: string = '';
+  private bus?: MessageBus;
+  private path?: string;
 
   constructor(accessoryInfo: AccessoryInfo) {
     super();
@@ -355,10 +355,11 @@ export class AvahiAdvertiser extends EventEmitter implements Advertiser {
         // Typically, this fails if e.g. avahi service was stopped in the meantime.
         debug("Destroying Avahi advertisement failed: " + error)
       }
-      this.path = '';
+      this.path = undefined;
     }
 
     this.bus.connection.stream.destroy()
+    this.bus = undefined
   }
 
   public static async isAvailable(): Promise<boolean> {

--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -287,10 +287,10 @@ export class AvahiAdvertiser extends EventEmitter implements Advertiser {
 
     // TODO debug remove!
     this.bus.connection.on("message", message => {
-      console.log("Received MESSAGE: " + message);
+      debug("Received MESSAGE: " + JSON.stringify(message));
     });
 
-    console.log(`Preparing Advertiser for '${this.accessoryInfo.displayName}' using Avahi backend!`);
+    debug(`Preparing Advertiser for '${this.accessoryInfo.displayName}' using Avahi backend!`);
   }
 
   private createTxt(): Array<Buffer> {
@@ -306,7 +306,7 @@ export class AvahiAdvertiser extends EventEmitter implements Advertiser {
       throw new Error("Tried starting Avahi advertisement without initializing port!");
     }
 
-    console.log(`Starting to advertise '${this.accessoryInfo.displayName}' using Avahi backend!`);
+    debug(`Starting to advertise '${this.accessoryInfo.displayName}' using Avahi backend!`);
 
     this.path = await AvahiAdvertiser.avahiInvoke(this.bus, '/', 'Server', 'EntryGroupNew') as string;
     await AvahiAdvertiser.avahiInvoke(this.bus, this.path, 'EntryGroup', 'AddService', {
@@ -343,7 +343,6 @@ export class AvahiAdvertiser extends EventEmitter implements Advertiser {
   }
 
   public static async isAvailable(): Promise<boolean> {
-    // TODO dynmaically import dbus?
     this.globalBus = this.globalBus ?? dbus.systemBus();
 
     try {

--- a/src/types/dbus-native.d.ts
+++ b/src/types/dbus-native.d.ts
@@ -1,11 +1,16 @@
 declare module "@homebridge/dbus-native" {
   import { EventEmitter } from "events";
+  import { Socket } from "net";
 
-  function systemBus(): SystemBus;
+  function systemBus(): MessageBus;
 
-  export class SystemBus {
-    connection: EventEmitter
+  export class MessageBus {
+    connection: BusConnection
 
     public invoke(message: any, callback: any): void;
+  }
+
+  export class BusConnection extends EventEmitter {
+    public stream: Socket
   }
 }

--- a/src/types/dbus-native.d.ts
+++ b/src/types/dbus-native.d.ts
@@ -1,1 +1,11 @@
-declare module "@homebridge/dbus-native";
+declare module "@homebridge/dbus-native" {
+  import { EventEmitter } from "events";
+
+  function systemBus(): SystemBus;
+
+  export class SystemBus {
+    connection: EventEmitter
+
+    public invoke(message: any, callback: any): void;
+  }
+}


### PR DESCRIPTION
## :recycle: Current situation

PR #918 introduced a new advertiser using native avahi over its dbus interface. The advertiser required to be manually enabled.

## :bulb: Proposed solution

This PR adds additional heuristic to check if (a) dbus is installed and (b) avahi is installed. If both is the case hap-nodejs will use the `AVAHI` advertiser if nothing else is specified.

## :gear: Release Notes

* The new `avahi` based advertiser will be automatically used on supported platforms.

## :heavy_plus_sign: Additional Information

Note, due to the fact that the new checks are performed asynchronously, the `Accessory.publish` signature was changed to return a `Promise<void>` instead of `void`.

### Testing

Added an additional test case, ensuring that the availability check succeeds in CI environment.

### Reviewer Nudging

--
