### PR TITLE
Update service and characteristic definitions to iOS 16

### DIFF
--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -45,6 +45,7 @@ import {
   ConfiguredName,
   ContactSensorState,
   CoolingThresholdTemperature,
+  CryptoHash,
   CurrentAirPurifierState,
   CurrentAmbientLightLevel,
   CurrentDoorState,
@@ -110,6 +111,7 @@ import {
   ManuallyDisabled,
   Manufacturer,
   MaximumTransmitPower,
+  MetricsBufferFullState,
   Model,
   MotionDetected,
   MultifunctionButton,
@@ -167,6 +169,7 @@ import {
   SelectedCameraRecordingConfiguration,
   SelectedDiagnosticsModes,
   SelectedRTPStreamConfiguration,
+  SelectedSleepConfiguration,
   SerialNumber,
   ServiceLabelIndex,
   ServiceLabelNamespace,
@@ -204,12 +207,15 @@ import {
   SupportedDiagnosticsModes,
   SupportedDiagnosticsSnapshot,
   SupportedFirmwareUpdateConfiguration,
+  SupportedMetrics,
   SupportedRouterConfiguration,
   SupportedRTPConfiguration,
+  SupportedSleepConfiguration,
   SupportedTransferTransportConfiguration,
   SupportedVideoRecordingConfiguration,
   SupportedVideoStreamConfiguration,
   SwingMode,
+  TapType,
   TargetAirPurifierState,
   TargetAirQuality,
   TargetControlList,
@@ -235,6 +241,7 @@ import {
   ThreadOpenThreadVersion,
   ThreadStatus,
   TimeUpdate,
+  Token,
   TransmitPower,
   TunnelConnectionTimeout,
   TunneledAccessoryAdvertising,
@@ -700,6 +707,7 @@ export class Characteristic extends EventEmitter {
   public static ConfiguredName: typeof ConfiguredName;
   public static ContactSensorState: typeof ContactSensorState;
   public static CoolingThresholdTemperature: typeof CoolingThresholdTemperature;
+  public static CryptoHash: typeof CryptoHash;
   public static CurrentAirPurifierState: typeof CurrentAirPurifierState;
   public static CurrentAmbientLightLevel: typeof CurrentAmbientLightLevel;
   public static CurrentDoorState: typeof CurrentDoorState;
@@ -780,6 +788,7 @@ export class Characteristic extends EventEmitter {
   public static ManuallyDisabled: typeof ManuallyDisabled;
   public static Manufacturer: typeof Manufacturer;
   public static MaximumTransmitPower: typeof MaximumTransmitPower;
+  public static MetricsBufferFullState: typeof MetricsBufferFullState;
   public static Model: typeof Model;
   public static MotionDetected: typeof MotionDetected;
   public static MultifunctionButton: typeof MultifunctionButton;
@@ -840,6 +849,7 @@ export class Characteristic extends EventEmitter {
   public static SelectedCameraRecordingConfiguration: typeof SelectedCameraRecordingConfiguration;
   public static SelectedDiagnosticsModes: typeof SelectedDiagnosticsModes;
   public static SelectedRTPStreamConfiguration: typeof SelectedRTPStreamConfiguration;
+  public static SelectedSleepConfiguration: typeof SelectedSleepConfiguration;
   public static SerialNumber: typeof SerialNumber;
   public static ServiceLabelIndex: typeof ServiceLabelIndex;
   public static ServiceLabelNamespace: typeof ServiceLabelNamespace;
@@ -877,12 +887,15 @@ export class Characteristic extends EventEmitter {
   public static SupportedDiagnosticsModes: typeof SupportedDiagnosticsModes;
   public static SupportedDiagnosticsSnapshot: typeof SupportedDiagnosticsSnapshot;
   public static SupportedFirmwareUpdateConfiguration: typeof SupportedFirmwareUpdateConfiguration;
+  public static SupportedMetrics: typeof SupportedMetrics;
   public static SupportedRouterConfiguration: typeof SupportedRouterConfiguration;
   public static SupportedRTPConfiguration: typeof SupportedRTPConfiguration;
+  public static SupportedSleepConfiguration: typeof SupportedSleepConfiguration;
   public static SupportedTransferTransportConfiguration: typeof SupportedTransferTransportConfiguration;
   public static SupportedVideoRecordingConfiguration: typeof SupportedVideoRecordingConfiguration;
   public static SupportedVideoStreamConfiguration: typeof SupportedVideoStreamConfiguration;
   public static SwingMode: typeof SwingMode;
+  public static TapType: typeof TapType;
   public static TargetAirPurifierState: typeof TargetAirPurifierState;
   /**
    * @deprecated Removed and not used anymore
@@ -917,6 +930,7 @@ export class Characteristic extends EventEmitter {
    * @deprecated Removed and not used anymore
    */
   public static TimeUpdate: typeof TimeUpdate;
+  public static Token: typeof Token;
   public static TransmitPower: typeof TransmitPower;
   public static TunnelConnectionTimeout: typeof TunnelConnectionTimeout;
   public static TunneledAccessoryAdvertising: typeof TunneledAccessoryAdvertising;

--- a/src/lib/Service.ts
+++ b/src/lib/Service.ts
@@ -40,6 +40,7 @@ import {
   Fanv2,
   Faucet,
   FilterMaintenance,
+  FirmwareUpdate,
   GarageDoorOpener,
   HeaterCooler,
   HumidifierDehumidifier,
@@ -70,6 +71,7 @@ import {
   StatefulProgrammableSwitch,
   StatelessProgrammableSwitch,
   Switch,
+  TapManagement,
   TargetControl,
   TargetControlManagement,
   Television,
@@ -211,6 +213,7 @@ export class Service extends EventEmitter {
   public static Fanv2: typeof Fanv2;
   public static Faucet: typeof Faucet;
   public static FilterMaintenance: typeof FilterMaintenance;
+  public static FirmwareUpdate: typeof FirmwareUpdate;
   public static GarageDoorOpener: typeof GarageDoorOpener;
   public static HeaterCooler: typeof HeaterCooler;
   public static HumidifierDehumidifier: typeof HumidifierDehumidifier;
@@ -249,6 +252,7 @@ export class Service extends EventEmitter {
   public static StatefulProgrammableSwitch: typeof StatefulProgrammableSwitch;
   public static StatelessProgrammableSwitch: typeof StatelessProgrammableSwitch;
   public static Switch: typeof Switch;
+  public static TapManagement: typeof TapManagement;
   public static TargetControl: typeof TargetControl;
   public static TargetControlManagement: typeof TargetControlManagement;
   public static Television: typeof Television;

--- a/src/lib/definitions/CharacteristicDefinitions.spec.ts
+++ b/src/lib/definitions/CharacteristicDefinitions.spec.ts
@@ -244,6 +244,12 @@ describe("CharacteristicDefinitions", () => {
     });
   });
 
+  describe("CryptoHash", () => {
+    it("should be able to construct", () => {
+      new Characteristic.CryptoHash();
+    });
+  });
+
   describe("CurrentAirPurifierState", () => {
     it("should be able to construct", () => {
       new Characteristic.CurrentAirPurifierState();
@@ -634,6 +640,12 @@ describe("CharacteristicDefinitions", () => {
     });
   });
 
+  describe("MetricsBufferFullState", () => {
+    it("should be able to construct", () => {
+      new Characteristic.MetricsBufferFullState();
+    });
+  });
+
   describe("Model", () => {
     it("should be able to construct", () => {
       new Characteristic.Model();
@@ -976,6 +988,12 @@ describe("CharacteristicDefinitions", () => {
     });
   });
 
+  describe("SelectedSleepConfiguration", () => {
+    it("should be able to construct", () => {
+      new Characteristic.SelectedSleepConfiguration();
+    });
+  });
+
   describe("SerialNumber", () => {
     it("should be able to construct", () => {
       new Characteristic.SerialNumber();
@@ -1198,6 +1216,12 @@ describe("CharacteristicDefinitions", () => {
     });
   });
 
+  describe("SupportedMetrics", () => {
+    it("should be able to construct", () => {
+      new Characteristic.SupportedMetrics();
+    });
+  });
+
   describe("SupportedRouterConfiguration", () => {
     it("should be able to construct", () => {
       new Characteristic.SupportedRouterConfiguration();
@@ -1207,6 +1231,12 @@ describe("CharacteristicDefinitions", () => {
   describe("SupportedRTPConfiguration", () => {
     it("should be able to construct", () => {
       new Characteristic.SupportedRTPConfiguration();
+    });
+  });
+
+  describe("SupportedSleepConfiguration", () => {
+    it("should be able to construct", () => {
+      new Characteristic.SupportedSleepConfiguration();
     });
   });
 
@@ -1231,6 +1261,12 @@ describe("CharacteristicDefinitions", () => {
   describe("SwingMode", () => {
     it("should be able to construct", () => {
       new Characteristic.SwingMode();
+    });
+  });
+
+  describe("TapType", () => {
+    it("should be able to construct", () => {
+      new Characteristic.TapType();
     });
   });
 
@@ -1381,6 +1417,12 @@ describe("CharacteristicDefinitions", () => {
   describe("TimeUpdate", () => {
     it("should be able to construct", () => {
       new Characteristic.TimeUpdate();
+    });
+  });
+
+  describe("Token", () => {
+    it("should be able to construct", () => {
+      new Characteristic.Token();
     });
   });
 

--- a/src/lib/definitions/CharacteristicDefinitions.ts
+++ b/src/lib/definitions/CharacteristicDefinitions.ts
@@ -804,6 +804,23 @@ export class CoolingThresholdTemperature extends Characteristic {
 Characteristic.CoolingThresholdTemperature = CoolingThresholdTemperature;
 
 /**
+ * Characteristic "Crypto Hash"
+ */
+export class CryptoHash extends Characteristic {
+
+  public static readonly UUID: string = "00000250-0000-1000-8000-0026BB765291";
+
+  constructor() {
+    super("Crypto Hash", CryptoHash.UUID, {
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_WRITE, Perms.WRITE_RESPONSE],
+    });
+    this.value = this.getDefaultValue();
+  }
+}
+Characteristic.CryptoHash = CryptoHash;
+
+/**
  * Characteristic "Current Air Purifier State"
  */
 export class CurrentAirPurifierState extends Characteristic {
@@ -2174,6 +2191,23 @@ export class MaximumTransmitPower extends Characteristic {
 Characteristic.MaximumTransmitPower = MaximumTransmitPower;
 
 /**
+ * Characteristic "Metrics Buffer Full State"
+ */
+export class MetricsBufferFullState extends Characteristic {
+
+  public static readonly UUID: string = "00000272-0000-1000-8000-0026BB765291";
+
+  constructor() {
+    super("Metrics Buffer Full State", MetricsBufferFullState.UUID, {
+      format: Formats.BOOL,
+      perms: [Perms.NOTIFY, Perms.PAIRED_READ],
+    });
+    this.value = this.getDefaultValue();
+  }
+}
+Characteristic.MetricsBufferFullState = MetricsBufferFullState;
+
+/**
  * Characteristic "Model"
  */
 export class Model extends Characteristic {
@@ -3309,6 +3343,23 @@ export class SelectedRTPStreamConfiguration extends Characteristic {
 Characteristic.SelectedRTPStreamConfiguration = SelectedRTPStreamConfiguration;
 
 /**
+ * Characteristic "Selected Sleep Configuration"
+ */
+export class SelectedSleepConfiguration extends Characteristic {
+
+  public static readonly UUID: string = "00000252-0000-1000-8000-0026BB765291";
+
+  constructor() {
+    super("Selected Sleep Configuration", SelectedSleepConfiguration.UUID, {
+      format: Formats.TLV8,
+      perms: [Perms.NOTIFY, Perms.PAIRED_READ, Perms.PAIRED_WRITE, Perms.WRITE_RESPONSE],
+    });
+    this.value = this.getDefaultValue();
+  }
+}
+Characteristic.SelectedSleepConfiguration = SelectedSleepConfiguration;
+
+/**
  * Characteristic "Serial Number"
  */
 export class SerialNumber extends Characteristic {
@@ -4025,6 +4076,23 @@ export class SupportedFirmwareUpdateConfiguration extends Characteristic {
 Characteristic.SupportedFirmwareUpdateConfiguration = SupportedFirmwareUpdateConfiguration;
 
 /**
+ * Characteristic "Supported Metrics"
+ */
+export class SupportedMetrics extends Characteristic {
+
+  public static readonly UUID: string = "00000271-0000-1000-8000-0026BB765291";
+
+  constructor() {
+    super("Supported Metrics", SupportedMetrics.UUID, {
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
+    });
+    this.value = this.getDefaultValue();
+  }
+}
+Characteristic.SupportedMetrics = SupportedMetrics;
+
+/**
  * Characteristic "Supported Router Configuration"
  */
 export class SupportedRouterConfiguration extends Characteristic {
@@ -4057,6 +4125,23 @@ export class SupportedRTPConfiguration extends Characteristic {
   }
 }
 Characteristic.SupportedRTPConfiguration = SupportedRTPConfiguration;
+
+/**
+ * Characteristic "Supported Sleep Configuration"
+ */
+export class SupportedSleepConfiguration extends Characteristic {
+
+  public static readonly UUID: string = "00000251-0000-1000-8000-0026BB765291";
+
+  constructor() {
+    super("Supported Sleep Configuration", SupportedSleepConfiguration.UUID, {
+      format: Formats.TLV8,
+      perms: [Perms.PAIRED_READ],
+    });
+    this.value = this.getDefaultValue();
+  }
+}
+Characteristic.SupportedSleepConfiguration = SupportedSleepConfiguration;
 
 /**
  * Characteristic "Supported Transfer Transport Configuration"
@@ -4133,6 +4218,23 @@ export class SwingMode extends Characteristic {
   }
 }
 Characteristic.SwingMode = SwingMode;
+
+/**
+ * Characteristic "Tap Type"
+ */
+export class TapType extends Characteristic {
+
+  public static readonly UUID: string = "0000022F-0000-1000-8000-0026BB765291";
+
+  constructor() {
+    super("Tap Type", TapType.UUID, {
+      format: Formats.UINT16,
+      perms: [Perms.PAIRED_READ],
+    });
+    this.value = this.getDefaultValue();
+  }
+}
+Characteristic.TapType = TapType;
 
 /**
  * Characteristic "Target Air Purifier State"
@@ -4685,6 +4787,23 @@ export class TimeUpdate extends Characteristic {
 }
 // noinspection JSDeprecatedSymbols
 Characteristic.TimeUpdate = TimeUpdate;
+
+/**
+ * Characteristic "Token"
+ */
+export class Token extends Characteristic {
+
+  public static readonly UUID: string = "00000231-0000-1000-8000-0026BB765291";
+
+  constructor() {
+    super("Token", Token.UUID, {
+      format: Formats.DATA,
+      perms: [Perms.PAIRED_WRITE],
+    });
+    this.value = this.getDefaultValue();
+  }
+}
+Characteristic.Token = Token;
 
 /**
  * Characteristic "Transmit Power"

--- a/src/lib/definitions/ServiceDefinitions.spec.ts
+++ b/src/lib/definitions/ServiceDefinitions.spec.ts
@@ -652,6 +652,28 @@ describe("ServiceDefinitions", () => {
     });
   });
 
+  describe("FirmwareUpdate", () => {
+    it("should be able to construct", () => {
+      const service0 = new Service.FirmwareUpdate();
+      const service1 = new Service.FirmwareUpdate("test name");
+      const service2 = new Service.FirmwareUpdate("test name", "test sub type");
+
+      expect(service0.displayName).toBe("");
+      expect(service0.testCharacteristic(Characteristic.Name)).toBe(false);
+      expect(service0.subtype).toBeUndefined();
+
+      expect(service1.displayName).toBe("test name");
+      expect(service1.testCharacteristic(Characteristic.Name)).toBe(true);
+      expect(service1.getCharacteristic(Characteristic.Name).value).toBe("test name");
+      expect(service1.subtype).toBeUndefined();
+
+      expect(service2.displayName).toBe("test name");
+      expect(service2.testCharacteristic(Characteristic.Name)).toBe(true);
+      expect(service2.getCharacteristic(Characteristic.Name).value).toBe("test name");
+      expect(service2.subtype).toBe("test sub type");
+    });
+  });
+
   describe("GarageDoorOpener", () => {
     it("should be able to construct", () => {
       const service0 = new Service.GarageDoorOpener();
@@ -1298,6 +1320,28 @@ describe("ServiceDefinitions", () => {
       const service0 = new Service.Switch();
       const service1 = new Service.Switch("test name");
       const service2 = new Service.Switch("test name", "test sub type");
+
+      expect(service0.displayName).toBe("");
+      expect(service0.testCharacteristic(Characteristic.Name)).toBe(false);
+      expect(service0.subtype).toBeUndefined();
+
+      expect(service1.displayName).toBe("test name");
+      expect(service1.testCharacteristic(Characteristic.Name)).toBe(true);
+      expect(service1.getCharacteristic(Characteristic.Name).value).toBe("test name");
+      expect(service1.subtype).toBeUndefined();
+
+      expect(service2.displayName).toBe("test name");
+      expect(service2.testCharacteristic(Characteristic.Name)).toBe(true);
+      expect(service2.getCharacteristic(Characteristic.Name).value).toBe("test name");
+      expect(service2.subtype).toBe("test sub type");
+    });
+  });
+
+  describe("TapManagement", () => {
+    it("should be able to construct", () => {
+      const service0 = new Service.TapManagement();
+      const service1 = new Service.TapManagement("test name");
+      const service2 = new Service.TapManagement("test name", "test sub type");
 
       expect(service0.displayName).toBe("");
       expect(service0.testCharacteristic(Characteristic.Name)).toBe(false);

--- a/src/lib/definitions/ServiceDefinitions.ts
+++ b/src/lib/definitions/ServiceDefinitions.ts
@@ -86,6 +86,8 @@ export class AccessoryMetrics extends Service {
 
     // Required Characteristics
     this.addCharacteristic(Characteristic.Active);
+    this.addCharacteristic(Characteristic.MetricsBufferFullState);
+    this.addCharacteristic(Characteristic.SupportedMetrics);
   }
 }
 Service.AccessoryMetrics = AccessoryMetrics;
@@ -356,10 +358,10 @@ export class CameraRecordingManagement extends Service {
 
     // Required Characteristics
     this.addCharacteristic(Characteristic.Active);
+    this.addCharacteristic(Characteristic.SelectedCameraRecordingConfiguration);
+    this.addCharacteristic(Characteristic.SupportedAudioRecordingConfiguration);
     this.addCharacteristic(Characteristic.SupportedCameraRecordingConfiguration);
     this.addCharacteristic(Characteristic.SupportedVideoRecordingConfiguration);
-    this.addCharacteristic(Characteristic.SupportedAudioRecordingConfiguration);
-    this.addCharacteristic(Characteristic.SelectedCameraRecordingConfiguration);
 
     // Optional Characteristics
     this.addOptionalCharacteristic(Characteristic.RecordingAudioActive);
@@ -656,6 +658,27 @@ export class FilterMaintenance extends Service {
   }
 }
 Service.FilterMaintenance = FilterMaintenance;
+
+/**
+ * Service "Firmware Update"
+ */
+export class FirmwareUpdate extends Service {
+
+  public static readonly UUID: string = "00000236-0000-1000-8000-0026BB765291";
+
+  constructor(displayName?: string, subtype?: string) {
+    super(displayName, FirmwareUpdate.UUID, subtype);
+
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.FirmwareUpdateReadiness);
+    this.addCharacteristic(Characteristic.FirmwareUpdateStatus);
+
+    // Optional Characteristics
+    this.addOptionalCharacteristic(Characteristic.StagedFirmwareVersion);
+    this.addOptionalCharacteristic(Characteristic.SupportedFirmwareUpdateConfiguration);
+  }
+}
+Service.FirmwareUpdate = FirmwareUpdate;
 
 /**
  * Service "Garage Door Opener"
@@ -1063,6 +1086,10 @@ export class PowerManagement extends Service {
 
     // Required Characteristics
     this.addCharacteristic(Characteristic.WakeConfiguration);
+
+    // Optional Characteristics
+    this.addOptionalCharacteristic(Characteristic.SelectedSleepConfiguration);
+    this.addOptionalCharacteristic(Characteristic.SupportedSleepConfiguration);
   }
 }
 Service.PowerManagement = PowerManagement;
@@ -1318,6 +1345,25 @@ export class Switch extends Service {
   }
 }
 Service.Switch = Switch;
+
+/**
+ * Service "Tap Management"
+ */
+export class TapManagement extends Service {
+
+  public static readonly UUID: string = "0000022E-0000-1000-8000-0026BB765291";
+
+  constructor(displayName?: string, subtype?: string) {
+    super(displayName, TapManagement.UUID, subtype);
+
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.Active);
+    this.addCharacteristic(Characteristic.CryptoHash);
+    this.addCharacteristic(Characteristic.TapType);
+    this.addCharacteristic(Characteristic.Token);
+  }
+}
+Service.TapManagement = TapManagement;
 
 /**
  * Service "Target Control"

--- a/src/lib/definitions/generate-definitions.ts
+++ b/src/lib/definitions/generate-definitions.ts
@@ -653,7 +653,7 @@ function generatePermsString(id: string, propertiesBitMap: number): string {
   }
 
   const result =  perms.join(", ");
-  assert(!result, "perms string cannot be empty (" + propertiesBitMap + ")");
+  assert(!!result, "perms string cannot be empty (" + propertiesBitMap + ")");
   return result;
 }
 


### PR DESCRIPTION
## :recycle: Current situation

Current service and characteristic definitions reflect the state of iOS 15.

## :bulb: Proposed solution

This PR regenerates service and characteristic definitions with the latest changes of iOS 16.

## :gear: Release Notes

- Added `FirmwareUpdate` service definition
- Added `TapManagement` service definition
- Updated `AccessoryMetrics` service definition
- Updated `PowerManagement` service definition

## :heavy_plus_sign: Additional Information
This PR fixes a small issue in the definition generator script.

### Testing

Tests were generated accordingly.

### Reviewer Nudging

--
