### PR TITLE
Mitigate event emitter "memory leak" warnings when a significant number of camera streaming events occur simultaneously.

### DIFF
--- a/src/lib/camera/RTPStreamManagement.ts
+++ b/src/lib/camera/RTPStreamManagement.ts
@@ -784,6 +784,7 @@ export class RTPStreamManagement {
 
     if (this.activeConnection) {
       this.activeConnection.removeListener(HAPConnectionEvent.CLOSED, this.activeConnectionClosedListener);
+      this.activeConnection.setMaxListeners(this.activeConnection.getMaxListeners() - 1);
       this.activeConnection = undefined;
     }
 
@@ -1098,6 +1099,7 @@ export class RTPStreamManagement {
       "Found non-nil `activeConnection` when trying to setup streaming endpoints, even though streamStatus is reported to be AVAILABLE!");
 
     this.activeConnection = connection;
+    this.activeConnection.setMaxListeners(this.activeConnection.getMaxListeners() + 1);
     this.activeConnection.on(HAPConnectionEvent.CLOSED, this.activeConnectionClosedListener);
 
     // noinspection JSDeprecatedSymbols


### PR DESCRIPTION

## :recycle: Current situation

When a substantial number of streaming requests come in to Homebridge simultaneously, "memory leak" event emitter warnings can be triggered. The issue being that when HAP-NodeJS adds a new listener, it isn't incrementing the max listener count accordingly leading to situations like:

```
(node:13787) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 closed listeners added to [HAPConnection]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at _addListener (node:events:594:17)
    at HAPConnection.addListener (node:events:612:10)
    at HAPConnection.on (/opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/util/eventedhttp.ts:426:29)
    at RTPStreamManagement.handleSetupEndpoints (/opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/camera/RTPStreamManagement.ts:1101:27)
    at SetupEndpoints.<anonymous> (/opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/camera/RTPStreamManagement.ts:777:14)
    at SetupEndpoints.emit (node:events:520:28)
    at /opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2596:16
    at new Promise (<anonymous>)
```
## :bulb: Proposed solution

The PR addresses this in the same manner as a similar issue affecting HomeKit Secure Video events.

## :gear: Release Notes

Mitigate event emitter "memory leak" warnings when a significant number of camera streaming events occur simultaneously.
## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging
@Supereg