### PR TITLE
Remove accidental usage of private jest type

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -19,7 +19,7 @@ import {
   ResourceRequest,
   ResourceRequestType,
 } from "../internal-types";
-import { CharacteristicValue, HAPPincode, InterfaceName, IPAddress, MacAddress, Nullable, VoidCallback, WithUUID } from "../types";
+import { CharacteristicValue, ConstructorArgs, HAPPincode, InterfaceName, IPAddress, MacAddress, Nullable, VoidCallback, WithUUID } from "../types";
 import { Advertiser, AdvertiserEvent, AvahiAdvertiser, BonjourHAPAdvertiser, CiaoAdvertiser, ResolvedAdvertiser } from "./Advertiser";
 // noinspection JSDeprecatedSymbols
 import { LegacyCameraSource, LegacyCameraSourceAdapter, StreamController } from "./camera";
@@ -469,8 +469,7 @@ export class Accessory extends EventEmitter {
    * @param constructorArgs - The arguments passed to the given constructor.
    * @returns Returns the constructed service instance.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public addService<S extends typeof Service>(serviceConstructor: S, ...constructorArgs: ConstructorArgsType<S>): Service
+  public addService<S extends typeof Service>(serviceConstructor: S, ...constructorArgs: ConstructorArgs<S>): Service
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public addService(serviceParam: Service | typeof Service, ...constructorArgs: any[]): Service {
     // service might be a constructor like `Service.AccessoryInformation` instead of an instance

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,11 @@ export type PartialAllowingNull<T> = {
 }
 
 /**
+ * Type of the constructor arguments of the provided constructor type.
+ */
+export type ConstructorArgs<C> = C extends new (...args: infer A) => any ? A : never; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+/**
  * UUID string uniquely identifying every HAP connection.
  */
 export type SessionIdentifier = string;


### PR DESCRIPTION
## :recycle: Current situation

#973 retyped the `Accessory.addService(...)` method to provide more clear typing when supplying a service using its constructor. This method used, my accident, a type which was internal to the jest testing framework.

## :bulb: Proposed solution

This PR packages the type as part of `hap-nodejs` itself.

## :gear: Release Notes

* Fixed an issue where `addService` referenced an internal type of the jest testing library.

## :heavy_plus_sign: Additional Information

### Testing

--

### Reviewer Nudging

--
