### PR TITLE
v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 ### Changes
 
 - ci: rename the pr-labeler caller job from stale to label
+- fix: stop one accessory's invalid permissions taking down the whole bridge (#1129)
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `@homebridge/hap-nodejs` will be documented in this file.
 
 - ci: rename the pr-labeler caller job from stale to label
 - fix: stop one accessory's invalid permissions taking down the whole bridge (#1129)
+- chore(deps): dependency updates
 
 ### Homebridge Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/ciao": "1.3.12",
-        "@homebridge/dbus-native": "0.7.9",
-        "bonjour-hap": "3.10.5",
+        "@homebridge/ciao": "^1.3.12",
+        "@homebridge/dbus-native": "^0.7.9",
+        "bonjour-hap": "^3.10.5",
         "debug": "^4.4.3",
         "fast-srp-hap": "^2.0.4",
         "futoin-hkdf": "^1.5.3",
@@ -31,7 +31,7 @@
         "@typescript-eslint/parser": "^8.67.0",
         "commander": "^15.0.0",
         "escape-html": "^1.0.3",
-        "eslint": "^10.8.1",
+        "eslint": "^10.9.0",
         "http-parser-js": "^0.5.10",
         "jest": "^30.4.2",
         "rimraf": "^6.1.3",
@@ -2426,9 +2426,9 @@
       ]
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
-      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2702,9 +2702,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
-      "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+      "version": "2.11.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.17.tgz",
+      "integrity": "sha512-KAUDn1OSS0fmPlGO+NOUMRcOQ/b/shUBH3OgkG73mPgdf+JD/BQ6fHboGxNOxnUmlwcq+lLq3dTkayRPuSfXwg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3180,9 +3180,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.407",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.407.tgz",
-      "integrity": "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ==",
+      "version": "1.5.412",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.412.tgz",
+      "integrity": "sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3260,9 +3260,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "dist"
   ],
   "dependencies": {
-    "@homebridge/ciao": "1.3.12",
-    "@homebridge/dbus-native": "0.7.9",
-    "bonjour-hap": "3.10.5",
+    "@homebridge/ciao": "^1.3.12",
+    "@homebridge/dbus-native": "^0.7.9",
+    "bonjour-hap": "^3.10.5",
     "debug": "^4.4.3",
     "fast-srp-hap": "^2.0.4",
     "futoin-hkdf": "^1.5.3",
@@ -74,7 +74,7 @@
     "@typescript-eslint/parser": "^8.67.0",
     "commander": "^15.0.0",
     "escape-html": "^1.0.3",
-    "eslint": "^10.8.1",
+    "eslint": "^10.9.0",
     "http-parser-js": "^0.5.10",
     "jest": "^30.4.2",
     "rimraf": "^6.1.3",

--- a/src/lib/Accessory.spec.ts
+++ b/src/lib/Accessory.spec.ts
@@ -319,6 +319,198 @@ describe("Accessory", () => {
   });
 
   describe("publish", () => {
+    test("blocks a standalone accessory containing invalid characteristic permissions", async () => {
+      const service = accessory.addService(Service.Switch);
+      const characteristic = service.getCharacteristic(Characteristic.On);
+      characteristic.props.perms = [null as unknown as Perms, Perms.NOTIFY];
+      const publishInfo: PublishInfo = {
+        username: serverUsername,
+        pincode: "000-00-000",
+        category: Categories.SWITCH,
+      };
+
+      await expect(accessory.publish(publishInfo)).rejects.toThrow(
+        /Test Accessory.*Switch.*On.*invalid permissions/,
+      );
+      // @ts-expect-error: verify publication stopped before internal initialization
+      expect(accessory.initialized).toBe(false);
+    });
+
+    test("validates bridged accessories when the bridge is validated", () => {
+      const bridge = new Bridge("TestBridge", uuid.generate("bridge validation delegation"));
+      const bridgedAccessory = new Accessory("Bridged Accessory", uuid.generate("validated bridged accessory"));
+      bridgedAccessory.addService(Service.Switch);
+      bridge.addBridgedAccessory(bridgedAccessory);
+
+      // @ts-expect-error: spying on private method
+      const validateSpy = jest.spyOn(bridgedAccessory, "validateAccessory");
+      // @ts-expect-error: private access
+      bridge.validateAccessory(true);
+
+      expect(validateSpy).toHaveBeenCalledTimes(1);
+      validateSpy.mockRestore();
+    });
+
+    describe("quarantine of bridged accessories with invalid characteristic permissions", () => {
+      let bridge: Bridge;
+      let validAccessory: Accessory;
+      let offendingAccessory: Accessory;
+      let offendingService: Service;
+      let offendingCharacteristic: Characteristic;
+      let warningHandler: Mock;
+      let consoleErrorSpy: jest.SpyInstance;
+      let enqueueSpy: jest.SpyInstance;
+
+      // Serves the /accessories route the way a controller would and reports the aids that came back, which is everything HomeKit gets to see.
+      const servedAids = async (): Promise<number[]> => {
+        callback.mockReset();
+
+        // @ts-expect-error: private access
+        bridge.handleAccessories(connection, callback);
+        await callbackPromise;
+
+        const response = callback.mock.calls[0][1] as AccessoriesResponse;
+        return response.accessories.map(served => served.aid);
+      };
+
+      const corruptPermissions = (): void => {
+        offendingCharacteristic.props.perms = [null as unknown as Perms, Perms.NOTIFY];
+      };
+
+      beforeEach(() => {
+        bridge = new Bridge("TestBridge", uuid.generate("bridge with quarantined accessory"));
+
+        validAccessory = new Accessory("Valid Accessory", uuid.generate("valid accessory"));
+        validAccessory.addService(Service.Switch);
+
+        offendingAccessory = new Accessory("Invalid Accessory", uuid.generate("quarantined accessory"));
+        offendingService = offendingAccessory.addService(Service.Switch);
+        offendingCharacteristic = offendingService.getCharacteristic(Characteristic.On);
+
+        bridge.addBridgedAccessories([ validAccessory, offendingAccessory ]);
+        bridge._identifierCache = new IdentifierCache(serverUsername);
+
+        warningHandler = jest.fn();
+        offendingAccessory.on(AccessoryEventTypes.CHARACTERISTIC_WARNING, warningHandler);
+
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        // @ts-expect-error: spying on private method
+        enqueueSpy = jest.spyOn(bridge, "enqueueConfigurationUpdate");
+      });
+
+      afterEach(() => {
+        consoleErrorSpy.mockRestore();
+        enqueueSpy.mockRestore();
+      });
+
+      test("serves the bridge and its valid accessories only, attributing the fault once", async () => {
+        corruptPermissions();
+
+        const aids = await servedAids();
+
+        expect(aids).toEqual([ bridge.aid, validAccessory.aid ]);
+        expect(aids).not.toContain(offendingAccessory.aid);
+
+        // the exclusion is presentation-level: the accessory is still bridged, and only what we serve changed
+        expect(bridge.bridgedAccessories).toContain(offendingAccessory);
+        expect(offendingAccessory.bridged).toBe(true);
+        expect(offendingAccessory.bridge).toBe(bridge);
+
+        expect(warningHandler).toHaveBeenCalledTimes(1);
+        expect(warningHandler).toHaveBeenCalledWith(expect.objectContaining({
+          characteristic: offendingCharacteristic,
+          type: CharacteristicWarningType.ERROR_MESSAGE,
+          message: expect.stringMatching(/Invalid Accessory.*excluded from the accessory database.*Switch.*On.*contains invalid permissions/),
+        }));
+      });
+
+      test("excludes an accessory whose permissions are corrupted after it was already served", async () => {
+        expect(await servedAids()).toEqual([ bridge.aid, validAccessory.aid, offendingAccessory.aid ]);
+
+        corruptPermissions();
+
+        expect(await servedAids()).toEqual([ bridge.aid, validAccessory.aid ]);
+      });
+
+      test("serves the accessory again once its permissions are corrected, under the same aid", async () => {
+        corruptPermissions();
+        expect(await servedAids()).not.toContain(offendingAccessory.aid);
+
+        const quarantinedAid = offendingAccessory.aid;
+        warningHandler.mockClear();
+        offendingCharacteristic.props.perms = [ Perms.PAIRED_READ, Perms.NOTIFY ];
+
+        expect(await servedAids()).toEqual([ bridge.aid, validAccessory.aid, offendingAccessory.aid ]);
+        expect(offendingAccessory.aid).toEqual(quarantinedAid);
+        expect(warningHandler).not.toHaveBeenCalled();
+      });
+
+      test("enqueues a configuration update on entering and on leaving quarantine", async () => {
+        await servedAids();
+        enqueueSpy.mockClear();
+
+        corruptPermissions();
+        await servedAids();
+        expect(enqueueSpy).toHaveBeenCalledTimes(1);
+
+        offendingCharacteristic.props.perms = [ Perms.PAIRED_READ, Perms.NOTIFY ];
+        await servedAids();
+        expect(enqueueSpy).toHaveBeenCalledTimes(2);
+      });
+
+      test("settles while the accessory stays quarantined, without repeating itself", async () => {
+        corruptPermissions();
+
+        await servedAids();
+        await servedAids();
+        await servedAids();
+
+        expect(warningHandler).toHaveBeenCalledTimes(1);
+        expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      });
+
+      test("quarantines an accessory whose permissions cannot be JSON-serialized, without failing the request", async () => {
+        offendingCharacteristic.props.perms = [ 1n ] as unknown as Perms[];
+
+        expect(await servedAids()).toEqual([ bridge.aid, validAccessory.aid ]);
+        expect(warningHandler).toHaveBeenCalledTimes(1);
+      });
+
+      test("quarantines an accessory carrying a characteristic that was constructed with invalid permissions", async () => {
+        const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+        const malformedCharacteristic = new Characteristic("Malformed", uuid.generate("characteristic constructed with invalid permissions"), {
+          format: Formats.BOOL,
+          perms: [null as unknown as Perms, Perms.NOTIFY],
+        });
+
+        // Construction is where a plugin hands us its own props, and a bare characteristic has nobody subscribed to it, so the console carries the warning.
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+        expect(consoleWarnSpy.mock.calls[0][0]).toMatch(/Malformed.*contains invalid permissions/);
+
+        offendingService.addCharacteristic(malformedCharacteristic);
+
+        expect(await servedAids()).toEqual([ bridge.aid, validAccessory.aid ]);
+        expect(warningHandler).toHaveBeenCalledTimes(1);
+        expect(warningHandler).toHaveBeenCalledWith(expect.objectContaining({
+          characteristic: malformedCharacteristic,
+          type: CharacteristicWarningType.ERROR_MESSAGE,
+        }));
+
+        consoleWarnSpy.mockRestore();
+      });
+
+      test("excludes the same accessory from the configuration that determines the configuration number", async () => {
+        corruptPermissions();
+
+        const aids = await servedAids();
+        // @ts-expect-error: private access
+        const configuration = bridge.internalHAPRepresentation();
+
+        expect(configuration.map(entry => entry.aid)).toEqual(aids);
+      });
+    });
+
     test.each`
       advertiser                 | republish
       ${MDNSAdvertiser.BONJOUR}  | ${false}

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -37,6 +37,8 @@ import {
   CharacteristicOperationContext,
   CharacteristicSetCallback,
   Perms,
+  describePerms,
+  isValidPerms,
 } from "./Characteristic";
 import {
   CameraController,
@@ -318,6 +320,15 @@ const enum WriteRequestState {
 }
 
 /**
+ * The first characteristic on an accessory whose permissions HomeKit would reject, together with the service holding it. The service travels alongside
+ * the characteristic because a characteristic does not know its service, and the message pointing the plugin author at the fault needs both.
+ */
+interface PermsViolation {
+  characteristic: Characteristic;
+  service: Service;
+}
+
+/**
  * @group Accessory
  */
 export const enum AccessoryEventTypes {
@@ -455,6 +466,12 @@ export class Accessory extends EventEmitter {
    * For multiple bursts of /accessories request we don't want to always contact GET handlers
    */
   private lastAccessoriesRequest = 0;
+  /**
+   * The result of the last permissions evaluation made by the bridge that hosts this accessory, used solely to tell a transition in or out of quarantine
+   * from a state that has not changed. It is never consulted to decide what gets served: {@link findPermsViolation}, re-run on every representation build,
+   * is the truth there.
+   */
+  private permsQuarantined = false;
 
   constructor(public displayName: string, public UUID: string) {
     super();
@@ -681,6 +698,7 @@ export class Accessory extends EventEmitter {
 
     accessory.bridged = false;
     accessory.bridge = undefined;
+    accessory.permsQuarantined = false; // a later bridge starts from a clean slate and re-evaluates the accessory itself
     accessory.removeAllListeners();
 
     if(!deferUpdate) {
@@ -923,6 +941,85 @@ export class Accessory extends EventEmitter {
   }
 
   /**
+   * Searches this accessory for the first characteristic whose permissions HomeKit would reject, ignoring any bridged accessories (each one is asked
+   * about itself). The permissions are read from the model on every call rather than remembered, because a plugin can assign `props.perms` directly at
+   * any time, which reaches neither {@link Characteristic.setProps} nor any event.
+   *
+   * @returns the offending characteristic and its service, or undefined if every characteristic on this accessory is well-formed.
+   */
+  private findPermsViolation(): PermsViolation | undefined {
+    for (const service of this.services) {
+      for (const characteristic of service.characteristics) {
+        if (!isValidPerms(characteristic.props.perms)) {
+          return { characteristic: characteristic, service: service };
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Describes a permissions violation to the plugin author: which accessory, which service, which characteristic, and the array that was rejected. The
+   * publish failure and the quarantine warning report the same fault at different boundaries, so they share this text and supply only the phrase that
+   * says what happened as a result.
+   *
+   * @param violation - the violation as returned by {@link findPermsViolation}.
+   * @param disposition - what became of this accessory, phrased to follow its name.
+   */
+  private permsViolationMessage(violation: PermsViolation, disposition: string): string {
+    const serviceName = violation.service.displayName || violation.service.constructor.name;
+
+    return `HAP-NodeJS: accessory '${this.displayName}' ${disposition}. Service '${serviceName}' (${violation.service.UUID}), `
+      + `characteristic '${violation.characteristic.displayName}' (${violation.characteristic.UUID}) contains invalid permissions: `
+      + `${describePerms(violation.characteristic.props.perms)}`;
+  }
+
+  /**
+   * Returns the bridged accessories fit to be served, excluding any whose characteristic permissions HomeKit would reject. Both representation builders
+   * go through here, so the accessory database we hand out and the configuration we hash agree by construction, whatever put the malformed permissions
+   * into the model.
+   *
+   * The exclusion is presentation-level and reversible. A quarantined accessory keeps its place in {@link bridgedAccessories}, its aid, its cached
+   * identifiers and its context, so correcting the permissions restores it exactly where it was, under the same identity HomeKit knew it by.
+   */
+  private servedBridgedAccessories(): Accessory[] {
+    const served: Accessory[] = [];
+
+    for (const accessory of this.bridgedAccessories) {
+      const violation = accessory.findPermsViolation();
+
+      if (violation) {
+        if (!accessory.permsQuarantined) {
+          accessory.permsQuarantined = true;
+          accessory.sendCharacteristicWarning(
+            violation.characteristic,
+            CharacteristicWarningType.ERROR_MESSAGE,
+            accessory.permsViolationMessage(violation, "is excluded from the accessory database until its permissions are corrected"),
+          );
+
+          /* The configuration this accessory contributed has just disappeared from what we serve, so the configuration number has to move. Enqueueing
+           * from inside a representation build is safe and terminates: the build that observes a transition records it before returning, so the
+           * debounced pass that follows sees a settled state, hashes it, and enqueues nothing further.
+           */
+          this.enqueueConfigurationUpdate();
+        }
+
+        continue;
+      }
+
+      if (accessory.permsQuarantined) {
+        accessory.permsQuarantined = false;
+        this.enqueueConfigurationUpdate();
+      }
+
+      served.push(accessory);
+    }
+
+    return served;
+  }
+
+  /**
    * This method is called right before the accessory is published. It should be used to check for common
    * mistakes in Accessory structured, which may lead to HomeKit rejecting the accessory when pairing.
    * If it is called on a bridge it will call this method for all bridged accessories.
@@ -955,9 +1052,8 @@ export class Accessory extends EventEmitter {
       assert(Buffer.from(this.displayName, "utf8").length <= 63, "Accessory displayName cannot be longer than 63 bytes!");
     }
 
-    if (this.bridged) {
-      this.bridgedAccessories.forEach(accessory => accessory.validateAccessory());
-    }
+    // any accessories we are bridging are validated the same way; the list is empty for anything that is not a bridge
+    this.bridgedAccessories.forEach(accessory => accessory.validateAccessory());
   }
 
   /**
@@ -1048,7 +1144,7 @@ export class Accessory extends EventEmitter {
 
     if (!this.bridged) {
       accessories.push(... await Promise.all(
-        this.bridgedAccessories
+        this.servedBridgedAccessories()
           .map(accessory => accessory.toHAP(connection, contactGetHandlers).then(value => value[0])),
       ));
     }
@@ -1074,7 +1170,7 @@ export class Accessory extends EventEmitter {
     const accessories: AccessoryJsonObject[] = [accessory];
 
     if (!this.bridged) {
-      for (const accessory of this.bridgedAccessories) {
+      for (const accessory of this.servedBridgedAccessories()) {
         accessories.push(accessory.internalHAPRepresentation(false)[0]);
       }
     }
@@ -1102,6 +1198,14 @@ export class Accessory extends EventEmitter {
   public async publish(info: PublishInfo, allowInsecureRequest?: boolean): Promise<void> {
     if (this.bridged) {
       throw new Error("Can't publish in accessory which is bridged by another accessory. Bridged by " + this.bridge?.displayName);
+    }
+
+    /* Bridged accessories with malformed permissions are quarantined at the serving boundary, but the accessory being published is the root of its own
+     * accessory database and has nowhere to be quarantined to. HomeKit would reject the whole database, so we refuse here instead, in the caller's stack.
+     */
+    const violation = this.findPermsViolation();
+    if (violation) {
+      throw new Error(this.permsViolationMessage(violation, "cannot be published"));
     }
 
     let service = this.getService(Service.ProtocolInformation);

--- a/src/lib/Characteristic.spec.ts
+++ b/src/lib/Characteristic.spec.ts
@@ -9,6 +9,8 @@ import {
   Perms,
   SerializedCharacteristic,
   Units,
+  describePerms,
+  isValidPerms,
 } from "./Characteristic";
 import { SelectedRTPStreamConfiguration } from "./definitions";
 import { HAPStatus } from "./HAPServer";
@@ -23,6 +25,50 @@ function createCharacteristicWithProps(props: CharacteristicProps, customUUID?: 
   return new Characteristic("Test", customUUID || uuid.generate("Foo"), props);
 }
 
+describe("isValidPerms", () => {
+  it("accepts an array in which every entry is a permission", () => {
+    expect(isValidPerms([Perms.PAIRED_READ])).toBe(true);
+    expect(isValidPerms([
+      Perms.PAIRED_READ, Perms.PAIRED_WRITE, Perms.NOTIFY, Perms.ADDITIONAL_AUTHORIZATION, Perms.TIMED_WRITE, Perms.HIDDEN, Perms.WRITE_RESPONSE,
+    ])).toBe(true);
+    // the EVENTS alias shares NOTIFY's wire value and is accepted through it
+    expect(isValidPerms([Perms.EVENTS])).toBe(true);
+  });
+
+  it.each([
+    { label: "an empty array", value: [] },
+    { label: "a bare string", value: "pr" },
+    { label: "null", value: null },
+    { label: "undefined", value: undefined },
+    { label: "an array containing null", value: [null, Perms.NOTIFY] },
+    { label: "an array containing an unknown string", value: ["READ", Perms.NOTIFY] },
+    { label: "a nested array", value: [[Perms.PAIRED_READ]] },
+  ])("rejects $label", ({ value }) => {
+    expect(isValidPerms(value)).toBe(false);
+  });
+
+  it("rejects a sparse array, whose holes would serialize to null", () => {
+    const sparse: (Perms | undefined)[] = [ Perms.PAIRED_READ, Perms.NOTIFY ];
+
+    delete sparse[0];
+
+    expect(isValidPerms(sparse)).toBe(false);
+  });
+});
+
+describe("describePerms", () => {
+  it("renders any value without throwing", () => {
+    expect(describePerms([ Perms.PAIRED_READ, null ])).toBe("[\"pr\",null]");
+    expect(describePerms(undefined)).toBe("undefined");
+
+    const cyclic: unknown[] = [ Perms.NOTIFY ];
+    cyclic.push(cyclic);
+
+    expect(typeof describePerms(cyclic)).toBe("string");
+    expect(typeof describePerms([ 1n ])).toBe("string");
+  });
+});
+
 describe("Characteristic", () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -36,6 +82,116 @@ describe("Characteristic", () => {
       characteristic.setProps(NEW_PROPS);
 
       expect(characteristic.props).toEqual(NEW_PROPS);
+    });
+
+    it.each([
+      { perms: [undefined, Perms.NOTIFY] },
+      { perms: [null, Perms.NOTIFY] },
+      { perms: [[Perms.PAIRED_READ], Perms.NOTIFY] },
+      { perms: ["invalid", Perms.NOTIFY] },
+      { perms: [] },
+      { perms: "pr" },
+    ])("should warn about invalid permissions $perms and keep them", ({ perms }) => {
+      const characteristic = createCharacteristic(Formats.BOOL);
+      const warnings: { type: CharacteristicWarningType; message: string }[] = [];
+      characteristic.on(CharacteristicEventTypes.CHARACTERISTIC_WARNING, (type, message) => {
+        warnings.push({ type, message });
+      });
+
+      characteristic.setProps({
+        perms: perms as unknown as Perms[],
+      });
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].type).toEqual(CharacteristicWarningType.ERROR_MESSAGE);
+      expect(warnings[0].message).toMatch(/contains invalid permissions/);
+      // An array the plugin declared is what the model carries, which is what the serving boundary quarantines the accessory over. A non-array
+      // becomes an empty array instead, because everything downstream indexes, iterates and pushes into this - see the test below.
+      expect(characteristic.props.perms).toEqual(Array.isArray(perms) ? perms : []);
+    });
+
+    it("substitutes an empty array for a non-array permissions value, so the array consumers stay safe", () => {
+      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const characteristic = createCharacteristic(Formats.BOOL);
+
+      // A bare string is the dangerous shape: String.prototype.includes substring-matches, so `props.perms.includes(Perms.PAIRED_READ)`
+      // would answer true and silently grant read access, while `props.perms.push(...)` would throw.
+      characteristic.setProps({ perms: Perms.PAIRED_READ as unknown as Perms[] });
+
+      expect(Array.isArray(characteristic.props.perms)).toBe(true);
+      expect(characteristic.props.perms.includes(Perms.PAIRED_READ)).toBe(false);
+      // An empty array is still invalid, so the serving boundary quarantines the accessory rather than serving it with no permissions.
+      expect(isValidPerms(characteristic.props.perms)).toBe(false);
+      expect(() => characteristic.setupAdditionalAuthorization(() => true)).not.toThrow();
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    // Characterisation, not a regression test: the set lookup already rejected these, and the explicit `typeof` check in isValidPerms exists so
+    // VALID_PERMS can be typed ReadonlySet<string> without casting the unknown entry back to a string.
+    it("rejects a permissions entry that is not a string at all", () => {
+      expect(isValidPerms([Perms.NOTIFY, 1])).toBe(false);
+      expect(isValidPerms([Perms.NOTIFY, { toString: () => Perms.NOTIFY }])).toBe(false);
+    });
+
+    it("warns through the console when nothing is subscribed to the characteristic", () => {
+      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const characteristic = createCharacteristic(Formats.BOOL);
+
+      characteristic.setProps({ perms: [null, Perms.NOTIFY] as unknown as Perms[] });
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy.mock.calls[0][0]).toMatch(/^HAP-NodeJS WARNING: \[Test \(.*\)] characteristic contains invalid permissions/);
+      // Nothing else will report this warning, and a characteristic with no service carries no accessory or service name, so the stack that the
+      // event subscribers would have received has to reach the console too - it is the only thing that points at the line responsible.
+      expect(consoleWarnSpy.mock.calls[0][0]).toMatch(/\nThrown at: [\s\S]*\n\s+at /);
+      expect(characteristic.props.perms).toEqual([null, Perms.NOTIFY]);
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("keeps a characteristic's own value out of the console when nothing is subscribed", () => {
+      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      // A value warning quotes the value that was rejected, and on something like PasswordSetting that value is the secret itself. The console
+      // fallback exists for a malformed *declaration*, which never carries one, so a value warning on an unheard characteristic still goes nowhere.
+      const characteristic = createCharacteristicWithProps({
+        format: Formats.STRING,
+        perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE],
+        maxLen: 4,
+      });
+
+      characteristic.updateValue("hunter2-the-actual-password");
+
+      for (const spy of [consoleWarnSpy, consoleErrorSpy]) {
+        for (const call of spy.mock.calls) {
+          expect(String(call[0])).not.toContain("hunter2-the-actual-password");
+        }
+      }
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("warns about permissions whose diagnostic cannot be JSON-serialized", () => {
+      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const characteristic = createCharacteristic(Formats.BOOL);
+      const cyclic: unknown[] = [ Perms.NOTIFY ];
+      cyclic.push(cyclic);
+
+      characteristic.setProps({ perms: cyclic as Perms[] });
+      characteristic.setProps({ perms: [ 1n ] as unknown as Perms[] });
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+      for (const call of consoleWarnSpy.mock.calls) {
+        expect(typeof call[0]).toBe("string");
+        expect(call[0]).toMatch(/contains invalid permissions/);
+      }
+      expect(characteristic.props.perms).toEqual([ 1n ]);
+
+      consoleWarnSpy.mockRestore();
     });
 
     it("should fail when setting invalid value range", () => {
@@ -2195,6 +2351,24 @@ describe("Characteristic", () => {
       const characteristic = Characteristic.deserialize(json);
 
       expect(characteristic instanceof Characteristic.Name).toBeTruthy();
+    });
+
+    it("should deserialize json carrying malformed permissions, on either branch", () => {
+      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const perms = [null, Perms.NOTIFY] as unknown as Perms[];
+      const json: SerializedCharacteristic = {
+        displayName: "Name",
+        UUID: "00000023-0000-1000-8000-0026BB765291",
+        eventOnlyCharacteristic: false,
+        value: "New Name!",
+        props: { format: Formats.STRING, perms: perms, maxLen: 64 },
+      };
+
+      // A restore reaches setProps whether or not the cached json names a constructor, so both routes out of a poisoned cache have to survive it.
+      expect(Characteristic.deserialize(json).props.perms).toEqual(perms);
+      expect(Characteristic.deserialize({ ...json, constructorName: "Name" }).props.perms).toEqual(perms);
+
+      consoleWarnSpy.mockRestore();
     });
 
   });

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import createDebug from "debug";
 import { EventEmitter } from "events";
+import { inspect } from "util";
 import { CharacteristicJsonObject, CharacteristicValue, Nullable, PartialAllowingNull, VoidCallback } from "../types";
 import { CharacteristicWarningType } from "./Accessory";
 import type {
@@ -347,6 +348,66 @@ export const enum Perms {
   TIMED_WRITE = "tw",
   HIDDEN = "hd",
   WRITE_RESPONSE = "wr",
+}
+
+/**
+ * The wire values of {@link Perms}, as a runtime lookup. A const enum is erased during compilation and cannot be enumerated, so this set is the enum's
+ * runtime mirror and lives beside it: a permission added to the enum above must be added here as well. The members are referenced rather than retyped,
+ * so the compiler inlines the same string literals the enum declares. `EVENTS` is an alias of `NOTIFY` and shares its value, hence is not listed.
+ */
+const VALID_PERMS: ReadonlySet<string> = new Set<string>([
+  Perms.PAIRED_READ,
+  Perms.PAIRED_WRITE,
+  Perms.NOTIFY,
+  Perms.ADDITIONAL_AUTHORIZATION,
+  Perms.TIMED_WRITE,
+  Perms.HIDDEN,
+  Perms.WRITE_RESPONSE,
+]);
+
+/**
+ * Checks that a value is a well-formed permissions array: a non-empty array in which every entry is one of the {@link Perms} wire values.
+ *
+ * HomeKit rejects an accessory whose characteristics carry anything else, so {@link Characteristic.setProps} reports a failing array through the
+ * characteristic warning channel and the accessory database excludes bridged accessories that fail it.
+ *
+ * @param perms - the value to check.
+ * @returns true if the value is a permissions array HomeKit accepts.
+ *
+ * @private
+ */
+export function isValidPerms(perms: unknown): perms is Perms[] {
+  if (!Array.isArray(perms) || perms.length === 0) {
+    return false;
+  }
+
+  // for...of iteration surfaces the holes of a sparse array as undefined, which Array.prototype.every would silently skip. A hole survives JSON
+  // serialization as null, the exact malformed entry this check exists to reject.
+  for (const permission of perms) {
+    if (typeof permission !== "string" || !VALID_PERMS.has(permission)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Formats a permissions value for a diagnostic message without ever throwing. `JSON.stringify` is not total over unknown input (a bigint or a cyclic
+ * entry raises a `TypeError`), and a diagnostic must never become the failure it reports, so anything the JSON form cannot render falls back to
+ * `util.inspect`, which renders any value.
+ *
+ * @param perms - the value to format.
+ * @returns a human-readable rendering of the value.
+ *
+ * @private
+ */
+export function describePerms(perms: unknown): string {
+  try {
+    return JSON.stringify(perms) ?? String(perms);
+  } catch {
+    return inspect(perms);
+  }
 }
 
 /**
@@ -1813,9 +1874,27 @@ export class Characteristic extends EventEmitter {
       formatDidChange = this.props.format !== props.format;
       this.props.format = props.format;
     }
+
+    /* A malformed permissions array is reported through the characteristic warning channel and assigned anyway, so the model holds exactly what the plugin
+     * declared and the accessories serving boundary - the one place that decides what HomeKit is shown - can quarantine the accessory until the permissions
+     * are corrected. A throw here would surface inside plugin characteristic constructors and inside cached accessory restore, neither of which is wrapped
+     * by anything that can recover.
+     */
     if (props.perms) {
-      assert(props.perms.length > 0, "characteristic prop perms cannot be empty array");
-      this.props.perms = props.perms;
+      if (!isValidPerms(props.perms)) {
+        this.characteristicWarning(
+          `characteristic contains invalid permissions: ${describePerms(props.perms)}`,
+          CharacteristicWarningType.ERROR_MESSAGE,
+          undefined,
+          true, // a declaration, not a value - safe to print, and nothing else will report it during construction
+        );
+      }
+      /* Everything downstream treats `props.perms` as an array. A non-array is the dangerous shape rather than merely an invalid one: on a string
+       * `includes` substring-matches, so a declared `"pr"` would answer true to a paired-read check and quietly grant access, and `push` would throw
+       * out of {@link setupAdditionalAuthorization}. An empty array fails {@link isValidPerms} exactly as the declared value does, so the accessory is
+       * still quarantined - it just fails closed on the way there. The warning above quotes what the plugin actually declared.
+       */
+      this.props.perms = Array.isArray(props.perms) ? props.perms : [];
     }
 
     if (props.unit !== undefined) {
@@ -2849,8 +2928,29 @@ export class Characteristic extends EventEmitter {
     this.iid = identifierCache.getIID(accessoryName, serviceUUID, serviceSubtype, this.UUID);
   }
 
-  private characteristicWarning(message: string, type = CharacteristicWarningType.WARN_MESSAGE, stack = new Error().stack): void {
-    this.emit(CharacteristicEventTypes.CHARACTERISTIC_WARNING, type, message, stack);
+  /**
+   * @param message - what went wrong.
+   * @param type - the severity the subscribers see.
+   * @param stack - where it was raised.
+   * @param reportWhenUnheard - print to the console if nothing is subscribed. **Only for a message that describes how a characteristic was DECLARED.**
+   * A characteristic that is not part of a service yet has nothing subscribed to its warnings, and a declaration is made in the constructor, which is
+   * exactly where a plugin gets it wrong - so those warnings would otherwise vanish. Every other warning quotes the offending characteristic VALUE
+   * (see {@link validateUserInput}), and on something like {@link Characteristic.PasswordSetting} that value is the secret itself, so those keep the
+   * long-standing behaviour of going nowhere until an accessory is listening.
+   */
+  private characteristicWarning(
+    message: string,
+    type = CharacteristicWarningType.WARN_MESSAGE,
+    stack = new Error().stack,
+    reportWhenUnheard = false,
+  ): void {
+    const heard = this.emit(CharacteristicEventTypes.CHARACTERISTIC_WARNING, type, message, stack);
+
+    if (!heard && reportWhenUnheard) {
+      // The stack the subscribers would have received goes with it: a characteristic with no service carries no accessory or service name, so it is
+      // the only thing that locates the fault.
+      console.warn(`HAP-NodeJS WARNING: [${this.displayName} (${this.UUID})] ${message}\nThrown at: ${stack ?? "unknown"}`);
+    }
   }
 
   /**


### PR DESCRIPTION
### Changes

- ci: rename the pr-labeler caller job from stale to label
- fix: stop one accessory's invalid permissions taking down the whole bridge (#1129)
- chore(deps): dependency updates

### Homebridge Dependencies

- `@homebridge/ciao` @ `v1.3.12`
- `@homebridge/dbus-native` @ `v0.7.9`
- `bonjour-hap` @ `v3.10.5`