### PR TITLE
Backport: HKSV AbortSignal support and graceful generator termination for recording streams.

### DIFF
--- a/src/lib/camera/RecordingManagement.ts
+++ b/src/lib/camera/RecordingManagement.ts
@@ -944,6 +944,7 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
   readonly delegate: CameraRecordingDelegate;
   readonly hdsRequestId: number;
   readonly streamId: number;
+  private abortController?: AbortController;
   private closed = false;
 
   eventHandler?: Record<string, EventHandler> = {
@@ -1000,11 +1001,12 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
     let lastFragmentWasMarkedLast = false;
 
     try {
-      this.generator = this.delegate.handleRecordingStreamRequest(this.streamId);
+      this.abortController = new AbortController();
+      this.generator = this.delegate.handleRecordingStreamRequest(this.streamId, this.abortController.signal);
 
       for await (const packet of this.generator) {
         if (this.closed) {
-          console.error(`[HDS ${this.connection.remoteAddress}] Delegate yielded fragment after stream ${this.streamId} was already closed!`);
+          debug("[HDS %s] Delegate yielded fragment after stream %d was already closed.", this.connection.remoteAddress, this.streamId);
           break;
         }
 
@@ -1085,6 +1087,7 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
       }
       return;
     } finally {
+      this.abortController = undefined;
       this.generator = undefined;
 
       if (this.generatorTimeout) {
@@ -1140,7 +1143,15 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
   }
 
   private handleClosed(closure: () => void): void {
+    if (this.closed) {
+      return;
+    }
+
     this.closed = true;
+
+    // Signal the delegate's generator to stop immediately. This allows delegates with abortable async operations (e.g. pacing delays) to interrupt them and
+    // return without yielding to a closed stream.
+    this.abortController?.abort();
 
     if (this.closingTimeout) {
       clearTimeout(this.closingTimeout);
@@ -1151,6 +1162,13 @@ class CameraRecordingStream extends EventEmitter implements DataStreamProtocolHa
     this.connection.removeListener(DataStreamConnectionEvent.CLOSED, this.closeListener);
 
     if (this.generator) {
+      // Signal the generator to terminate via the async generator protocol. The return is queued and takes effect after the generator's current await completes.
+      // Combined with the AbortSignal above, this ensures the generator terminates promptly even if the delegate doesn't check the signal. We catch rejections
+      // to prevent unhandled promise warnings if the generator's cleanup throws.
+      // @ts-expect-error: AsyncGenerator.return() requires a value parameter, but we're signaling termination — no meaningful RecordingPacket to provide.
+      void this.generator.return().catch((error: Error) =>
+        debug("[HDS %s] Error while closing recording generator for stream %d: %s", this.connection.remoteAddress, this.streamId, error.stack ?? String(error)));
+
       // when this variable is defined, the generator hasn't returned yet.
       // we start a timeout to uncover potential programming mistakes where we await forever and can't free resources.
       this.generatorTimeout = setTimeout(() => {

--- a/src/lib/controller/CameraController.ts
+++ b/src/lib/controller/CameraController.ts
@@ -280,8 +280,10 @@ export interface CameraRecordingDelegate {
    * NOTE: Don't rely on the streamId for unique identification. Two {@link DataStreamConnection}s might share the same identifier space.
    *
    * @param streamId - The streamId of the currently ongoing stream.
+   * @param signal - An optional {@link AbortSignal} that is aborted when the recording stream is closed. Delegates can use this to interrupt pending async
+   *   operations (e.g. pacing delays) for immediate cleanup, rather than waiting for {@link closeRecordingStream} to be called.
    */
-  handleRecordingStreamRequest(streamId: number): AsyncGenerator<RecordingPacket>;
+  handleRecordingStreamRequest(streamId: number, signal?: AbortSignal): AsyncGenerator<RecordingPacket>;
 
   /**
    * This method is called once the HomeKit Controller acknowledges the `endOfStream`.


### PR DESCRIPTION
Backport of #1110 to the 0.14.x release line. Cherry-pick applies cleanly — the recording management code is identical between 0.14.x and 2.x for the paths modified.

See #1110 for full background, approach, and test plan.
