### PR TITLE
HSV: Properly handle closed HDS connection; ensure recording streams are always freed

### DIFF
--- a/src/lib/camera/RecordingManagement.ts
+++ b/src/lib/camera/RecordingManagement.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import crypto from "crypto";
 import createDebug from "debug";
 import { EventEmitter } from "events";

--- a/src/lib/camera/RecordingManagement.ts
+++ b/src/lib/camera/RecordingManagement.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import crypto from "crypto";
 import createDebug from "debug";
 import { EventEmitter } from "events";
@@ -874,7 +875,17 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
   private readonly closeListener: () => void;
 
   private generator?: AsyncGenerator<RecordingPacket>;
+  /**
+   * This timeout is used to detect non-returning generators.
+   * When we signal the delegate that it is being closed its generator must return withing 10s.
+   */
   private generatorTimeout?: NodeJS.Timeout;
+  /**
+   * This timer is used to check if the stream is properly closed when we expect it to do so.
+   * When we expect a close signal from the remote, we wait 4s for it. Otherwise, we abort and close it ourselves.
+   * This ensures memory is freed, and that we recover fast from erroneous states.
+   */
+  private closingTimeout?: NodeJS.Timeout;
 
   constructor(connection: DataStreamConnection, delegate: CameraRecordingDelegate, requestId: number, streamId: number) {
     super();
@@ -907,10 +918,6 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
 
     // tracks if the last received RecordingPacket was yielded with `isLast=true`.
     let lastFragmentWasMarkedLast = false;
-
-    // in the `finally` block we ensure that when we exit this loop, we are properly freeing this recording stream.
-    // With this property we save a close reason if we encounter any to provide context to the delegate.
-    let finallyCloseReason: HDSProtocolSpecificErrorReason | undefined = HDSProtocolSpecificErrorReason.UNEXPECTED_FAILURE;
 
     try {
       this.generator = this.delegate.handleRecordingStreamRequest(this.streamId);
@@ -976,24 +983,21 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
       if (this.closed) {
         console.warn(`[HDS ${this.connection.remoteAddress}] Encountered unexpected error on already closed recording stream ${this.streamId}: ${error.stack}`);
       } else {
-        finallyCloseReason = HDSProtocolSpecificErrorReason.UNEXPECTED_FAILURE;
+        let closeReason = HDSProtocolSpecificErrorReason.UNEXPECTED_FAILURE;
 
         if (error instanceof HDSProtocolError) {
-          finallyCloseReason = error.reason;
+          closeReason = error.reason;
           debug("[HDS %s] Delegate signaled to close the recording stream %d.", this.connection.remoteAddress, this.streamId);
         } else if (error instanceof HDSConnectionError && error.type === HDSConnectionErrorType.CLOSED_SOCKET) {
           // we are probably on a shutdown or just late. Connection is dead. End the stream!
-          finallyCloseReason = undefined; // undefined reason signals connection close
           debug("[HDS %s] Exited recording stream due to closed HDS socket: stream id %d.", this.connection.remoteAddress, this.streamId);
-          return; // execute finally and then exit (most importantly: we skip the `sendEvent` below)
+          return; // execute finally and then exit (we want to skip the `sendEvent` below)
         } else {
           console.error(`[HDS ${this.connection.remoteAddress}] Encountered unexpected error for recording stream ${this.streamId}: ${error.stack}`);
         }
 
-        this.connection.sendEvent(Protocols.DATA_SEND, Topics.CLOSE, {
-          streamId: this.streamId,
-          reason: finallyCloseReason!,
-        });
+        // call close to go through standard close routine!
+        this.close(closeReason);
       }
       return;
     } finally {
@@ -1003,9 +1007,11 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
         clearTimeout(this.generatorTimeout);
       }
 
-      // ensure the stream is properly closed!
       if (!this.closed) {
-        this.close(finallyCloseReason);
+        // e.g. when returning with `endOfStream` we rely on the HomeHub to send an ACK event to close the recording.
+        // With this timer we ensure that the HomeHub has the chance to close the stream gracefully but at the same time
+        // ensure that if something fails the recording stream is freed nonetheless.
+        this.kickOfCloseTimeout();
       }
     }
 
@@ -1057,6 +1063,11 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
   private handleClosed(closure: () => void): void {
     this.closed = true;
 
+    if (this.closingTimeout) {
+      clearTimeout(this.closingTimeout);
+      this.closingTimeout = undefined;
+    }
+
     this.connection.removeProtocolHandler(Protocols.DATA_SEND, this);
     this.connection.removeListener(DataStreamConnectionEvent.CLOSED, this.closeListener);
 
@@ -1064,8 +1075,8 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
       // when this variable is defined, the generator hasn't returned yet.
       // we start a timeout to uncover potential programming mistakes where we await forever and can't free resources.
       this.generatorTimeout = setTimeout(() => {
-        console.error("[HDS %s] Recording download stream %d is still awaiting generator although stream was closed 10s ago!",
-          this.connection.remoteAddress, this.streamId);
+        console.error("[HDS %s] Recording download stream %d is still awaiting generator although stream was closed 10s ago! " +
+          "This is a programming mistake by the camera implementation which prevents freeing up resources.", this.connection.remoteAddress, this.streamId);
       }, 10000);
     }
 
@@ -1091,11 +1102,29 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
       // @ts-expect-error: forceConsistentCasingInFileNames compiler option
       this.connection.remoteAddress, this.streamId, reason ? HDSProtocolSpecificErrorReason[reason] : "CLOSED");
 
-    this.connection.sendEvent(Protocols.DATA_SEND, Topics.CLOSE, {
-      streamId: this.streamId,
-      reason: reason,
-    });
+    // the `isConsideredClosed` check just ensures that the won't ever throw here and that `handledClosed` is always executed.
+    if (!this.connection.isConsideredClosed()) {
+      this.connection.sendEvent(Protocols.DATA_SEND, Topics.CLOSE, {
+        streamId: this.streamId,
+        reason: reason,
+      });
+    }
 
     this.handleClosed(() => this.delegate.closeRecordingStream(this.streamId, reason));
+  }
+
+  private kickOfCloseTimeout(): void {
+    if (this.closingTimeout) {
+      clearTimeout(this.closingTimeout);
+    }
+
+    this.closingTimeout = setTimeout(() => {
+      if (this.closed) {
+        return;
+      }
+
+      debug("[HDS %s] Recording stream %d took longer than expected to fully close. Force closing now!", this.connection.remoteAddress, this.streamId);
+      this.close(undefined);
+    }, 4000);
   }
 }

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -1043,6 +1043,10 @@ export class DataStreamConnection extends EventEmitter {
     this.socket.end();
   }
 
+  isConsideredClosed(): boolean {
+    return this.state >= ConnectionState.CLOSING;
+  }
+
   private onHAPSessionClosed() {
     // If the hap connection is closed it is probably also a good idea to close the data stream connection
     debug("[%s] HAP connection disconnected. Also closing DataStream connection now.", this.remoteAddress);

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -493,6 +493,21 @@ export declare interface DataStreamConnection {
   emit(event: "closed"): boolean;
 }
 
+export const enum HDSConnectionErrorType {
+  ILLEGAL_STATE = 1,
+  CLOSED_SOCKET = 2,
+  MAX_PAYLOAD_LENGTH = 3,
+}
+
+export class HDSConnectionError extends Error {
+  readonly type: HDSConnectionErrorType;
+
+  constructor(message: string, type: HDSConnectionErrorType) {
+    super(message);
+    this.type = type;
+  }
+}
+
 /**
  * DataStream connection which holds any necessary state information, encryption an decryption keys, manages
  * protocol handlers and also handles sending and receiving of data stream frames.
@@ -655,7 +670,7 @@ export class DataStreamConnection extends EventEmitter {
       delete this.responseHandlers[requestId];
       delete this.responseTimers[requestId];
 
-      // handler should be able to cleanup their stuff
+      // handler should be able to clean up their stuff
       handler(new Error("timeout"), undefined, {});
     }, 10000); // 10s timer
 
@@ -894,7 +909,7 @@ export class DataStreamConnection extends EventEmitter {
     frames.forEach(frame => {
       const payload = frame.plaintextPayload;
       if (!payload) {
-        throw new Error("Reached illegal state. Encountered HDSFrame with wasn't decrypted yet!");
+        throw new HDSConnectionError("Reached illegal state. Encountered HDSFrame with wasn't decrypted yet!", HDSConnectionErrorType.ILLEGAL_STATE);
       }
 
       const headerLength = payload.readUInt8(0);
@@ -966,7 +981,7 @@ export class DataStreamConnection extends EventEmitter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private sendHDSFrame(header: Record<any, any>, message: Record<any, any>) {
     if (this.state >= ConnectionState.CLOSING) {
-      throw Error("Cannot send message on closing/closed socket!");
+      throw new HDSConnectionError("Cannot send message on closing/closed socket!", HDSConnectionErrorType.CLOSED_SOCKET);
     }
 
     const headerWriter = new DataStreamWriter();
@@ -980,7 +995,10 @@ export class DataStreamConnection extends EventEmitter {
     payloadHeaderBuffer.writeUInt8(headerWriter.length(), 0);
     const payloadBuffer = Buffer.concat([payloadHeaderBuffer, headerWriter.getData(), messageWriter.getData()]);
     if (payloadBuffer.length > DataStreamConnection.MAX_PAYLOAD_LENGTH) {
-      throw new Error("Tried sending payload with length larger than the maximum allowed for data stream");
+      throw new HDSConnectionError(
+        "Tried sending payload with length larger than the maximum allowed for data stream",
+        HDSConnectionErrorType.MAX_PAYLOAD_LENGTH,
+      );
     }
 
     const frameTypeBuffer = Buffer.alloc(1);


### PR DESCRIPTION
## :recycle: Current situation

As reported in #926, shutting down `hap-nodejs` during an ongoing recording session will result in an unhandled erroneous state.

## :bulb: Proposed solution

This PR introduces additional measures to gracefully exit a recording stream when encountering a closed socket!

Additionally, the "main loop" of the recording stream was refactored to ensure that resources are always freed once the stream has ended.

## :gear: Release Notes

* Fixed an unhanded error when shutting down `hap-nodejs` while a HSV recording stream is still in progress.
* Improved handling of ongoing HSV recording streams to ensure resources are always freed in erroneous states.

## :heavy_plus_sign: Additional Information

This PR resolves #926.

### Testing

Nothing changed.

### Reviewer Nudging

--
