### PR TITLE
Fixed a regression where floats were rounded incorrectly when no minValue was provided

### DIFF
--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -1063,6 +1063,22 @@ describe("Characteristic", () => {
       expect(characteristic.value).toEqual(0.1);
     });
 
+    it("should accept Formats.FLOAT with non-defined min/max value", () => {
+      const characteristic = createCharacteristicWithProps({
+        format: Formats.FLOAT,
+        minStep: 0.01,
+        perms: [Perms.PAIRED_READ, Perms.NOTIFY],
+      }, uuid.generate("051"));
+
+      // @ts-expect-error - spying on private property
+      const mock = jest.spyOn(characteristic, "characteristicWarning");
+
+      mock.mockReset();
+      characteristic.updateValue(0.09);
+      expect(characteristic.value).toEqual(0.09);
+      expect(mock).toBeCalledTimes(0);
+    });
+
     it("should validate Formats.FLOAT with precision", () => {
       const characteristic = new Characteristic.CurrentAmbientLightLevel();
 

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -602,9 +602,9 @@ function extractHAPStatusFromError(error: Error) {
 }
 
 function maxWithUndefined(a?: number, b?: number): number | undefined {
-  if (a === undefined) {
+  if (a == null) {
     return b;
-  } else if (b === undefined) {
+  } else if (b == null) {
     return a;
   } else {
     return Math.max(a, b);
@@ -612,9 +612,9 @@ function maxWithUndefined(a?: number, b?: number): number | undefined {
 }
 
 function minWithUndefined(a?: number, b?: number): number | undefined {
-  if (a === undefined) {
+  if (a == null) {
     return b;
-  } else if (b === undefined) {
+  } else if (b == null) {
     return a;
   } else {
     return Math.min(a, b);
@@ -2042,7 +2042,7 @@ export class Characteristic extends EventEmitter {
       }
 
       if (stepValue != null && stepValue > 0) {
-        const minValue = numericMin != null ? numericMin : 0;
+        const minValue = this.props.minValue != null ? this.props.minValue : 0;
         value = stepValue * Math.round((value - minValue) / stepValue) + minValue;
       }
 


### PR DESCRIPTION
## :recycle: Current situation

The release of v0.10.3 introduced fixes to the float rounding mechanism (see #956, #958). It introduced a regression when no `minValue` was provided (see #971).

## :bulb: Proposed solution

This PR introduces a fix for this regression.

## :gear: Release Notes

* Fixed a regression where floats were rounded incorrectly when no `minValue` was provided

## :heavy_plus_sign: Additional Information

This regression slipped through in this review step: https://github.com/homebridge/HAP-NodeJS/pull/958/files#r893353790.

### Testing

A regression test was added, covering this case.

### Reviewer Nudging

--
