### PR TITLE
Fix #945 - Node.js v18 os.networkInterfaces()[].family number/string comparison

### DIFF
--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -713,7 +713,8 @@ export class HAPConnection extends EventEmitter {
 
     if (ipVersion === "ipv4") {
       for (const info of infos) {
-        if (info.family === "IPv4") {
+        // @ts-expect-error Nodejs 18+ uses the number 4 the string "IPv4"
+        if (info.family === "IPv4" || info.family === 4) {
           return info.address;
         }
       }
@@ -723,7 +724,8 @@ export class HAPConnection extends EventEmitter {
       let localUniqueAddress: string | undefined = undefined;
 
       for (const info of infos) {
-        if (info.family === "IPv6") {
+        // @ts-expect-error Nodejs 18+ uses the number 6 instead of the string "IPv6"
+        if (info.family === "IPv6" || info.family === 6) {
           if (!info.scopeid) {
             return info.address;
           } else if (!localUniqueAddress) {

--- a/src/lib/util/net-utils.ts
+++ b/src/lib/util/net-utils.ts
@@ -13,11 +13,13 @@ export function findLoopbackAddress(): string {
       }
 
       internal = true;
-      if (info.family === "IPv4") {
+      // @ts-expect-error Nodejs 18+ uses the number 4 the string "IPv4"
+      if (info.family === "IPv4" || info.family === 4) {
         if (!ipv4) {
           ipv4 = info.address;
         }
-      } else if (info.family === "IPv6") {
+      // @ts-expect-error Nodejs 18+ uses the number 6 the string "IPv6"
+      } else if (info.family === "IPv6" || info.family === 6) {
         if (info.scopeid) {
           if (!ipv6LinkLocal) {
             ipv6LinkLocal = info.address + "%" + name; // ipv6 link local addresses are only valid with a scope


### PR DESCRIPTION
## :recycle: Current situation

https://github.com/nodejs/node/issues/42787
https://github.com/nodejs/node/pull/41431#discussion_r841277378

## :bulb: Proposed solution

It's worth doing this sooner rather than later. There may be other compatibility issues in Node.js 18 we won't find until this one is patched.

The use of `@ts-expect-error` should alert us to remove the exception when @types/node is updated to 18 (if they decide to keep backwards compatibility with old versions, which they may not, be we need to).

Alternatively we could do something like this, but I feel like it will result in the exception never being removed in the future:

```ts
(info.family === "IPv6" || (info.family as unknown as string) === 6)
```

## :gear: Release Notes

* Fix an issue with network interface family detection when running Node.js 18

### Testing

Tests are still failing on Node v18.0.0 - out of scope for this PR.

### Reviewer Nudging

@Supereg 