### PR TITLE
fix: ensure we check names using the full UTF-8 character set.

### DIFF
--- a/src/lib/util/checkName.ts
+++ b/src/lib/util/checkName.ts
@@ -1,3 +1,5 @@
+import { CharacteristicValue, Nullable } from "../../types";
+
 /**
  * Checks that supplied field meets Apple HomeKit naming rules
  * https://developer.apple.com/design/human-interface-guidelines/homekit#Help-people-choose-useful-names
@@ -5,12 +7,10 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-export function checkName(displayName: string, name: string, value: any): void {
-  const validHK = /^[a-zA-Z0-9\s'-.]+$/;   // Ensure only letter, numbers, apostrophe, or dash
-  const startWith = /^[a-zA-Z0-9]/;       // Ensure only letters or numbers are at the beginning of string
-  const endWith = /[a-zA-Z0-9]$/;         // Ensure only letters or numbers are at the end of string
+export function checkName(displayName: string, name: string, value: Nullable<CharacteristicValue>): void {
 
-  if (!validHK.test(value) || !startWith.test(value) || !endWith.test(value)) {
+  // Ensure the string starts and ends with a Unicode letter or number and allow any combination of letters, numbers, spaces, and apostrophes in the middle.
+  if (typeof value === "string" && value.length && !(new RegExp(/^[\p{L}\p{N}][\p{L}\p{N} ']*[\p{L}\p{N}]$/u)).test(value)) {
     console.warn("HAP-NodeJS WARNING: The accessory '" + displayName + "' is getting published with the characteristic '" +
       name + "'" + " not following HomeKit naming rules ('" + value + "'). " +
       "Use only alphanumeric, space, and apostrophe characters, start and end with an alphabetic or numeric character, and don't include emojis. " +

--- a/src/lib/util/checkName.ts
+++ b/src/lib/util/checkName.ts
@@ -10,7 +10,7 @@ import { CharacteristicValue, Nullable } from "../../types";
 export function checkName(displayName: string, name: string, value: Nullable<CharacteristicValue>): void {
 
   // Ensure the string starts and ends with a Unicode letter or number and allow any combination of letters, numbers, spaces, and apostrophes in the middle.
-  if (typeof value === "string" && value.length && !(new RegExp(/^[\p{L}\p{N}][\p{L}\p{N} ']*[\p{L}\p{N}]$/u)).test(value)) {
+  if (typeof value === "string" && !(new RegExp(/^[\p{L}\p{N}][\p{L}\p{N} ']*[\p{L}\p{N}]$/u)).test(value)) {
     console.warn("HAP-NodeJS WARNING: The accessory '" + displayName + "' is getting published with the characteristic '" +
       name + "'" + " not following HomeKit naming rules ('" + value + "'). " +
       "Use only alphanumeric, space, and apostrophe characters, start and end with an alphabetic or numeric character, and don't include emojis. " +

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ES5",
-    "module": "commonjs",
-    "downlevelIteration": true,
-    "importHelpers": true,
-    "lib": [
-      "es2015",
-      "es2016",
-      "es2017",
-      "es2018"
-    ],
+    "allowSyntheticDefaultImports": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "preserveConstEnums": true, // do not remove this option!
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2022",
     "useUnknownInCatchVariables": false
   },
   "include": [


### PR DESCRIPTION
## :recycle: Current situation

This further refines #1009 to:

1. Check names using the UTF-8 character set rather than ASCII.
2. Ensure we fully comply with HomeKit naming requirements.
3. Ignores the value if it’s empty. ConfiguredName is an optional characteristic and it’s okay if it’s empty, for instance.
4. Updates tsconfig to support Node 18 at a minimum (required to get UTF-8 regular expressions).

## :bulb: Proposed solution

Refactored and implemented.

## :gear: Release Notes

improvement: refinements to HomeKit name validation.

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

@NorthernMan54
