### PR TITLE
Properly type once

### DIFF
--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1589,7 +1589,7 @@ export class Characteristic extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       try {
-        this.emit(CharacteristicEventTypes.GET, once((status?: Error | HAPStatus | null, value?: Nullable<CharacteristicValue>) => {
+        this.emit(CharacteristicEventTypes.GET, once((status, value) => {
           if (status) {
             if (typeof status === "number") {
               const hapStatusError = new HapStatusError(status);
@@ -1722,7 +1722,7 @@ export class Characteristic extends EventEmitter {
     } else {
       return new Promise((resolve, reject) => {
         try {
-          this.emit(CharacteristicEventTypes.SET, value, once((status?: Error | HAPStatus | null, writeResponse?: Nullable<CharacteristicValue>) => {
+          this.emit(CharacteristicEventTypes.SET, value, once((status, writeResponse) => {
             if (status) {
               if (typeof status === "number") {
                 const hapStatusError = new HapStatusError(status);

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -430,7 +430,7 @@ export class HAPServer extends EventEmitter {
       return;
     }
 
-    this.emit(HAPServerEventTypes.IDENTIFY, once((err: Error) => {
+    this.emit(HAPServerEventTypes.IDENTIFY, once(err => {
       if (!err) {
         debug("[%s] Identification success", this.accessoryInfo.username);
         response.writeHead(HAPHTTPCode.NO_CONTENT);
@@ -602,7 +602,7 @@ export class HAPServer extends EventEmitter {
     const encrypted = hapCrypto.chacha20_poly1305_encryptAndSeal(hkdfEncKey, Buffer.from("PS-Msg06"), null, message);
 
     // finally, notify listeners that we have been paired with a client
-    this.emit(HAPServerEventTypes.PAIR, clientUsername.toString(), clientLTPK, once((err?: Error) => {
+    this.emit(HAPServerEventTypes.PAIR, clientUsername.toString(), clientLTPK, once(err => {
       if (err) {
         debug("[%s] Error adding pairing info: %s", this.accessoryInfo.username, err.message);
         response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
@@ -812,7 +812,7 @@ export class HAPServer extends EventEmitter {
       return;
     }
     // call out to listeners to retrieve the latest accessories JSON
-    this.emit(HAPServerEventTypes.ACCESSORIES, connection, once((error: HAPHttpError | undefined, result: AccessoriesResponse) => {
+    this.emit(HAPServerEventTypes.ACCESSORIES, connection, once((error, result) => {
       if (error) {
         response.writeHead(error.httpCode, { "Content-Type": "application/hap+json" });
         response.end(JSON.stringify({ status: error.status }));
@@ -861,14 +861,15 @@ export class HAPServer extends EventEmitter {
         HAPServerEventTypes.GET_CHARACTERISTICS,
         connection,
         readRequest,
-        once((error: HAPHttpError | undefined, readResponse: CharacteristicsReadResponse) => {
+        once((error, readResponse) => {
           if (error) {
             response.writeHead(error.httpCode, { "Content-Type": "application/hap+json" });
             response.end(JSON.stringify({ status: error.status }));
             return;
           }
 
-          const characteristics = readResponse.characteristics;
+          // typescript can't type that this exists if error doesnt
+          const characteristics = readResponse!.characteristics;
 
           let errorOccurred = false; // determine if we send a 207 Multi-Status
           for (const data of characteristics) {
@@ -911,14 +912,15 @@ export class HAPServer extends EventEmitter {
         HAPServerEventTypes.SET_CHARACTERISTICS,
         connection,
         writeRequest,
-        once((error: HAPHttpError | undefined, writeResponse: CharacteristicsWriteResponse) => {
+        once((error, writeResponse) => {
           if (error) {
             response.writeHead(error.httpCode, { "Content-Type": "application/hap+json" });
             response.end(JSON.stringify({ status: error.status }));
             return;
           }
 
-          const characteristics = writeResponse.characteristics;
+          // typescript can't type that this exists if error doesnt
+          const characteristics = writeResponse!.characteristics;
 
           let multiStatus = false;
           for (const data of characteristics) {
@@ -1012,7 +1014,7 @@ export class HAPServer extends EventEmitter {
 
       const resourceRequest = JSON.parse(data.toString()) as ResourceRequest;
       // call out to listeners to retrieve the resource, snapshot only right now
-      this.emit(HAPServerEventTypes.REQUEST_RESOURCE, resourceRequest, once((error: HAPHttpError | undefined, resource: Buffer) => {
+      this.emit(HAPServerEventTypes.REQUEST_RESOURCE, resourceRequest, once((error, resource) => {
         if (error) {
           response.writeHead(error.httpCode, { "Content-Type": "application/hap+json" });
           response.end(JSON.stringify({ status: error.status }));

--- a/src/lib/util/once.ts
+++ b/src/lib/util/once.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
 export function once<T extends Function>(func: T): T {
   let called = false;
 

--- a/src/lib/util/once.ts
+++ b/src/lib/util/once.ts
@@ -1,13 +1,12 @@
-// eslint-disable-next-line @typescript-eslint/ban-types,@typescript-eslint/no-explicit-any
-export function once<T extends Function>(func: T): any {
+export function once<T extends Function>(func: T): T {
   let called = false;
 
-  return (...args: unknown[]) => {
+  return ((...args: unknown[]) => {
     if (called) {
       throw new Error("This callback function has already been called by someone else; it can only be called one time.");
     } else {
       called = true;
       return func(...args);
     }
-  };
+  }) as unknown as T;
 }


### PR DESCRIPTION
Noticed in homebridge/homebridge that using once() required the inner function to explicitly typed while returning any. So no type inference and more importantly potential bugs.

Easiest way to see the effect is on [TS playground](https://www.typescriptlang.org/play?ts=4.5.4#code/CYUwxgNghgTiAEAzArgOzAFwJYHtX2BwGUNlFEAKMKCCAIyjAGsAueCqN1ZAWzpBgBtALoBKeAF4AfPABuOLMFFt5igNwAoDSAAeABxwwMSNJlz48YEACEQiQyAA8AFXi6MIVMADO8AGKm2HhSFCjobM7K8FCoAJ7wAN4a8PAQIMbUtCDAkkg03iCayfBwpDD4FAB01bAA5t5saEyoOADuqCLi0onFKViI7JlpSj0pY-AYABYwbfCoIK3wAKIwMzAUAETOk1i+QwzMJuhB+JNQvjRwUMDx-J7wQ9nwdPHeODwgeAggEAVq8FgMjF4HgILcEI8cl8JlgPpUNqJNOMAL5uX4IJLjFKQ3IYGDIQq9MalZDlI5gKo1GD1RFE5HFZGaelaXQGIzkk4g9AgABybRcbh0Hi8vgCx3MITCYAiUVcmNS6QeNGGuUQ+UJxRJZIolMqdQa8CaLXanUkMnlfQGVGV2XEFrGUxmi3mixWa02212StoByYHPM8DOFwgVxuzxA9xxL3gbw+0J+fwBQIsqDB4e9Kuh2DhCKRY1RCYxROxNpyEgm+MJWJK6VJ+Cluv1tJRDPE50NqGabXw7ecTK0hBIZEolhsdgcHDNozGAHoZ9FA+3YXoIFgwIDonFKvBrDgcJUNMjaRpB6RyBRR3zWpPuva5wusKhEAInu3uHwBNFVlBYtvYj+AEJD1EREgA).
 
