### PR TITLE
fix: Ensure data is only transmitted on open and ready connections.

### DIFF
--- a/src/lib/camera/RecordingManagement.ts
+++ b/src/lib/camera/RecordingManagement.ts
@@ -1018,6 +1018,10 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
         let offset = 0;
         let dataChunkSequenceNumber = 1;
         while (offset < fragment.length) {
+          if (this.closed) {
+            break;
+          }
+
           const data = fragment.slice(offset, offset + maxChunk);
           offset += data.length;
 

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -715,7 +715,9 @@ export class DataStreamConnection extends EventEmitter {
     header.protocol = protocol;
     header.event = event;
 
-    this.sendHDSFrame(header, message);
+    if (this.state === ConnectionState.READY) {
+      this.sendHDSFrame(header, message);
+    }
   }
 
   /**


### PR DESCRIPTION
## :recycle: Current situation

When a HomeKit Secure Video recording event is closed while inflight, HAP-NodeJS still attempts to send data over a closed connection resulting in errors like:

```
[HDS ::ffff:1.2.3.4] Encountered unexpected error for recording stream 1: Error: Cannot send message on closing/closed socket!
    at new HDSConnectionError (/opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/datastream/DataStreamServer.ts:578:10)
    at DataStreamConnection.sendHDSFrame (/opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/datastream/DataStreamServer.ts:1066:13)
    at DataStreamConnection.sendEvent (/opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/datastream/DataStreamServer.ts:718:10)
    at CameraRecordingStream.<anonymous> (/opt/homebrew/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/camera/RecordingManagement.ts:1042:27)
    at step (/opt/homebrew/lib/node_modules/homebridge/node_modules/tslib/tslib.js:195:27)
    at Object.next (/opt/homebrew/lib/node_modules/homebridge/node_modules/tslib/tslib.js:176:57)
    at fulfilled (/opt/homebrew/lib/node_modules/homebridge/node_modules/tslib/tslib.js:166:62)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

## :bulb: Proposed solution

This PR addresses the problem in two places:

- In the DataStreamServer module, ensure `sendEvent` only ever attempts to send if the connection is in the `READY` state.
- In the RecordingManagement module, ensure our connection hasn’t been closed while we are processing data from the recording delegate.

## :gear: Release Notes

fix: For HomeKit Secure Video events, ensure data is only transmitted on open and ready connections.

### Reviewer Nudging

@Supereg 
