### PR TITLE
Minor fixes to recording logging and one change in logging.

### DIFF
--- a/src/lib/camera/RecordingManagement.ts
+++ b/src/lib/camera/RecordingManagement.ts
@@ -588,7 +588,7 @@ export class RecordingManagement {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     this.recordingStream = new CameraRecordingStream(connection, this.delegate, id, streamId);
     this.recordingStream.on(CameraRecordingStreamEvents.CLOSED, () => {
-      debug("[HDS %s] Removing active recoding session from recording management!");
+      debug("[HDS %s] Removing active recoding session from recording management!", connection.remoteAddress);
       this.recordingStream = undefined;
     });
 
@@ -1056,8 +1056,8 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
 
       if (!lastFragmentWasMarkedLast && !this.closed) {
         // Delegate violates the contract. Exited normally on a non-closed stream without properly setting `isLast`.
-        console.warn(`[HDS ${this.connection.remoteAddress}] Delegate finished streaming for ${this.streamId} without setting RecordingPacket.isLast. \
-        Can't notify Controller about endOfStream!`);
+        console.warn(`[HDS ${this.connection.remoteAddress}] Delegate finished streaming for ${this.streamId} without setting RecordingPacket.isLast. ` +
+        "Can't notify Controller about endOfStream!");
       }
     } catch (error) {
       if (this.closed) {
@@ -1093,11 +1093,6 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
         // ensure that if something fails the recording stream is freed nonetheless.
         this.kickOffCloseTimeout();
       }
-    }
-
-    if (initialization) { // we never actually sent anything out there!
-      console.warn(`[HDS ${this.connection.remoteAddress}] Delegate finished recording stream ${this.streamId} without sending anything out. \
-      Controller will CANCEL.`);
     }
 
     debug("[HDS %s] Finished DATA_SEND transmission for stream %d!", this.connection.remoteAddress, this.streamId);


### PR DESCRIPTION
## :recycle: Current situation

Two fixes for logging:

- A missing connection identifier in the debug logging of the close handler.
- Message notifying users that isLast is missing used string literals with the message broken up over two lines for code formatting purposes. I've adjusted it to output as-intended on a single line.

Removed one log warning related to not sending any data out through the recording handler. There are valid situations where not sending out any data is the correct answer such as when the HomeKit hub specifically terminates the connection before the first recording packet is sent out. In that instance, sending any data back would result in a different error (Delegate yielded fragment after close). In truth, while this should be an edge case that rarely occurs, it does occur regularly enough that you'll see it in a typical home environment when you have more than a few cameras that are producing HomeKit Secure Video events.
 
## :bulb: Proposed solution

See above.

## :gear: Release Notes

Minor logging improvements for HomeKit Secure Video recording delegates.

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

@donavanbecker @Supereg
