### PR TITLE
Fix notification events order

### DIFF
--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -501,6 +501,10 @@ export class HAPConnection extends EventEmitter {
   private writeEventNotification(notification: EventNotification): void {
     debugCon("[%s] Sending HAP event notifications %o", this.remoteAddress, notification.characteristics);
 
+    // Apple backend processes events in reverse order, so we need to reverse the array
+    // so that events are processed in chronological order.
+    notification.characteristics.reverse();
+
     const dataBuffer = Buffer.from(JSON.stringify(notification), "utf8");
     const header = Buffer.from(
       "EVENT/1.0 200 OK\r\n" +


### PR DESCRIPTION
## :recycle: Current situation

Empirically proven that Apple backend processes multiple characteristics submitted in the same request in reverse order. In the current version, the characteristics array is populated in chronological order. In some situations, the incorrect order of characteristics can lead to the setting of an obsolete characteristic value.

For example, some Zigbee devices report the current state before the change which causes consequent updates within a very short time window. In this case, HAP-NodeJS sends multiple characteristics in the same request.

```
2022-08-26T21:04:30.554Z HAP-NodeJS:EventedHTTPServer:Connection [::ffff:10.10.10.139] HTTP request: /characteristics
2022-08-26T21:04:30.554Z HAP-NodeJS:HAPServer [0E:3B:79:C7:EE:E4] HAP Request: PUT /characteristics
2022-08-26T21:04:30.555Z HAP-NodeJS:Accessory [Homebridge EEE4 3B31] Processing characteristic set: {"characteristics":[{"aid":25,"iid":11,"value":1}]}
[8/27/2022, 12:04:30 AM] [zigbee2mqtt] Pending data: {"state_left":"ON"}
2022-08-26T21:04:30.556Z HAP-NodeJS:EventedHTTPServer [::ffff:10.10.10.139] Muting event '25.11' notification for this connection since it originated here.
[8/27/2022, 12:04:30 AM] [zigbee2mqtt] Publish to 'zigbee2mqtt/0x00124b001802eebd/set': '{"state_left":"ON"}'
2022-08-26T21:04:30.557Z HAP-NodeJS:Accessory [Homebridge EEE4 3B31] Setting Characteristic "On" to value 1
2022-08-26T21:04:30.559Z HAP-NodeJS:EventedHTTPServer:Connection [::ffff:10.10.10.139] HTTP Response is finished
[8/27/2022, 12:04:30 AM] [zigbee2mqtt] Handled device update for sw-living-room-2: {"linkquality":98,"state_bottom_right":"ON","state_left":"OFF","state_right":"ON"}
[8/27/2022, 12:04:31 AM] [zigbee2mqtt] Handled device update for sw-living-room-2: {"linkquality":94,"state_bottom_right":"ON","state_left":"ON","state_right":"ON"}
2022-08-26T21:04:31.098Z HAP-NodeJS:EventedHTTPServer:Connection [::ffff:10.10.10.139] Sending HAP event notifications [ { aid: 25, iid: 11, value: 0 }, { aid: 25, iid: 11, value: 1 } ]
```

The characteristics are submitted in chronological order: 0 (Off), 1(On)
```
[
   {
      "aid":25,
      "iid":11,
      "value":0
   },
   {
      "aid":25,
      "iid":11,
      "value":1
   }
]
```

The accessory after switching On flips to Off since HomeKit backend processes characteristics in reverse order.

## :bulb: Proposed solution

The trivial fix is to reverse the characteristics array before submission in `writeEventNotification` function.

```
notification.characteristics.reverse();
```

## :gear: Release Notes

## :heavy_plus_sign: Additional Information

### Testing

Conducted several tests locally.

### Reviewer Nudging