### PR TITLE
v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: unguarded buffer reads in camera stream TLV parsing
 - fix: category defaulting to string instead of enum
 - fix: missing error argument in pairing debug logs
+- fix: use constant-time comparison for pincode checks
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: validate required TLV fields in pairing handlers
 - fix: unhandled `Promise.all` rejection in RTP proxy setup
 - fix: missing `SEQUENCE_NUM` check in pair handlers
+- fix: prevent M1 resetting in-progress pair setup
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: missing error argument in pairing debug logs
 - fix: use constant-time comparison for pincode checks
 - fix: `"undefined"` string in characteristic error warnings
+- fix: O(n²) buffer concat in encrypt/decrypt hot path
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: prevent M1 resetting in-progress pair setup
 - fix: TLV decoder missing length bounds validation
 - fix: unsafe non-null assertions in accessory lookups
+- fix: validate `aid.iid` format before parsing
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: missing `SEQUENCE_NUM` check in pair handlers
 - fix: prevent M1 resetting in-progress pair setup
 - fix: TLV decoder missing length bounds validation
+- fix: unsafe non-null assertions in accessory lookups
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: `readFloat64LE` missing reader index advance
 - fix: utf-8 tag using char count not byte length
 - fix: validate encrypted data length before crypto split
+- fix: validate required TLV fields in pairing handlers
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: validate encrypted data length before crypto split
 - fix: validate required TLV fields in pairing handlers
 - fix: unhandled `Promise.all` rejection in RTP proxy setup
+- fix: missing `SEQUENCE_NUM` check in pair handlers
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: TLV decoder missing length bounds validation
 - fix: unsafe non-null assertions in accessory lookups
 - fix: validate `aid.iid` format before parsing
+- fix: unguarded buffer reads in camera stream TLV parsing
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 
 - fix: int32 range check in `DataStreamParser`
 - fix: `readFloat64LE` missing reader index advance
+- fix: utf-8 tag using char count not byte length
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: use constant-time comparison for pincode checks
 - fix: `"undefined"` string in characteristic error warnings
 - fix: O(n²) buffer concat in encrypt/decrypt hot path
+- chore: dependency updates, inc. `typescript`
+
+### Homebridge Dependencies
+
+- `@homebridge/ciao` @ `v1.3.7`
+- `@homebridge/dbus-native` @ `v0.7.4`
+- `bonjour-hap` @ `v3.10.1`
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: unsafe non-null assertions in accessory lookups
 - fix: validate `aid.iid` format before parsing
 - fix: unguarded buffer reads in camera stream TLV parsing
+- fix: category defaulting to string instead of enum
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@homebridge/hap-nodejs` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v2.1.3 (Pending Release)
+
+### Changes
+
+- fix: int32 range check in `DataStreamParser`
+
 ## v2.1.2 (2026-03-29)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 ### Changes
 
 - fix: int32 range check in `DataStreamParser`
+- fix: `readFloat64LE` missing reader index advance
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: int32 range check in `DataStreamParser`
 - fix: `readFloat64LE` missing reader index advance
 - fix: utf-8 tag using char count not byte length
+- fix: validate encrypted data length before crypto split
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: category defaulting to string instead of enum
 - fix: missing error argument in pairing debug logs
 - fix: use constant-time comparison for pincode checks
+- fix: `"undefined"` string in characteristic error warnings
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: validate `aid.iid` format before parsing
 - fix: unguarded buffer reads in camera stream TLV parsing
 - fix: category defaulting to string instead of enum
+- fix: missing error argument in pairing debug logs
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: utf-8 tag using char count not byte length
 - fix: validate encrypted data length before crypto split
 - fix: validate required TLV fields in pairing handlers
+- fix: unhandled `Promise.all` rejection in RTP proxy setup
 
 ## v2.1.2 (2026-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 - fix: unhandled `Promise.all` rejection in RTP proxy setup
 - fix: missing `SEQUENCE_NUM` check in pair handlers
 - fix: prevent M1 resetting in-progress pair setup
+- fix: TLV decoder missing length bounds validation
 
 ## v2.1.2 (2026-03-29)
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,11 @@ import type { Config } from "jest";
 const config: Config = {
   "preset": "ts-jest",
   "testEnvironment": "node",
+  "transform": {
+    "^.+\\.tsx?$": ["ts-jest", {
+      "tsconfig": "tsconfig.spec.json",
+    }],
+  },
   "coverageReporters": ["lcov"],
   "collectCoverageFrom": [
     "src/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/ciao": "^1.3.6",
+        "@homebridge/ciao": "^1.3.7",
         "@homebridge/dbus-native": "^0.7.4",
         "bonjour-hap": "^3.10.1",
         "debug": "^4.4.3",
@@ -26,23 +26,23 @@
         "@types/debug": "^4.1.13",
         "@types/escape-html": "^1.0.4",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.6.0",
         "@types/plist": "^3.0.5",
-        "@typescript-eslint/eslint-plugin": "^8.57.2",
-        "@typescript-eslint/parser": "^8.57.2",
-        "axios": "^1.14.0",
+        "@typescript-eslint/eslint-plugin": "^8.59.0",
+        "@typescript-eslint/parser": "^8.59.0",
+        "axios": "^1.15.2",
         "commander": "^14.0.3",
         "escape-html": "^1.0.3",
-        "eslint": "^10.1.0",
+        "eslint": "^10.2.1",
         "http-parser-js": "^0.5.10",
         "jest": "^30.3.0",
         "rimraf": "^6.1.3",
         "semver": "^7.7.4",
         "simple-plist": "^1.4.0",
-        "ts-jest": "^29.4.6",
+        "ts-jest": "^29.4.9",
         "ts-node": "^10.9.2",
-        "typedoc": "^0.28.18",
-        "typescript": "^5.9.3"
+        "typedoc": "^0.28.19",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": "^22 || ^24"
@@ -589,21 +589,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -652,13 +652,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -690,13 +690,13 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -706,22 +706,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -787,13 +787,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.6.tgz",
-      "integrity": "sha512-2F9N/15Q/GnoBXimr8PFg7fb1QrAQBvuZpaW2kseWOOy14Lzc3yZB1mT9N1Ju/4hlkboU33uHxtOxZkvkPoE/w==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.7.tgz",
+      "integrity": "sha512-ncvcXQe4vrqBLNqnVjQjke5NpNin6SO9bStfBZ4jgZk/xIjD9GMcH8vp8XKd7hw5akIzwITMiDMysIKvE5rHBw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -847,25 +847,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1024,9 +1038,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1533,9 +1547,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1720,13 +1734,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/plist": {
@@ -1772,20 +1786,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
-      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/type-utils": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1795,9 +1809,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.2",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1811,16 +1825,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
-      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1832,18 +1846,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.2",
-        "@typescript-eslint/types": "^8.57.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1854,18 +1868,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1876,9 +1890,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1889,21 +1903,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
-      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1914,13 +1928,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1932,21 +1946,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.2",
-        "@typescript-eslint/tsconfig-utils": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1956,7 +1970,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
@@ -1983,13 +1997,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1999,16 +2013,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
-      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2019,17 +2033,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2354,13 +2368,13 @@
       ]
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/acorn": {
@@ -2400,9 +2414,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2510,9 +2524,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2649,9 +2663,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2706,9 +2720,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2717,9 +2731,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2737,11 +2751,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2814,9 +2828,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {
@@ -3179,9 +3193,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -3308,18 +3322,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.3",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -3450,13 +3464,13 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3739,9 +3753,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -3958,9 +3972,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4078,9 +4092,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5351,9 +5365,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5671,13 +5685,13 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
-      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
+        "@xmldom/xmldom": "^0.9.10",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
@@ -5893,9 +5907,9 @@
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5903,13 +5917,13 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6369,14 +6383,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6406,19 +6420,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -6435,7 +6449,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -6564,17 +6578,17 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.18.tgz",
-      "integrity": "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==",
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.1",
-        "minimatch": "^10.2.4",
-        "yaml": "^2.8.2"
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -6611,13 +6625,13 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6627,9 +6641,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6662,9 +6676,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types"
   ],
   "dependencies": {
-    "@homebridge/ciao": "^1.3.6",
+    "@homebridge/ciao": "^1.3.7",
     "@homebridge/dbus-native": "^0.7.4",
     "bonjour-hap": "^3.10.1",
     "debug": "^4.4.3",
@@ -70,22 +70,22 @@
     "@types/debug": "^4.1.13",
     "@types/escape-html": "^1.0.4",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.6.0",
     "@types/plist": "^3.0.5",
-    "@typescript-eslint/eslint-plugin": "^8.57.2",
-    "@typescript-eslint/parser": "^8.57.2",
-    "axios": "^1.14.0",
+    "@typescript-eslint/eslint-plugin": "^8.59.0",
+    "@typescript-eslint/parser": "^8.59.0",
+    "axios": "^1.15.2",
     "commander": "^14.0.3",
     "escape-html": "^1.0.3",
-    "eslint": "^10.1.0",
+    "eslint": "^10.2.1",
     "http-parser-js": "^0.5.10",
     "jest": "^30.3.0",
     "rimraf": "^6.1.3",
     "semver": "^7.7.4",
     "simple-plist": "^1.4.0",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
-    "typedoc": "^0.28.18",
-    "typescript": "^5.9.3"
+    "typedoc": "^0.28.19",
+    "typescript": "^6.0.3"
   }
 }

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1852,6 +1852,9 @@ export class Accessory extends EventEmitter {
   private handleHAPConnectionClosed(connection: HAPConnection): void {
     for (const event of connection.getRegisteredEvents()) {
       const ids = event.split(".");
+      if (ids.length < 2) {
+        continue;
+      }
       const aid = parseInt(ids[0], 10);
       const iid = parseInt(ids[1], 10);
 

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1447,8 +1447,11 @@ export class Accessory extends EventEmitter {
         const aid = parseInt(split[0], 10);
         const iid = parseInt(split[1], 10);
 
-        const accessory = this.getAccessoryByAID(aid)!;
-        const characteristic = accessory.getCharacteristicByIID(iid)!;
+        const accessory = this.getAccessoryByAID(aid);
+        const characteristic = accessory?.getCharacteristicByIID(iid);
+        if (!accessory || !characteristic) {
+          continue;
+        }
         this.sendCharacteristicWarning(characteristic, CharacteristicWarningType.SLOW_READ, "The read handler for the characteristic '" +
           characteristic.displayName + "' on the accessory '" + accessory.displayName + "' was slow to respond!");
       }
@@ -1462,8 +1465,11 @@ export class Accessory extends EventEmitter {
           const aid = parseInt(split[0], 10);
           const iid = parseInt(split[1], 10);
 
-          const accessory = this.getAccessoryByAID(aid)!;
-          const characteristic = accessory.getCharacteristicByIID(iid)!;
+          const accessory = this.getAccessoryByAID(aid);
+          const characteristic = accessory?.getCharacteristicByIID(iid);
+          if (!accessory || !characteristic) {
+            continue;
+          }
           this.sendCharacteristicWarning(characteristic, CharacteristicWarningType.TIMEOUT_READ, "The read handler for the characteristic '" +
             characteristic.displayName + "' on the accessory '" + accessory.displayName + "' didn't respond at all!. " +
             "Please check that you properly call the callback!");
@@ -1617,8 +1623,11 @@ export class Accessory extends EventEmitter {
         const aid = parseInt(split[0], 10);
         const iid = parseInt(split[1], 10);
 
-        const accessory = this.getAccessoryByAID(aid)!;
-        const characteristic = accessory.getCharacteristicByIID(iid)!;
+        const accessory = this.getAccessoryByAID(aid);
+        const characteristic = accessory?.getCharacteristicByIID(iid);
+        if (!accessory || !characteristic) {
+          continue;
+        }
         this.sendCharacteristicWarning(characteristic, CharacteristicWarningType.SLOW_WRITE, "The write handler for the characteristic '" +
           characteristic.displayName + "' on the accessory '" + accessory.displayName + "' was slow to respond!");
       }
@@ -1632,8 +1641,11 @@ export class Accessory extends EventEmitter {
           const aid = parseInt(split[0], 10);
           const iid = parseInt(split[1], 10);
 
-          const accessory = this.getAccessoryByAID(aid)!;
-          const characteristic = accessory.getCharacteristicByIID(iid)!;
+          const accessory = this.getAccessoryByAID(aid);
+          const characteristic = accessory?.getCharacteristicByIID(iid);
+          if (!accessory || !characteristic) {
+            continue;
+          }
           this.sendCharacteristicWarning(characteristic, CharacteristicWarningType.TIMEOUT_WRITE, "The write handler for the characteristic '" +
             characteristic.displayName + "' on the accessory '" + accessory.displayName + "' didn't respond at all!. " +
             "Please check that you properly call the callback!");

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -2118,7 +2118,7 @@ export class Characteristic extends EventEmitter {
     try {
       value = this.validateUserInput(value)!;
     } catch (error) {
-      this.characteristicWarning(error?.message + "", CharacteristicWarningType.ERROR_MESSAGE, error?.stack);
+      this.characteristicWarning(error?.message || "Unknown error", CharacteristicWarningType.ERROR_MESSAGE, error?.stack);
       if (callback) {
         callback(error);
       }
@@ -2204,7 +2204,7 @@ export class Characteristic extends EventEmitter {
     try {
       value = this.validateUserInput(value);
     } catch (error) {
-      this.characteristicWarning(error?.message + "", CharacteristicWarningType.ERROR_MESSAGE, error?.stack);
+      this.characteristicWarning(error?.message || "Unknown error", CharacteristicWarningType.ERROR_MESSAGE, error?.stack);
       if (callback) {
         callback();
       }

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -494,7 +494,7 @@ export class HAPServer extends EventEmitter {
       return;
     }
     const sequence = tlvData[TLVValues.SEQUENCE_NUM][0]; // value is single byte with sequence number
-    if (sequence === PairingStates.M1) {
+    if (sequence === PairingStates.M1 && !connection._pairSetupState) {
       this.handlePairSetupM1(connection, request, response);
     } else if (sequence === PairingStates.M3 && connection._pairSetupState === PairingStates.M2) {
       this.handlePairSetupM3(connection, request, response, tlvData);

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -488,6 +488,11 @@ export class HAPServer extends EventEmitter {
     }
 
     const tlvData = tlv.decode(data);
+    if (!tlvData[TLVValues.SEQUENCE_NUM]) {
+      response.writeHead(HAPPairingHTTPCode.BAD_REQUEST, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      return;
+    }
     const sequence = tlvData[TLVValues.SEQUENCE_NUM][0]; // value is single byte with sequence number
     if (sequence === PairingStates.M1) {
       this.handlePairSetupM1(connection, request, response);
@@ -663,6 +668,11 @@ export class HAPServer extends EventEmitter {
 
   private handlePairVerify(connection: HAPConnection, url: URL, request: IncomingMessage, data: Buffer, response: ServerResponse): void {
     const tlvData = tlv.decode(data);
+    if (!tlvData[TLVValues.SEQUENCE_NUM]) {
+      response.writeHead(HAPPairingHTTPCode.BAD_REQUEST, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      return;
+    }
     const sequence = tlvData[TLVValues.SEQUENCE_NUM][0]; // value is single byte with sequence number
 
     if (sequence === PairingStates.M1) {

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -968,6 +968,11 @@ export class HAPServer extends EventEmitter {
       const ids: CharacteristicId[] = [];
       for (const entry of idParam.split(",")) { // ["1.9","2.14"]
         const split = entry.split("."); // ["1","9"]
+        if (split.length !== 2 || !/^\d+$/.test(split[0]) || !/^\d+$/.test(split[1])) {
+          response.writeHead(HAPHTTPCode.BAD_REQUEST, { "Content-Type": HAPMimeTypes.HAP_JSON });
+          response.end(JSON.stringify({ status: HAPStatus.INVALID_VALUE_IN_REQUEST }));
+          return;
+        }
         ids.push({
           aid: parseInt(split[0], 10), // accessory id
           iid: parseInt(split[1], 10), // (characteristic) instance id

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -555,6 +555,13 @@ export class HAPServer extends EventEmitter {
     // pull the SRP server we created in stepOne out of the current session
     const srpServer = connection.srpServer!;
     const encryptedData = tlvData[TLVValues.ENCRYPTED_DATA];
+    if (!encryptedData || encryptedData.length < 16) {
+      debug("[%s] M5: Encrypted data missing or too short", this.accessoryInfo.username);
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.SEQUENCE_NUM, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.AUTHENTICATION));
+      connection._pairSetupState = undefined;
+      return;
+    }
     const messageData = Buffer.alloc(encryptedData.length - 16);
     const authTagData = Buffer.alloc(16);
     encryptedData.copy(messageData, 0, 0, encryptedData.length - 16);
@@ -698,6 +705,13 @@ export class HAPServer extends EventEmitter {
   private handlePairVerifyM3(connection: HAPConnection, request: IncomingMessage, response: ServerResponse, objects: Record<number, Buffer>): void {
     debug("[%s] Pair verify step 2/2", this.accessoryInfo.username);
     const encryptedData = objects[TLVValues.ENCRYPTED_DATA];
+    if (!encryptedData || encryptedData.length < 16) {
+      debug("[%s] M3: Encrypted data missing or too short", this.accessoryInfo.username);
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.AUTHENTICATION));
+      connection._pairVerifyState = undefined;
+      return;
+    }
     const messageData = Buffer.alloc(encryptedData.length - 16);
     const authTagData = Buffer.alloc(16);
     encryptedData.copy(messageData, 0, 0, encryptedData.length - 16);

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -487,7 +487,15 @@ export class HAPServer extends EventEmitter {
       return;
     }
 
-    const tlvData = tlv.decode(data);
+    let tlvData: Record<number, Buffer>;
+    try {
+      tlvData = tlv.decode(data);
+    } catch (error) {
+      debug("[%s] Pair-Setup: failed to decode TLV request: %s", this.accessoryInfo.username, error.message);
+      response.writeHead(HAPPairingHTTPCode.BAD_REQUEST, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      return;
+    }
     if (!tlvData[TLVValues.SEQUENCE_NUM]) {
       response.writeHead(HAPPairingHTTPCode.BAD_REQUEST, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
@@ -587,7 +595,16 @@ export class HAPServer extends EventEmitter {
       return;
     }
     // decode the client payload and pass it on to the next step
-    const M5Packet = tlv.decode(plaintext);
+    let M5Packet: Record<number, Buffer>;
+    try {
+      M5Packet = tlv.decode(plaintext);
+    } catch (error) {
+      debug("[%s] M5: Failed to decode decrypted TLV payload: %s", this.accessoryInfo.username, error.message);
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.SEQUENCE_NUM, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      connection._pairSetupState = undefined;
+      return;
+    }
     const clientUsername = M5Packet[TLVValues.USERNAME];
     const clientLTPK = M5Packet[TLVValues.PUBLIC_KEY];
     const clientProof = M5Packet[TLVValues.PROOF];
@@ -667,7 +684,15 @@ export class HAPServer extends EventEmitter {
   }
 
   private handlePairVerify(connection: HAPConnection, url: URL, request: IncomingMessage, data: Buffer, response: ServerResponse): void {
-    const tlvData = tlv.decode(data);
+    let tlvData: Record<number, Buffer>;
+    try {
+      tlvData = tlv.decode(data);
+    } catch (error) {
+      debug("[%s] Pair-Verify: failed to decode TLV request: %s", this.accessoryInfo.username, error.message);
+      response.writeHead(HAPPairingHTTPCode.BAD_REQUEST, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      return;
+    }
     if (!tlvData[TLVValues.SEQUENCE_NUM]) {
       response.writeHead(HAPPairingHTTPCode.BAD_REQUEST, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
@@ -748,7 +773,16 @@ export class HAPServer extends EventEmitter {
       return;
     }
 
-    const decoded = tlv.decode(plaintext);
+    let decoded: Record<number, Buffer>;
+    try {
+      decoded = tlv.decode(plaintext);
+    } catch (error) {
+      debug("[%s] M3: Failed to decode decrypted TLV payload: %s", this.accessoryInfo.username, error.message);
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      connection._pairVerifyState = undefined;
+      return;
+    }
     const clientUsername = decoded[TLVValues.USERNAME];
     const proof = decoded[TLVValues.PROOF];
     if (!clientUsername || !proof) {
@@ -802,7 +836,15 @@ export class HAPServer extends EventEmitter {
       return;
     }
 
-    const objects = tlv.decode(data);
+    let objects: Record<number, Buffer>;
+    try {
+      objects = tlv.decode(data);
+    } catch (error) {
+      debug("[%s] Pairings: failed to decode TLV request: %s", this.accessoryInfo.username, error.message);
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      return;
+    }
     if (!objects[TLVValues.METHOD] || !objects[TLVValues.STATE]) {
       response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -1023,7 +1023,12 @@ export class HAPServer extends EventEmitter {
       );
     } else if (request.method === "PUT") {
       if (!connection.isAuthenticated()) {
-        if (!request.headers || (request.headers && request.headers.authorization !== this.accessoryInfo.pincode)) {
+        const authorization = request.headers?.authorization;
+        const authorizationBuffer = authorization ? Buffer.from(authorization) : undefined;
+        const pincodeBuffer = Buffer.from(this.accessoryInfo.pincode);
+        if (!authorizationBuffer
+          || authorizationBuffer.length !== pincodeBuffer.length
+          || !crypto.timingSafeEqual(authorizationBuffer, pincodeBuffer)) {
           response.writeHead(HAPPairingHTTPCode.CONNECTION_AUTHORIZATION_REQUIRED, { "Content-Type": HAPMimeTypes.HAP_JSON });
           response.end(JSON.stringify({ status: HAPStatus.INSUFFICIENT_PRIVILEGES }));
           return;
@@ -1121,7 +1126,12 @@ export class HAPServer extends EventEmitter {
 
   private handleResource(connection: HAPConnection, url: URL, request: IncomingMessage, data: Buffer, response: ServerResponse): void {
     if (!connection.isAuthenticated()) {
-      if (!(this.allowInsecureRequest && request.headers && request.headers.authorization === this.accessoryInfo.pincode)) {
+      const authorization = request.headers?.authorization;
+      const authorizationBuffer = authorization ? Buffer.from(authorization) : undefined;
+      const pincodeBuffer = Buffer.from(this.accessoryInfo.pincode);
+      if (!(this.allowInsecureRequest && authorizationBuffer
+        && authorizationBuffer.length === pincodeBuffer.length
+        && crypto.timingSafeEqual(authorizationBuffer, pincodeBuffer))) {
         response.writeHead(HAPPairingHTTPCode.CONNECTION_AUTHORIZATION_REQUIRED, { "Content-Type": HAPMimeTypes.HAP_JSON });
         response.end(JSON.stringify({ status: HAPStatus.INSUFFICIENT_PRIVILEGES }));
         return;

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -588,7 +588,7 @@ export class HAPServer extends EventEmitter {
     try {
       plaintext = hapCrypto.chacha20_poly1305_decryptAndVerify(outputKey, Buffer.from("PS-Msg05"), null, messageData, authTagData);
     } catch (error) {
-      debug("[%s] Error while decrypting and verifying M5 subTlv: %s", this.accessoryInfo.username);
+      debug("[%s] Error while decrypting and verifying M5 subTlv: %s", this.accessoryInfo.username, error);
       response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.SEQUENCE_NUM, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.AUTHENTICATION));
       connection._pairSetupState = undefined;
@@ -766,7 +766,7 @@ export class HAPServer extends EventEmitter {
     try {
       plaintext = hapCrypto.chacha20_poly1305_decryptAndVerify(enc.hkdfPairEncryptionKey, Buffer.from("PV-Msg03"), null, messageData, authTagData);
     } catch (error) {
-      debug("[%s] M3: Failed to decrypt and/or verify", this.accessoryInfo.username);
+      debug("[%s] M3: Failed to decrypt and/or verify: %s", this.accessoryInfo.username, error);
       response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
       response.end(tlv.encode(TLVValues.STATE, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.AUTHENTICATION));
       connection._pairVerifyState = undefined;

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -586,6 +586,13 @@ export class HAPServer extends EventEmitter {
     const clientUsername = M5Packet[TLVValues.USERNAME];
     const clientLTPK = M5Packet[TLVValues.PUBLIC_KEY];
     const clientProof = M5Packet[TLVValues.PROOF];
+    if (!clientUsername || !clientLTPK || !clientProof) {
+      debug("[%s] M5: Missing required TLV fields in decrypted payload", this.accessoryInfo.username);
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.SEQUENCE_NUM, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      connection._pairSetupState = undefined;
+      return;
+    }
     this.handlePairSetupM5_2(connection, request, response, clientUsername, clientLTPK, clientProof, outputKey);
   }
 
@@ -734,6 +741,13 @@ export class HAPServer extends EventEmitter {
     const decoded = tlv.decode(plaintext);
     const clientUsername = decoded[TLVValues.USERNAME];
     const proof = decoded[TLVValues.PROOF];
+    if (!clientUsername || !proof) {
+      debug("[%s] M3: Missing required TLV fields in decrypted payload", this.accessoryInfo.username);
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M4, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      connection._pairVerifyState = undefined;
+      return;
+    }
     const material = Buffer.concat([enc.clientPublicKey, clientUsername, enc.publicKey]);
     // since we're paired, we should have the public key stored for this client
     const clientPublicKey = this.accessoryInfo.getClientPublicKey(clientUsername.toString());
@@ -779,6 +793,11 @@ export class HAPServer extends EventEmitter {
     }
 
     const objects = tlv.decode(data);
+    if (!objects[TLVValues.METHOD] || !objects[TLVValues.STATE]) {
+      response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+      response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+      return;
+    }
     const method = objects[TLVValues.METHOD][0]; // value is single byte with request type
 
     const state = objects[TLVValues.STATE][0];
@@ -787,6 +806,11 @@ export class HAPServer extends EventEmitter {
     }
 
     if (method === PairMethods.ADD_PAIRING) {
+      if (!objects[TLVValues.IDENTIFIER] || !objects[TLVValues.PUBLIC_KEY] || !objects[TLVValues.PERMISSIONS]) {
+        response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+        response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+        return;
+      }
       const identifier = objects[TLVValues.IDENTIFIER].toString();
       const publicKey = objects[TLVValues.PUBLIC_KEY];
       const permissions = objects[TLVValues.PERMISSIONS][0] as PermissionTypes;
@@ -804,6 +828,11 @@ export class HAPServer extends EventEmitter {
         debug("[%s] Pairings: successfully executed ADD_PAIRING", this.accessoryInfo.username);
       }));
     } else if (method === PairMethods.REMOVE_PAIRING) {
+      if (!objects[TLVValues.IDENTIFIER]) {
+        response.writeHead(HAPPairingHTTPCode.OK, { "Content-Type": "application/pairing+tlv8" });
+        response.end(tlv.encode(TLVValues.STATE, PairingStates.M2, TLVValues.ERROR_CODE, TLVErrorCode.UNKNOWN));
+        return;
+      }
       const identifier = objects[TLVValues.IDENTIFIER].toString();
 
       this.emit(HAPServerEventTypes.REMOVE_PAIRING, connection, identifier, once((error: TLVErrorCode | 0) => {

--- a/src/lib/camera/RTPStreamManagement.ts
+++ b/src/lib/camera/RTPStreamManagement.ts
@@ -1151,6 +1151,15 @@ export class RTPStreamManagement {
           this.generateSetupEndpointResponse(connection, sessionIdentifier, prepareRequest, response, callback);
         }
       }));
+    }).catch((error: Error) => {
+      debug(`RTP proxy setup failed: ${error.message}`);
+      this.setupEndpointsResponse = tlv.encode(
+        SetupEndpointsResponseTypes.SESSION_ID, uuid.write(sessionIdentifier),
+        SetupEndpointsResponseTypes.STATUS, SetupEndpointsStatus.ERROR,
+      ).toString("base64");
+
+      this.handleSessionClosed();
+      callback(error);
     });
   }
 

--- a/src/lib/camera/RTPStreamManagement.ts
+++ b/src/lib/camera/RTPStreamManagement.ts
@@ -818,6 +818,19 @@ export class RTPStreamManagement {
     audioConfiguration: Record<number, Buffer>,
     callback: CharacteristicSetCallback,
   ): void {
+    try {
+      this._handleStartStreamInner(videoConfiguration, audioConfiguration, callback);
+    } catch (error) {
+      debug("Failed to parse stream start request: %s", (error as Error).message);
+      callback(HAPStatus.INVALID_VALUE_IN_REQUEST);
+    }
+  }
+
+  private _handleStartStreamInner(
+    videoConfiguration: Record<number, Buffer>,
+    audioConfiguration: Record<number, Buffer>,
+    callback: CharacteristicSetCallback,
+  ): void {
     // selected video configuration
     // noinspection JSUnusedLocalSymbols
     const videoCodec = videoConfiguration[SelectedVideoParametersTypes.CODEC_TYPE]; // always 0x00 for h264

--- a/src/lib/datastream/DataStreamParser.spec.ts
+++ b/src/lib/datastream/DataStreamParser.spec.ts
@@ -1,0 +1,101 @@
+import { DataStreamParser, DataStreamReader, DataStreamWriter, Float64 } from "./DataStreamParser";
+
+describe("DataStreamParser", () => {
+  describe("writeNumber Int32 range check", () => {
+    test("should encode numbers in Int32 range as Int32, not Int64", () => {
+      const writer = new DataStreamWriter();
+      // 100000 is within Int32 range but was previously encoded as Int64
+      writer.writeNumber(100000);
+      const data = writer.getData();
+      const reader = new DataStreamReader(data);
+
+      // Tag byte (1) + 4 bytes for Int32 = 5 bytes total
+      // If incorrectly encoded as Int64, it would be 1 + 8 = 9 bytes
+      expect(data.length).toBe(5);
+
+      // Verify it decodes back correctly
+      const decoded = DataStreamParser.decode(reader);
+      expect(decoded).toBe(100000);
+    });
+
+    test("should encode max Int32 value as Int32", () => {
+      const writer = new DataStreamWriter();
+      writer.writeNumber(2147483647);
+      const data = writer.getData();
+
+      // 1 tag byte + 4 data bytes = 5
+      expect(data.length).toBe(5);
+
+      const reader = new DataStreamReader(data);
+      expect(DataStreamParser.decode(reader)).toBe(2147483647);
+    });
+
+    test("should encode min Int32 value as Int32", () => {
+      const writer = new DataStreamWriter();
+      writer.writeNumber(-2147483648);
+      const data = writer.getData();
+
+      // 1 tag byte + 4 data bytes = 5
+      expect(data.length).toBe(5);
+
+      const reader = new DataStreamReader(data);
+      expect(DataStreamParser.decode(reader)).toBe(-2147483648);
+    });
+
+    test("should encode numbers beyond Int32 range as Int64", () => {
+      const writer = new DataStreamWriter();
+      writer.writeNumber(2147483648); // one above Int32 max
+      const data = writer.getData();
+
+      // 1 tag byte + 8 data bytes = 9
+      expect(data.length).toBe(9);
+
+      const reader = new DataStreamReader(data);
+      expect(DataStreamParser.decode(reader)).toBe(2147483648);
+    });
+  });
+
+  describe("readFloat64LE reader index advance", () => {
+    test("should advance reader index after reading Float64", () => {
+      const writer = new DataStreamWriter();
+      writer.writeFloat64LE(new Float64(3.14));
+      writer.writeFloat64LE(new Float64(2.71));
+      const data = writer.getData();
+
+      const reader = new DataStreamReader(data);
+      const first = DataStreamParser.decode(reader);
+      const second = DataStreamParser.decode(reader);
+
+      expect(first).toBeCloseTo(3.14);
+      expect(second).toBeCloseTo(2.71);
+      // If the reader index wasn't advancing, both would be 3.14
+      expect(second).not.toBeCloseTo(3.14);
+    });
+  });
+
+  describe("UTF-8 tag byte length", () => {
+    test("should correctly encode multi-byte UTF-8 strings", () => {
+      const writer = new DataStreamWriter();
+      // "é" is 2 bytes in UTF-8 but 1 character in JS
+      const testString = "é";
+      writer.writeUTF8(testString);
+      const data = writer.getData();
+
+      const reader = new DataStreamReader(data);
+      const decoded = DataStreamParser.decode(reader);
+      expect(decoded).toBe(testString);
+    });
+
+    test("should round-trip short strings with multi-byte characters", () => {
+      const writer = new DataStreamWriter();
+      // Mix of ASCII and multi-byte: 5 chars, 7 bytes in UTF-8
+      const testString = "hëllo";
+      writer.writeUTF8(testString);
+      const data = writer.getData();
+
+      const reader = new DataStreamReader(data);
+      const decoded = DataStreamParser.decode(reader);
+      expect(decoded).toBe(testString);
+    });
+  });
+});

--- a/src/lib/datastream/DataStreamParser.ts
+++ b/src/lib/datastream/DataStreamParser.ts
@@ -791,7 +791,7 @@ export class DataStreamWriter {
     const length = Buffer.byteLength(utf8);
     if (length <= 32) {
       this.ensureLength(1 + length);
-      this.writeTag(DataFormatTags.UTF8_LENGTH_START + utf8.length);
+      this.writeTag(DataFormatTags.UTF8_LENGTH_START + length);
       this._writeUTF8(utf8);
     } else if (length <= 255) {
       this.writeUTF8_Length8(utf8);

--- a/src/lib/datastream/DataStreamParser.ts
+++ b/src/lib/datastream/DataStreamParser.ts
@@ -441,6 +441,7 @@ export class DataStreamReader {
   readFloat64LE(): number {
     this.ensureLength(8);
     const value = this.data.readDoubleLE(this.readerIndex);
+    this.readerIndex += 8;
     return this.trackData(value);
   }
 

--- a/src/lib/datastream/DataStreamParser.ts
+++ b/src/lib/datastream/DataStreamParser.ts
@@ -684,7 +684,7 @@ export class DataStreamWriter {
       this.writeInt8(new Int8(number));
     } else if (number >= -32768 && number <= 32767) {
       this.writeInt16LE(new Int16(number));
-    } else if (number >= -2147483648 && number <= -2147483648) {
+    } else if (number >= -2147483648 && number <= 2147483647) {
       this.writeInt32LE(new Int32(number));
     } else if (number >= Number.MIN_SAFE_INTEGER && number <= Number.MAX_SAFE_INTEGER) { // use correct uin64 restriction when we convert to bigint
       this.writeInt64LE(new Int64(number));

--- a/src/lib/model/AccessoryInfo.spec.ts
+++ b/src/lib/model/AccessoryInfo.spec.ts
@@ -1,7 +1,28 @@
 import { AccessoryInfo } from "./AccessoryInfo";
+import { Categories } from "../Accessory";
+import { HAPStorage } from "./HAPStorage";
 import { AssertionError } from "assert";
 
 describe("AccessoryInfo", () => {
+  describe("#load()", () => {
+    it("should default category to Categories.OTHER when missing", () => {
+      const mockStorage = HAPStorage.storage();
+      (mockStorage.getItem as jest.Mock).mockReturnValueOnce({
+        displayName: "Test",
+        pincode: "123-45-678",
+        signSk: "aa".repeat(64),
+        signPk: "bb".repeat(32),
+        pairedClients: {},
+        // category intentionally omitted
+      });
+
+      const info = AccessoryInfo.load("0E:AE:FC:45:7B:91");
+      expect(info).not.toBeNull();
+      expect(info!.category).toBe(Categories.OTHER);
+      expect(typeof info!.category).toBe("number");
+    });
+  });
+
   describe("#assertValidUsername()", () => {
     it("should verify correct device id", () => {
       const VALUE = "0E:AE:FC:45:7B:91";

--- a/src/lib/model/AccessoryInfo.ts
+++ b/src/lib/model/AccessoryInfo.ts
@@ -280,7 +280,7 @@ export class AccessoryInfo {
     if (saved) {
       const info = new AccessoryInfo(username);
       info.displayName = saved.displayName || "";
-      info.category = saved.category || "";
+      info.category = saved.category || Categories.OTHER;
       info.pincode = saved.pincode || "";
       info.signSk = Buffer.from(saved.signSk || "", "hex");
       info.signPk = Buffer.from(saved.signPk || "", "hex");

--- a/src/lib/util/hapCrypto.spec.ts
+++ b/src/lib/util/hapCrypto.spec.ts
@@ -126,6 +126,14 @@ describe("hapCrypto", () => {
       expect(C_decrypted).toEqual(Buffer.concat([message1, message3]));
     });
 
+    test("large message encryption and decryption (multi-chunk)", () => {
+      // Message larger than 0x400 (1024) bytes forces multiple chunks
+      const largeMessage = crypto.randomBytes(3000);
+      const encrypted = hapCrypto.layerEncrypt(largeMessage, serverEncryption);
+      const decrypted = hapCrypto.layerDecrypt(encrypted, clientEncryption);
+      expect(decrypted).toEqual(largeMessage);
+    });
+
     test("incomplete frames decryption; first", () => {
       const S_encrypted0 = hapCrypto.layerEncrypt(message0, serverEncryption);
       const S_encrypted1 = hapCrypto.layerEncrypt(message1, serverEncryption);

--- a/src/lib/util/hapCrypto.ts
+++ b/src/lib/util/hapCrypto.ts
@@ -118,7 +118,7 @@ export function chacha20_poly1305_encryptAndSeal(key: Buffer, nonce: Buffer, aad
  * @group Cryptography
  */
 export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
-  let result = Buffer.alloc(0);
+  const chunks: Buffer[] = [];
   const total = data.length;
   for (let offset = 0; offset < total; ) {
     const length = Math.min(total - offset, 0x400);
@@ -131,9 +131,9 @@ export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
     const encrypted = chacha20_poly1305_encryptAndSeal(encryption.accessoryToControllerKey, nonce, leLength, data.subarray(offset, offset + length));
     offset += length;
 
-    result = Buffer.concat([result,leLength,encrypted.ciphertext,encrypted.authTag]);
+    chunks.push(leLength, encrypted.ciphertext, encrypted.authTag);
   }
-  return result;
+  return Buffer.concat(chunks);
 }
 
 /**
@@ -145,7 +145,7 @@ export function layerDecrypt(packet: Buffer, encryption: HAPEncryption): Buffer 
     encryption.incompleteFrame = undefined;
   }
 
-  let result = Buffer.alloc(0);
+  const chunks: Buffer[] = [];
   const total = packet.length;
 
   for (let offset = 0; offset < total;) {
@@ -167,9 +167,9 @@ export function layerDecrypt(packet: Buffer, encryption: HAPEncryption): Buffer 
       packet.subarray(offset + 2, offset + 2 + realDataLength),
       packet.subarray(offset + 2 + realDataLength, offset + 2 + realDataLength + 16),
     );
-    result = Buffer.concat([result, plaintext]);
+    chunks.push(plaintext);
     offset += (18 + realDataLength);
   }
 
-  return result;
+  return Buffer.concat(chunks);
 }

--- a/src/lib/util/tlv.spec.ts
+++ b/src/lib/util/tlv.spec.ts
@@ -95,6 +95,21 @@ describe("tlv", () => {
         1: Buffer.from("010203", "hex"),
       });
     });
+
+    test("should throw on truncated buffer (incomplete header)", () => {
+      // Only 1 byte — not enough for type + length
+      expect(() => decode(Buffer.from("01", "hex"))).toThrow("incomplete type/length header");
+    });
+
+    test("should throw when declared length exceeds remaining buffer", () => {
+      // Type 0x01, length 0x05, but only 2 bytes of data follow
+      expect(() => decode(Buffer.from("01050102", "hex"))).toThrow("declared length");
+    });
+
+    test("should not throw on valid zero-length entry", () => {
+      // Type 0x01, length 0x00
+      expect(() => decode(Buffer.from("0100", "hex"))).not.toThrow();
+    });
   });
 
   describe("decodeWithLists", () => {

--- a/src/lib/util/tlv.ts
+++ b/src/lib/util/tlv.ts
@@ -92,10 +92,17 @@ export function decode(buffer: Buffer): Record<number, Buffer> {
   let currentIndex = 0;
 
   for (; leftLength > 0;) {
+    if (leftLength < 2) {
+      throw new Error("TLV decode failure: incomplete type/length header");
+    }
     const type = buffer[currentIndex];
     const length = buffer[currentIndex + 1];
     currentIndex += 2;
     leftLength -= 2;
+
+    if (length > leftLength) {
+      throw new Error("TLV decode failure: declared length " + length + " exceeds remaining buffer " + leftLength);
+    }
 
     const data = buffer.subarray(currentIndex, currentIndex + length);
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "noEmit": true
+  },
+  "include": [
+    "src/"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
- fix: int32 range check in `DataStreamParser`
- fix: `readFloat64LE` missing reader index advance
- fix: utf-8 tag using char count not byte length
- fix: validate encrypted data length before crypto split
- fix: validate required TLV fields in pairing handlers
- fix: unhandled `Promise.all` rejection in RTP proxy setup
- fix: missing `SEQUENCE_NUM` check in pair handlers
- fix: prevent M1 resetting in-progress pair setup
- fix: TLV decoder missing length bounds validation
- fix: unsafe non-null assertions in accessory lookups
- fix: validate `aid.iid` format before parsing
- fix: unguarded buffer reads in camera stream TLV parsing
- fix: category defaulting to string instead of enum
- fix: missing error argument in pairing debug logs
- fix: use constant-time comparison for pincode checks
- fix: `"undefined"` string in characteristic error warnings
- fix: O(n²) buffer concat in encrypt/decrypt hot path
- chore: dependency updates, inc. `typescript`