### PR TITLE
Refine name validation in checkName function

### DIFF
--- a/src/lib/util/checkName.ts
+++ b/src/lib/util/checkName.ts
@@ -5,13 +5,21 @@ import { CharacteristicValue, Nullable } from "../../types";
  * https://developer.apple.com/design/human-interface-guidelines/homekit#Help-people-choose-useful-names
  * @private Private API
  */
-
 export function checkName(displayName: string, name: string, value: Nullable<CharacteristicValue>): void {
 
-  // Ensure the string starts and ends with a Unicode letter or number and allow any combination of letters, numbers, spaces, and apostrophes in the middle.
-  if (typeof value === "string" && !(new RegExp(/^[\p{L}\p{N}][\p{L}\p{N}\u2019 '.,-]*[\p{L}\p{N}\u2019]$/u)).test(value)) {
-    console.warn("HAP-NodeJS WARNING: The accessory '" + displayName + "' has an invalid '" + name + "' characteristic ('" + value + "'). Please use only " +
-      "alphanumeric, space, and apostrophe characters. Ensure it starts and ends with an alphabetic or numeric character, and avoid emojis. This may prevent " +
-      "the accessory from being added in the Home App or cause unresponsiveness.");
+  // Ensure the string starts and ends with a Unicode letter or number.
+  // Allow letters, numbers, spaces, apostrophes, and common punctuation in the middle.
+  if (
+    typeof value === 'string' &&
+    !/^[\p{L}\p{N}][\p{L}\p{N}\p{Z}\u2019'&!._:;()\/,-]*[\p{L}\p{N}]$/u.test(value)
+  ) {
+    console.warn(
+      "HAP-NodeJS WARNING: The accessory '" + displayName +
+      "' has an invalid '" + name + "' characteristic ('" + value +
+      "'). Please ensure the name starts and ends with a letter or number. " +
+      "Only letters, numbers, spaces, apostrophes, and common punctuation are supported. " +
+      "Avoid emojis or unsupported symbols. This may prevent the accessory from being added " +
+      "in the Home App or cause unresponsiveness."
+    );
   }
 }


### PR DESCRIPTION
The current accessory name validation appears more restrictive than the modern Apple Home app behaviour.

Historically, validation only allowed letters, numbers, spaces, and apostrophes in accessory names. However, current versions of the Home app accept a wider range of common punctuation characters when used within a name (for example: TV / Lounge, Heating & Cooling, or Camera: Front Yard).

This update relaxes the middle-character validation to better align with real-world Home app compatibility, while preserving the original safety constraints that names must begin and end with a Unicode letter or number.

The intent is to reduce unnecessary warnings and validation failures for valid accessory names without relaxing protection against malformed names, unsupported symbols, or problematic leading/trailing punctuation.

## :recycle: Current situation

_Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets)._

## :bulb: Proposed solution

_Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?_

## :gear: Release Notes

_Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features._

## :heavy_plus_sign: Additional Information

_If applicable, provide additional context in this section._

### Testing

_Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_
