### PR TITLE
Improvement: HKSV recording stream AbortSignal support and graceful generator termination.

### DIFF
--- a/src/lib/camera/RecordingManagement.ts
+++ b/src/lib/camera/RecordingManagement.ts
@@ -941,6 +941,7 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
   readonly delegate: CameraRecordingDelegate;
   readonly hdsRequestId: number;
   readonly streamId: number;
+  private abortController?: AbortController;
   private closed = false;
 
   eventHandler?: Record<string, EventHandler> = {
@@ -997,11 +998,12 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
     let lastFragmentWasMarkedLast = false;
 
     try {
-      this.generator = this.delegate.handleRecordingStreamRequest(this.streamId);
+      this.abortController = new AbortController();
+      this.generator = this.delegate.handleRecordingStreamRequest(this.streamId, this.abortController.signal);
 
       for await (const packet of this.generator) {
         if (this.closed) {
-          console.error(`[HDS ${this.connection.remoteAddress}] Delegate yielded fragment after stream ${this.streamId} was already closed!`);
+          debug("[HDS %s] Delegate yielded fragment after stream %d was already closed.", this.connection.remoteAddress, this.streamId);
           break;
         }
 
@@ -1082,6 +1084,7 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
       }
       return;
     } finally {
+      this.abortController = undefined;
       this.generator = undefined;
 
       if (this.generatorTimeout) {
@@ -1137,7 +1140,15 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
   }
 
   private handleClosed(closure: () => void): void {
+    if (this.closed) {
+      return;
+    }
+
     this.closed = true;
+
+    // Signal the delegate's generator to stop immediately. This allows delegates with abortable async operations (e.g. pacing delays) to interrupt them and
+    // return without yielding to a closed stream.
+    this.abortController?.abort();
 
     if (this.closingTimeout) {
       clearTimeout(this.closingTimeout);
@@ -1148,6 +1159,13 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
     this.connection.removeListener(DataStreamConnectionEvent.CLOSED, this.closeListener);
 
     if (this.generator) {
+      // Signal the generator to terminate via the async generator protocol. The return is queued and takes effect after the generator's current await completes.
+      // Combined with the AbortSignal above, this ensures the generator terminates promptly even if the delegate doesn't check the signal. We catch rejections
+      // to prevent unhandled promise warnings if the generator's cleanup throws.
+      // @ts-expect-error: AsyncGenerator.return() requires a value parameter, but we're signaling termination — no meaningful RecordingPacket to provide.
+      void this.generator.return().catch((error: Error) =>
+        debug("[HDS %s] Error while closing recording generator for stream %d: %s", this.connection.remoteAddress, this.streamId, error.stack ?? String(error)));
+
       // when this variable is defined, the generator hasn't returned yet.
       // we start a timeout to uncover potential programming mistakes where we await forever and can't free resources.
       this.generatorTimeout = setTimeout(() => {

--- a/src/lib/controller/CameraController.ts
+++ b/src/lib/controller/CameraController.ts
@@ -279,8 +279,10 @@ export interface CameraRecordingDelegate {
    * NOTE: Don't rely on the streamId for unique identification. Two {@link DataStreamConnection}s might share the same identifier space.
    *
    * @param streamId - The streamId of the currently ongoing stream.
+   * @param signal - An optional {@link AbortSignal} that is aborted when the recording stream is closed. Delegates can use this to interrupt pending async
+   *   operations (e.g. pacing delays) for immediate cleanup, rather than waiting for {@link closeRecordingStream} to be called.
    */
-  handleRecordingStreamRequest(streamId: number): AsyncGenerator<RecordingPacket>;
+  handleRecordingStreamRequest(streamId: number, signal?: AbortSignal): AsyncGenerator<RecordingPacket>;
 
   /**
    * This method is called once the HomeKit Controller acknowledges the `endOfStream`.


### PR DESCRIPTION
## Summary
  - Add `AbortSignal` support to `CameraRecordingDelegate.handleRecordingStreamRequest()` for immediate, cooperative cancellation of recording stream generators when an HDS stream closes.
  - Call `generator.return()` in `handleClosed()` as a protocol-level backstop to ensure generator termination.
  - Add idempotency guard to `handleClosed()` to prevent double invocation from batched TCP messages.
  - Downgrade the "Delegate yielded fragment after stream was already closed" message from `console.error` to `debug()`.
  - Extensively tested with `homebridge-unifi-protect` and validated as working correctly.

## Background
When an HDS recording stream closes, `handleClosed()` sets `this.closed = true` and calls `closeRecordingStream()` on the delegate. The delegate's async generator is expected to stop yielding. However, if the generator is suspended in an async operation (e.g. a pacing delay or FFmpeg wait), it can't observe the close signal until that operation completes — which may be seconds later. By then, the generator yields one more fragment to a closed stream, triggering the "Delegate yielded fragment after stream was already closed" error.

This is an inherent race condition in the async generator protocol: `handleClosed()` can't preemptively stop a generator that has a pending `.next()` call. The consumer must wait for the generator to yield before it can break the loop.

Additionally, `handleClosed()` lacked an idempotency guard — unlike `close()` which checks `this.closed` before proceeding, `handleClosed()` could be invoked multiple times when multiple close-related messages arrive in the same TCP chunk and are processed in the `forEach` loop within `onSocketData`. This resulted in `closeRecordingStream()` being called twice for the same stream, causing duplicate side effects in delegate implementations.

## Approach
Four changes, each independently tested and validated:

  1. **`AbortSignal`** — `handleClosed()` aborts the signal immediately alongside setting `this.closed`. Delegates that make their async operations abortable (e.g. using `node:timers/promises` `setTimeout` with a signal) wake up instantly and can return without yielding. This is the modern platform pattern for cooperative async cancellation.

  2. **`generator.return()`** — Called in `handleClosed()` as a fire-and-forget signal. Per the async generator spec, the return is queued and takes effect after the generator's current await completes. This ensures termination even for delegates that don't adopt the `AbortSignal`.

  3. **`handleClosed()` idempotency guard** — Matches the existing pattern in `close()`. Prevents double invocation when batched TCP messages trigger multiple close events for the same stream in a single `onSocketData` processing cycle.

  4. **`debug()` downgrade** — The post-close yield is an inherent race for delegates that haven't adopted the signal. The fragment is already discarded and the loop breaks. Logging it as `console.error` implies a programming mistake when it's actually a protocol-level timing condition.

## Backwards compatibility
The `signal` parameter on `handleRecordingStreamRequest()` is optional. Existing delegates that don't declare it continue working exactly as before — the signal is passed but ignored. The `generator.return()` backstop ensures termination regardless of delegate adoption.

## Test plan
  - [x] Existing HKSV recording functionality is unaffected — recordings start, stream, and end normally.
  - [x] The "Delegate yielded fragment after stream was already closed" `console.error` no longer appears in production logs.
  - [x] Delegates using abortable async operations (e.g. `setTimeout` with signal) exit immediately on stream close without yielding post-close fragments.
  - [x] Delegates NOT using the signal still terminate via the `generator.return()` backstop.
  - [x] `handleClosed()` idempotency guard prevents duplicate `closeRecordingStream()` calls from batched TCP messages.

## Backport
Once merged, we should be cherry-picked to the `release-0.x` branch. The recording management code is identical between 0.14.x and 2.x for the paths we're modifying — the cherry-pick applies cleanly (verified).