### PR TITLE
Increase snapshot handler warning timeout to 8000ms.

### DIFF
--- a/src/lib/controller/CameraController.ts
+++ b/src/lib/controller/CameraController.ts
@@ -1025,7 +1025,7 @@ export class CameraController extends EventEmitter implements SerializableContro
           reject(HAPStatus.OPERATION_TIMED_OUT);
         }, 17000);
         timeout.unref();
-      }, 5000);
+      }, 8000);
       timeout.unref();
 
       try {


### PR DESCRIPTION
## :recycle: Current situation

When a camera image snapshot takes more than 5s to return an image to HAP-NodeJS a warning is generated, even though the HomeKit timeout appears to be at least 10s.
## :bulb: Proposed solution

Revised the warning to generate at 8s instead of 5s, allowing developers a longer window without warnings.

## :gear: Release Notes

Updated image snapshot warning timeout to 8s (previously 5s).
