### PR TITLE
Fix floating point precision

### DIFF
--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -1095,32 +1095,28 @@ describe("Characteristic", () => {
     });
 
     it("should validate Formats.FLOAT with precision with minimum steps", () => {
-      const steps = (100 / 6);
-      const characteristic = createCharacteristicWithProps({
-        format: Formats.FLOAT,
-        perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
-        minValue: 0,
-        maxValue: 100,
-        minStep: steps,
-      });
+      const pad = 1;
+      const characteristic = createCharacteristic(Formats.FLOAT);
 
-      characteristic.setValue(steps);
-      expect(characteristic.value).toEqual(steps);
+      // takes up to 3 minutes
+      for(let ceil = 1; ceil <= 100; ceil++) {
+        const steps = (ceil / 6);
+        for(let maxValue = ceil; maxValue > 0; maxValue--) {
+          for(let minValue = 0; minValue < maxValue; minValue++) {
+            characteristic.setProps({
+              minValue: minValue,
+              maxValue: maxValue,
+              minStep: steps,
+            });
+            for(let amp = 0; amp < (ceil / steps) + pad; amp++) {
+              const desiredValue = Math.min(Math.max(steps * amp, minValue), maxValue);
 
-      characteristic.setValue(steps * 2);
-      expect(characteristic.value).toEqual(steps * 2);
-
-      characteristic.setValue(steps * 3);
-      expect(characteristic.value).toEqual(steps * 3);
-
-      characteristic.setValue(steps * 4);
-      expect(characteristic.value).toEqual(steps * 4);
-
-      characteristic.setValue(steps * 5);
-      expect(characteristic.value).toEqual(steps * 5);
-
-      characteristic.setValue(steps * 6);
-      expect(characteristic.value).toEqual(steps * 6);
+              characteristic.setValue(steps * amp);
+              expect(characteristic.value).toEqual(desiredValue);
+            }
+          }
+        }
+      }
     });
 
     it("should allow negative floats in range for Formats.FLOAT", () => {

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -2041,6 +2041,16 @@ export class Characteristic extends EventEmitter {
         stepValue = maxWithUndefined(this.props.minStep, 1);
       }
 
+      if (stepValue != null) {
+        if (stepValue === 1) {
+          value = Math.round(value);
+        } else if (stepValue > 1) {
+          const eps = 1; // stable constant for floating point precision
+          value = Math.floor(value);
+          value = value - ((value + eps) % stepValue) + eps;
+        } // for stepValue < 1 rounding is done only when formatting the response. We can't store the "perfect" .step anyways
+      }
+
       if (numericMin != null && value < numericMin) {
         this.characteristicWarning(`characteristic was supplied illegal value: number ${value} exceeded minimum of ${numericMin}`);
         value = numericMin;
@@ -2065,16 +2075,6 @@ export class Characteristic extends EventEmitter {
           ${this.props.validValueRanges}, supplying illegal values will throw errors in the future`);
           value = this.props.validValueRanges[1];
         }
-      }
-
-      if (stepValue != null) {
-        if (stepValue === 1) {
-          value = Math.round(value);
-        } else if (stepValue > 1) {
-          const eps = 1; // stable constant for floating point precision
-          value = Math.round(value);
-          value = value - ((value + eps) % stepValue) + eps;
-        } // for stepValue < 1 rounding is done only when formatting the response. We can't store the "perfect" .step anyways
       }
 
       return value;


### PR DESCRIPTION
## :recycle: Current situation

Related:
- #955 
- #956 

## :bulb: Proposed solution

As @adriancable have mentioned in #956, the previous solution may have possible incorrect behaviors.
So I have tried all possible tests which can be happened in 0 and 100.

I moved the rounding logic in front of clamping logic.
Plus, to fix in case the error is smaller than epsilon and greater than 0.5, I have changed `Math.round()` to `Math.floor()`. 
We don't need round the value in server-side, due to Apple Home app will always automatically round the value fit to step size.

## :gear: Release Notes


## :heavy_plus_sign: Additional Information


### Testing

I have rewritten entire test code related with this issue.
The `minStep` in the final test only uses (100/6), of course I have tried other combinations like 3, 7, 9.
All cases have passed, including approaches which @adriancable have mentioned before.

The test takes up to 3 minutes per step, this is the reason why I have decided to use only 100/6.

### Reviewer Nudging

I would appreciate if you have better idea.
