### PR TITLE
Introduce layer to debug event registrations on HAPConnection

### DIFF
--- a/src/lib/camera/RTPStreamManagement.ts
+++ b/src/lib/camera/RTPStreamManagement.ts
@@ -510,7 +510,7 @@ export class RTPStreamManagement {
    */
   connectionID?: SessionIdentifier;
   private activeConnection?: HAPConnection;
-  private activeConnectionClosedListener?: () => void;
+  private readonly activeConnectionClosedListener: (callback?: CharacteristicSetCallback) => void;
   sessionIdentifier?: StreamSessionIdentifier = undefined;
   streamStatus: StreamingStatus = StreamingStatus.AVAILABLE; // use _updateStreamStatus to update this property
   private ipVersion?: "ipv4" | "ipv6"; // ip version for the current session
@@ -557,6 +557,8 @@ export class RTPStreamManagement {
     this.supportedRTPConfiguration = RTPStreamManagement._supportedRTPConfiguration(this.supportedCryptoSuites);
     this.supportedVideoStreamConfiguration = RTPStreamManagement._supportedVideoStreamConfiguration(options.video);
     this.supportedAudioStreamConfiguration = this._supportedAudioStreamConfiguration(options.audio);
+
+    this.activeConnectionClosedListener = this._handleStopStream.bind(this);
 
     this.service = service || this.constructService(id);
     this.setupServiceHandlers();
@@ -667,14 +669,13 @@ export class RTPStreamManagement {
     this.resetSelectedStreamConfiguration();
     this.resetSetupEndpointsResponse();
 
-    if (this.activeConnectionClosedListener && this.activeConnection) {
+    if (this.activeConnection) {
       this.activeConnection.removeListener(HAPConnectionEvent.CLOSED, this.activeConnectionClosedListener);
-      this.activeConnectionClosedListener = undefined;
+      this.activeConnection = undefined;
     }
 
     this._updateStreamStatus(StreamingStatus.AVAILABLE);
     this.sessionIdentifier = undefined;
-    this.activeConnection = undefined;
     // noinspection JSDeprecatedSymbols
     this.connectionID = undefined;
     this.ipVersion = undefined;
@@ -691,13 +692,11 @@ export class RTPStreamManagement {
 
   private streamingIsDisabled(callback?: CharacteristicSetCallback): boolean {
     if (!this.service.getCharacteristic(Characteristic.Active).value) {
-      console.log("STREAMING DISABLED ACTIVE");
       callback && callback(new HapStatusError(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE));
       return true;
     }
 
     if (this.disabledThroughOperatingMode?.()) {
-      console.log("STREAMING DISABLED OPERATION MODE!");
       callback && callback(new HapStatusError(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE));
       return true;
     }
@@ -755,6 +754,7 @@ export class RTPStreamManagement {
     default:
       debug(`Unhandled request type ${SessionControlCommand[requestType]}`);
       callback(HAPStatus.INVALID_VALUE_IN_REQUEST);
+      // TODO should we call stop stream?
       return;
     }
   }
@@ -982,8 +982,11 @@ export class RTPStreamManagement {
       return;
     }
 
+    assert(this.activeConnection == null,
+      "Found non-nil `activeConnection` when trying to setup streaming endpoints, even though streamStatus is reported to be AVAILABLE!");
+
     this.activeConnection = connection;
-    this.activeConnection.on(HAPConnectionEvent.CLOSED, (this.activeConnectionClosedListener = this._handleStopStream.bind(this)));
+    this.activeConnection.on(HAPConnectionEvent.CLOSED, this.activeConnectionClosedListener);
 
     // noinspection JSDeprecatedSymbols
     this.connectionID = connection.sessionID;

--- a/src/lib/camera/RTPStreamManagement.ts
+++ b/src/lib/camera/RTPStreamManagement.ts
@@ -754,7 +754,6 @@ export class RTPStreamManagement {
     default:
       debug(`Unhandled request type ${SessionControlCommand[requestType]}`);
       callback(HAPStatus.INVALID_VALUE_IN_REQUEST);
-      // TODO should we call stop stream?
       return;
     }
   }

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -15,6 +15,7 @@ import * as uuid from "./uuid";
 
 const debug = createDebug("HAP-NodeJS:EventedHTTPServer");
 const debugCon = createDebug("HAP-NodeJS:EventedHTTPServer:Connection");
+const debugEvents = createDebug("HAP-NodeJS:EventEmitter");
 
 export type HAPUsername = string;
 export type EventName = string; // "<aid>.<iid>"
@@ -359,6 +360,47 @@ export class HAPConnection extends EventEmitter {
     this.internalHttpServer.on("error", this.onHttpServerError.bind(this));
     // close event is added later on the "connect" event as possible listen retries would throw unnecessary close events
     this.internalHttpServer.listen(0, this.internalHttpServerAddress = getOSLoopbackAddressIfAvailable());
+  }
+
+  private debugListenerRegistration(event: string | symbol, registration = true, beforeCount = -1): void {
+    const stackTrace = new Error().stack!.split("\n")[3];
+    const eventCount = this.listeners(event).length;
+
+    const tabs1 = event === HAPConnectionEvent.AUTHENTICATED ? "\t" : "\t\t";
+    const tabs2 = !registration ? "\t" : "\t\t";
+
+    // eslint-disable-next-line max-len
+    debugEvents(`[${this.remoteAddress}] ${registration ? "Registered" : "Unregistered"} event '${String(event).toUpperCase()}' ${tabs1}(total: ${eventCount}${!registration ? " Before: " + beforeCount : ""}) ${tabs2}${stackTrace}`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string | symbol, listener: (...args: any[]) => void): this {
+    const result =  super.on(event, listener);
+    this.debugListenerRegistration(event);
+    return result;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this {
+    const result = super.addListener(event, listener);
+    this.debugListenerRegistration(event);
+    return result;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this {
+    const beforeCount = this.listeners(event).length;
+    const result = super.removeListener(event, listener);
+    this.debugListenerRegistration(event, false, beforeCount);
+    return result;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  off(event: string | symbol, listener: (...args: any[]) => void): this {
+    const result =  super.off(event, listener);
+    const beforeCount = this.listeners(event).length;
+    this.debugListenerRegistration(event, false, beforeCount);
+    return result;
   }
 
   /**


### PR DESCRIPTION
## :recycle: Current situation

As of some reports, it seems that there are still issues with memory leaks with listeners registered to `HAPConnection`.

## :bulb: Proposed solution

This PR adds detailed debug information with the new `HAP-NodeJS:EventEmitter` for every registered and removed event listener on `HAPConnection` objects. This will help us to gather more detailed information about the situation.

## :gear: Release Notes

* Added more detailed debugging for event listener registrations for `HAPConnection` objects.

## :heavy_plus_sign: Additional Information

### Testing

The feature was verified locally.

### Reviewer Nudging

CC: @hjdhjd
