### PR TITLE
Refactor DBus InvokeError

### DIFF
--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../@types/bonjour-hap.d.ts" />
 import ciao, { CiaoService, MDNSServerOptions, Responder, ServiceEvent, ServiceTxt, ServiceType } from "@homebridge/ciao";
 import { InterfaceName, IPAddress } from "@homebridge/ciao/lib/NetworkManager";
-import dbus, { DBusInterface, InvokeError, MessageBus } from "@homebridge/dbus-native";
+import dbus, { DBusInterface, MessageBus } from "@homebridge/dbus-native";
 import assert from "assert";
 import bonjour, { BonjourHAP, BonjourHAPService, MulticastOptions } from "bonjour-hap";
 import crypto from "crypto";
@@ -303,7 +303,8 @@ function messageBusConnectionResult(bus: MessageBus): Promise<void> {
 export class DBusInvokeError extends Error {
   readonly errorName: string;
 
-  constructor(errorObject: InvokeError) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(errorObject: { name: string, message: any }) {
     super();
 
     Object.setPrototypeOf(this, DBusInvokeError.prototype);

--- a/src/types/dbus-native.d.ts
+++ b/src/types/dbus-native.d.ts
@@ -4,17 +4,11 @@ declare module "@homebridge/dbus-native" {
 
   function systemBus(): MessageBus;
 
-  export class InvokeError {
-    name: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    message: any;
-  }
-
   export class MessageBus {
     connection: BusConnection;
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
-    public invoke(message: any, callback: (error: InvokeError | undefined, value: any) => void): void;
+    public invoke(message: any, callback: (error: { name: string, message: any } | undefined, value: any) => void): void;
 
     public getService(name: string): DBusService;
   }


### PR DESCRIPTION
## :recycle: Current situation

Currently using hap-nodejs/homebridge as a dependency is a struggle in strongly typed environments as reported in #998.

## :bulb: Proposed solution

This PR refactors the exported interface of HAP-NodeJS such that the internal type declaration file is not part of it anymore.

## :gear: Release Notes

* Fixes an issue compiling projects relying on hap-nodejs that enforce strict type rules.

## :heavy_plus_sign: Additional Information

### Testing

--

### Reviewer Nudging

--
