### PR TITLE
Use bonjour advertiser as default again, warn when Avahi is used on an unsupported platform.

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1220,10 +1220,14 @@ export class Accessory extends EventEmitter {
     // create our Advertiser which broadcasts our presence over mdns
     const parsed = Accessory.parseBindOption(info);
 
-    const defaultAdvertiser = info.advertiser
-      ?? (await AvahiAdvertiser.isAvailable() ? MDNSAdvertiser.AVAHI : MDNSAdvertiser.BONJOUR);
+    let selectedAdvertiser = info.advertiser ?? MDNSAdvertiser.BONJOUR;
+    if (info.advertiser === MDNSAdvertiser.AVAHI && !await AvahiAdvertiser.isAvailable()) {
+      console.error("[${this.displayName}] Selected \"" + MDNSAdvertiser.AVAHI + "\" advertiser though it isn't available on the platform. " +
+        "Reverting to \"" + MDNSAdvertiser.BONJOUR + "\"");
+      selectedAdvertiser = MDNSAdvertiser.BONJOUR;
+    }
 
-    switch (defaultAdvertiser) {
+    switch (selectedAdvertiser) {
     case MDNSAdvertiser.CIAO:
       this._advertiser = new CiaoAdvertiser(this._accessoryInfo, {
         interface: parsed.advertiserAddress,


### PR DESCRIPTION
## :recycle: Current situation

For the beta period of 0.10.0 we changed how we select the default advertiser, moving from `bonjour` to `avahi` as a default if we our heuristic detects it being available on the platform.
This heuristic might not be perfect and might result in non advertised HAP service (see https://github.com/homebridge/homebridge/pull/3062#issuecomment-1014326006).

## :bulb: Proposed solution

To avoid any breaking changes for existing users, this PR revers the default advertiser back to the `bonjour` package.

## :gear: Release Notes

* Revert to `bonjour` as the default advertiser.

## :heavy_plus_sign: Additional Information

When selecting the `avahi` advertiser, this PR will now additionally run the availability check, and revert to `bonjour` if we find to be running on a non compatible platform. Additionally, we print an error message informing the user about it.

### Testing

--

### Reviewer Nudging

--
