### PR TITLE
fixes #945

### DIFF
--- a/src/lib/util/net-utils.ts
+++ b/src/lib/util/net-utils.ts
@@ -13,11 +13,11 @@ export function findLoopbackAddress(): string {
       }
 
       internal = true;
-      if (info.family === "IPv4" || info.family === 4) { //nodejs18 uses numbers 4 or 6
+      if (info.family === "IPv4" || info.family == 4) { //nodejs18 uses numbers 4 or 6
         if (!ipv4) {
           ipv4 = info.address;
         }
-      } else if (info.family === "IPv6" || info.family === 6) {
+      } else if (info.family === "IPv6" || info.family == 6) {
         if (info.scopeid) {
           if (!ipv6LinkLocal) {
             ipv6LinkLocal = info.address + "%" + name; // ipv6 link local addresses are only valid with a scope

--- a/src/lib/util/net-utils.ts
+++ b/src/lib/util/net-utils.ts
@@ -13,11 +13,12 @@ export function findLoopbackAddress(): string {
       }
 
       internal = true;
-      if (info.family === "IPv4" || info.family == 4) { //nodejs18 uses numbers 4 or 6
+      const family: string | number = info.family as any;
+      if (family === "IPv4" || family === 4) { //nodejs18 uses numbers 4 or 6
         if (!ipv4) {
           ipv4 = info.address;
         }
-      } else if (info.family === "IPv6" || info.family == 6) {
+      } else if (family === "IPv6" || family === 6) {
         if (info.scopeid) {
           if (!ipv6LinkLocal) {
             ipv6LinkLocal = info.address + "%" + name; // ipv6 link local addresses are only valid with a scope

--- a/src/lib/util/net-utils.ts
+++ b/src/lib/util/net-utils.ts
@@ -13,11 +13,11 @@ export function findLoopbackAddress(): string {
       }
 
       internal = true;
-      if (info.family === "IPv4") {
+      if (info.family === "IPv4" || info.family === 4) { //nodejs18 uses numbers 4 or 6
         if (!ipv4) {
           ipv4 = info.address;
         }
-      } else if (info.family === "IPv6") {
+      } else if (info.family === "IPv6" || info.family === 6) {
         if (info.scopeid) {
           if (!ipv6LinkLocal) {
             ipv6LinkLocal = info.address + "%" + name; // ipv6 link local addresses are only valid with a scope


### PR DESCRIPTION
## :recycle: Current situation

This code does not work with nodejs 18, since the one field type in the objects returend by os.networkInterfaces() changed from string to number. 'family' field is either 4 or 6, previously it was a string IPv4 or IPv6

## :bulb: Proposed solution

add extra check in the conditions so both old and new nodeJS work
