### PR TITLE
Workaround avahi issues on synology platform

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1430,7 +1430,12 @@ export class Accessory extends EventEmitter {
 
     this._advertiser!.startAdvertising()
       .then(() => this.emit(AccessoryEventTypes.ADVERTISED))
-      .catch(reason => console.error("Could not create mDNS advertisement. The HAP-Server won't be discoverable: " + reason));
+      .catch(reason => {
+        console.error("Could not create mDNS advertisement. The HAP-Server won't be discoverable: " + reason);
+        if (reason.stack) {
+          debug("Detailed error: " + reason.stack);
+        }
+      });
 
     this.emit(AccessoryEventTypes.LISTENING, port, hostname);
   }


### PR DESCRIPTION
## :recycle: Current situation

As described in #993 there are issues with avahi advertiser feature introduced in #970 where we detect avahi-daemon restarts.
This feature fails on synology platforms and causes the whole advertiser to fail.

## :bulb: Proposed solution

This PR introduces a workaround to be able to start the advertiser even when the restart listener is not in place.

## :gear: Release Notes

* Introduced a workaround for issues with avahi advertiser on Synology

## :heavy_plus_sign: Additional Information


### Testing

--

### Reviewer Nudging

--
