### PR TITLE
Corrected message for MaxValue<numericLowerBound (#937)

### DIFF
--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1134,7 +1134,7 @@ export class Characteristic extends EventEmitter {
         } else if (props.maxValue < numericLowerBound(this.props.format)) {
           this.characteristicWarning(
             "Characteristic Property 'maxValue' was set to " + props.maxValue + ", but for numeric format " +
-            this.props.format + " minimum possible is " + numericUpperBound(this.props.format),
+            this.props.format + " minimum possible is " + numericLowerBound(this.props.format),
             CharacteristicWarningType.ERROR_MESSAGE,
           );
           props.maxValue = numericUpperBound(this.props.format);


### PR DESCRIPTION
## :recycle: Current situation

The warning message for `props.maxValue` being below the minimum for the `format` is incorrectly using `numericUpperBound` instead of `numericLowerBound`. This only affects the warning message; The actual range check is applied correctly.

The equivalent code for `props.minValue` is correct.

## :bulb: Proposed solution

Replace `numericUpperBound` by `numericLowerBound` when constructing the warning message.

## :gear: Release Notes

Corrected warning message when an attempt is made to set `props.maxValue` to less than the minimum allowed value for the characteristic's type.

### Testing

There do not appear to be any tests for the content of warning messages.