### PR TITLE
Iterate on characteristic value correction when calling setProps

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,13 @@ export type Nullable<T> = T | null;
 export type WithUUID<T> = T & { UUID: string };
 
 /**
+ * {@see Partial} but allowing null as a value.
+ */
+export type PartialAllowingNull<T> = {
+  [P in keyof T]?: T[P] | null;
+}
+
+/**
  * UUID string uniquely identifying every HAP connection.
  */
 export type SessionIdentifier = string;


### PR DESCRIPTION
## :recycle: Current situation

Value correction was introduced in #902. The PR didn't introduce any test cases and also didn't handle a lot of edge cases (see https://github.com/homebridge/HAP-NodeJS/pull/902#issuecomment-1278578336).

## :bulb: Proposed solution

This PR iterates on this changes by:
- Adding test coverage
- Skipping value correction in certain edge cases.

## :gear: Release Notes

--

## :heavy_plus_sign: Additional Information

### Testing

Tests were added to verify that setProps corrects numeric and string based formats if bounds restrictions change.
Tests were added to ensure that there aren't any faulty CHANGE events generated.

### Reviewer Nudging

--

CC: @ebaauw 
