### PR TITLE
Mitigate memory "leak" warnings when significant numbers of HSV events are happening simultaneously.

### DIFF
--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -804,6 +804,7 @@ export class DataStreamConnection extends EventEmitter {
           this.state = ConnectionState.EXPECTING_HELLO;
 
           // below listener is removed in .close()
+          this.connection.setMaxListeners(this.connection.getMaxListeners() + 1);
           this.connection.on(HAPConnectionEvent.CLOSED, this.hapConnectionClosedListener); // register close listener
 
           debug("[%s] Registering CLOSED handler to HAP connection. Connection currently has %d close handlers!",
@@ -1139,6 +1140,7 @@ export class DataStreamConnection extends EventEmitter {
     this.emit(DataStreamConnectionEvent.CLOSED);
 
     this.connection?.removeListener(HAPConnectionEvent.CLOSED, this.hapConnectionClosedListener);
+    this.connection?.setMaxListeners(this.connection.getMaxListeners() - 1);
     this.removeAllListeners();
   }
 


### PR DESCRIPTION
This small PR addresses the warnings that can occur when the following scenario occurs:

* Multiple HSV-configured cameras have been configured and are in use.
* Multiple HSV events are occurring simultaneously.

When can easily hit the event emitter thresholds for individual HAP controller connections. This PR increments and decrements the max listener high water mark to scale appropriately regardless of the number of cameras and simultaneous events.
