### PR TITLE
add avahi file advertiser

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -28,7 +28,7 @@ import {
   VoidCallback,
   WithUUID,
 } from "../types";
-import { Advertiser, AdvertiserEvent, AvahiAdvertiser, BonjourHAPAdvertiser, CiaoAdvertiser, ResolvedAdvertiser } from "./Advertiser";
+import { Advertiser, AdvertiserEvent, AvahiAdvertiser, BonjourHAPAdvertiser, CiaoAdvertiser, ResolvedAdvertiser, AvahiFileAdvertiser } from "./Advertiser";
 // noinspection JSDeprecatedSymbols
 import { LegacyCameraSource, LegacyCameraSourceAdapter, StreamController } from "./camera";
 import {
@@ -290,7 +290,7 @@ export interface PublishInfo {
 /**
  * @group Accessory
  */
-export const enum MDNSAdvertiser {
+export enum MDNSAdvertiser {
   /**
    * Use the `@homebridge/ciao` module as advertiser.
    */
@@ -311,6 +311,10 @@ export const enum MDNSAdvertiser {
    * Consequentially, treat this feature as an experimental feature.
    */
   RESOLVED = "resolved",
+  /**
+   * Use the `avahi-file` module as advertiser.
+   */
+  AVAHI_FILE = "avahi-file",
 }
 
 /**
@@ -1331,6 +1335,9 @@ export class Accessory extends EventEmitter {
       break;
     case MDNSAdvertiser.RESOLVED:
       this._advertiser = new ResolvedAdvertiser(this._accessoryInfo);
+      break;
+    case MDNSAdvertiser.AVAHI_FILE:
+      this._advertiser = new AvahiFileAdvertiser(this._accessoryInfo);
       break;
     default:
       throw new Error("Unsupported advertiser setting: '" + info.advertiser + "'");


### PR DESCRIPTION
## :recycle: Current situation

- the docker container requires host networking because homebridge wants to advertise its own service

## :bulb: Proposed solution

- make it possible to publish zeroconf information via an avahi xml file, so that it can be mounted, example:
  ```yml
  volumes:
  - /etc/avahi/services/myhub-0000.service:/homebridge/myhub-0000.service
  ```
  (of course, this also requires changes in `config.json` as well as [`jneubrand/homebridge#94b2f53`](https://github.com/jneubrand/homebridge/commit/94b2f538657f064bb8dfd35f67c1679e96cd8dee))
  once this is done, it's no longer necessary to expose host networking when using the docker homebridge image. (other relevant ports need to be exposed explicitly nonetheless)

## :gear: Release Notes

- add avahi-file advertiser

## :heavy_plus_sign: Additional Information

- i've been using this patch for a few years and it works
- should probably allow users to configure the path the `.service` file is written to

### Testing

- none implemented, just want to submit a proof-of-concept pr to check if anyone else wants this :)

### Reviewer Nudging

this isn't ready to merge yet