### PR TITLE
Fix `[${this.displayName}]` interpolation for error displayed when Avahi is not available.

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1222,8 +1222,10 @@ export class Accessory extends EventEmitter {
 
     let selectedAdvertiser = info.advertiser ?? MDNSAdvertiser.BONJOUR;
     if (info.advertiser === MDNSAdvertiser.AVAHI && !await AvahiAdvertiser.isAvailable()) {
-      console.error("[${this.displayName}] Selected \"" + MDNSAdvertiser.AVAHI + "\" advertiser though it isn't available on the platform. " +
-        "Reverting to \"" + MDNSAdvertiser.BONJOUR + "\"");
+      console.error(
+        `[${this.displayName}] The selected advertiser, "${MDNSAdvertiser.AVAHI}" isn't available this the platform. ` +
+        ` Reverting to "${MDNSAdvertiser.BONJOUR}"`,
+      );
       selectedAdvertiser = MDNSAdvertiser.BONJOUR;
     }
 

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1223,8 +1223,8 @@ export class Accessory extends EventEmitter {
     let selectedAdvertiser = info.advertiser ?? MDNSAdvertiser.BONJOUR;
     if (info.advertiser === MDNSAdvertiser.AVAHI && !await AvahiAdvertiser.isAvailable()) {
       console.error(
-        `[${this.displayName}] The selected advertiser, "${MDNSAdvertiser.AVAHI}" isn't available this the platform. ` +
-        ` Reverting to "${MDNSAdvertiser.BONJOUR}"`,
+        `[${this.displayName}] The selected advertiser, "${MDNSAdvertiser.AVAHI}", isn't available on this platform. ` +
+        `Reverting to "${MDNSAdvertiser.BONJOUR}"`,
       );
       selectedAdvertiser = MDNSAdvertiser.BONJOUR;
     }


### PR DESCRIPTION
## :recycle: Current situation

`[${this.displayName}]` was not being interpolated.

## :bulb: Proposed solution

Use backtick formatting for the entire line.
