### PR TITLE
Document that `DOORBELL` EventTriggerOption is not supported by HomeKit client side

### DIFF
--- a/src/lib/camera/RecordingManagement.ts
+++ b/src/lib/camera/RecordingManagement.ts
@@ -76,6 +76,11 @@ export const enum EventTriggerOption {
   MOTION = 0x01,
   /**
    * The Doorbell trigger. If enabled a doorbell button press should trigger the start of a recording.
+   *
+   * Note: While the doorbell is defined by the HomeKit specification and HAP-NodeJS supports (and the
+   * {@link RecordingManagement} advertises support for it), HomeKit HomeHubs will (as of now, iOS 15-16)
+   * never enable Doorbell triggers. Seemingly this is currently unsupported by Apple.
+   * See https://github.com/homebridge/HAP-NodeJS/issues/976#issuecomment-1280301989.
    */
   DOORBELL = 0x02,
 }


### PR DESCRIPTION
## :recycle: Current situation

As described in #976, the `DOORBELL` event trigger is part of HomeKit specification (as discovery through reversing certified accessories) but isn't implemented by Apples HomeKit client-side.

## :bulb: Proposed solution

This PR clarifies this matter in the documentation of the `EventTriggerOption` definitions.

## :gear: Release Notes

- Clarified technical documentation of `EventTriggerOption.DOORBELL`.

## :heavy_plus_sign: Additional Information

### Testing

--

### Reviewer Nudging

--
