### PR TITLE
Remove setNoDelay call to response socket

### DIFF
--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -676,9 +676,10 @@ export class HAPConnection extends EventEmitter {
       return;
     }
 
+    debugCon("[%s] HTTP request: %s", this.remoteAddress, request.url);
+
     request.socket.setNoDelay(true);
 
-    debugCon("[%s] HTTP request: %s", this.remoteAddress, request.url);
     this.emit(HAPConnectionEvent.REQUEST, request, response);
   }
 

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -677,7 +677,6 @@ export class HAPConnection extends EventEmitter {
     }
 
     request.socket.setNoDelay(true);
-    response.connection.setNoDelay(true); // deprecated since 13.0.0
 
     debugCon("[%s] HTTP request: %s", this.remoteAddress, request.url);
     this.emit(HAPConnectionEvent.REQUEST, request, response);


### PR DESCRIPTION
## :recycle: Current situation

Currently, we set the `setNoDelay` tcp option for our internal http/tcp server, running for every connection.
This seemingly causes issues as identified in https://github.com/homebridge/homebridge/issues/3226#issuecomment-1246174713.
Particularly, according to the documentation, the property `response.connection` might be nulled once response.end() was called on it.

## :bulb: Proposed solution

This PR removes this call, as `request.socket` and `response.connection` are the same object anyways.

## :gear: Release Notes

* Fixed a potential crash occurring in some rare situations when handling http requests.

## :heavy_plus_sign: Additional Information

- Reported in https://github.com/homebridge/homebridge/issues/3226

### Testing

--

### Reviewer Nudging

--
