### PR TITLE
provide connection source address hint to advise udp binding

### DIFF
--- a/src/lib/camera/RTPStreamManagement.ts
+++ b/src/lib/camera/RTPStreamManagement.ts
@@ -392,6 +392,7 @@ export type SnapshotRequest = {
  */
 export type PrepareStreamRequest = {
   sessionID: StreamSessionIdentifier,
+  sourceAddress: string,
   targetAddress: string,
   addressVersion: "ipv4" | "ipv6",
   audio: Source,
@@ -1142,6 +1143,7 @@ export class RTPStreamManagement {
 
     const prepareRequest: PrepareStreamRequest = {
       sessionID: sessionIdentifier,
+      sourceAddress: connection.localAddress,
       targetAddress: controllerAddress,
       addressVersion: addressVersion === IPAddressVersion.IPV6? "ipv6": "ipv4",
 


### PR DESCRIPTION
Currently HAP-NodeJS doesn't provide the incoming address for the HAP connection. This means that the UDP video must bind to 0.0.0.0, and can be problematic. For example, wifi and ethernet may both be connected to the LAN. Binding to all addresses and sending data may result in the video being sent over wifi.

Currently getting around this by requiring users to select their LAN IP addresses, and guessing which address to use based on ipv4 and ipv6. This doesn't really work if multiple ipv4 addresses are advertised on different networks.

Providing the source address for the connection in addition to the target would be ideal here.