### PR TITLE
Move to GitHub based release note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+# The GitHub release configuration file: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - 'breaking change'
+    - title: Featured Changes ✨
+      labels:
+        - 'feature'
+        - 'enhancement'
+    - title: Bug Fixes 🐛
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
+    - title: Other Changes
+      labels:
+        - "chore"
+        - "housekeeping"
+        - "*"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,14 +1,12 @@
-name: Release Drafter
+name: PR Labeler
 
 on:
-  push:
-    branches: [master]
   pull_request: # required for autolabeler
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 jobs:
   stale:
-    uses: homebridge/.github/.github/workflows/release-drafter.yml@main
+    uses: homebridge/.github/.github/workflows/pr-labeler.yml@main
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :recycle: Current situation

Currently we rely on a GitHub action for release note generation. GitHub provides (for a while now) a release not generation toll out of the box.

## :bulb: Proposed solution

This PR moves to the GitHub integrated release note generation tool.
We integrated the PR auto labeler as a separate GitHub Action.

## :gear: Release Notes

* Added configuration for GitHub Release note generation.

## :heavy_plus_sign: Additional Information

### Testing

--

### Reviewer Nudging

--
