### PR TITLE
Fixed memory leak with HomeKit DataStreams

### DIFF
--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -734,6 +734,9 @@ export class DataStreamConnection extends EventEmitter {
 
           // below listener is removed in .close()
           this.connection.on(HAPConnectionEvent.CLOSED, this.hapConnectionClosedListener); // register close listener
+
+          debug("[%s] Registering CLOSED handler to HAP connection. Connection currently has %d close handlers!",
+            this.remoteAddress, this.connection.listeners(HAPConnectionEvent.CLOSED).length);
         }
       });
 
@@ -1037,8 +1040,6 @@ export class DataStreamConnection extends EventEmitter {
       return; // connection is already closing/closed
     }
 
-    this.connection?.removeListener(HAPConnectionEvent.CLOSED, this.hapConnectionClosedListener);
-
     this.state = ConnectionState.CLOSING;
     this.socket.end();
   }
@@ -1062,6 +1063,8 @@ export class DataStreamConnection extends EventEmitter {
     // this instance is now considered completely dead
     this.state = ConnectionState.CLOSED;
     this.emit(DataStreamConnectionEvent.CLOSED);
+
+    this.connection?.removeListener(HAPConnectionEvent.CLOSED, this.hapConnectionClosedListener);
     this.removeAllListeners();
   }
 


### PR DESCRIPTION
## :recycle: Current situation

As reported in #931, we experienced a memory leak when continuously using HomeKit Secure Video.

## :bulb: Proposed solution

We identified an issue in how we handle closing HomeKit DataStream connections. Every opened DataStream connection registers a `CLOSED` listener to its HAP connection, in order to ensure both connections are closed if the main HAP TCP socket dies. This listener was not removed properly when the HDS connection was closed through the remote host.

## :gear: Release Notes

- Fixed a memory leak which occurred on every HDS closed by the remote host.

## :heavy_plus_sign: Additional Information

Added a debug message to monitor the listener count in the future.

### Testing
--

### Reviewer Nudging

CC @hjdhjd
